### PR TITLE
feat(toast): add event handlers to toast notifications

### DIFF
--- a/kit/src/components/toast/mod.rs
+++ b/kit/src/components/toast/mod.rs
@@ -4,16 +4,20 @@ use crate::{
 };
 
 use dioxus::prelude::*;
+use uuid::Uuid;
 
-#[derive(PartialEq, Props)]
-pub struct Props {
-    #[props(optional)]
+#[derive(Props)]
+pub struct Props<'a> {
+    id: Uuid,
+    on_hover: EventHandler<'a, Uuid>,
+    on_close: EventHandler<'a, Uuid>,
+    #[props(!optional)]
     icon: Option<Icon>,
-    #[props(optional)]
+    #[props(!optional)]
     with_title: Option<String>,
-    #[props(optional)]
+    #[props(!optional)]
     with_content: Option<String>,
-    #[props(optional)]
+    #[props(!optional)]
     appearance: Option<Appearance>,
 }
 
@@ -27,13 +31,14 @@ pub fn get_icon(cx: &Scope<Props>) -> Icon {
 }
 
 #[allow(non_snake_case)]
-pub fn Toast(cx: Scope<Props>) -> Element {
+pub fn Toast<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let content = cx.props.with_content.clone().unwrap_or_default();
     let title = cx.props.with_title.clone().unwrap_or_default();
 
     cx.render(rsx!(
         div {
             class: "toast",
+            onmouseover: move |_| cx.props.on_hover.call(cx.props.id),
             (cx.props.icon.is_some()).then(|| rsx!(
                 span {
                     class: "toast-icon",
@@ -54,9 +59,7 @@ pub fn Toast(cx: Scope<Props>) -> Element {
             Button {
                 icon: Icon::XMark,
                 appearance: Appearance::Secondary,
-                onpress: move |_| {
-                    // cx.emit(UiEvent::RemoveElement);
-                }
+                onpress: move |_| cx.props.on_close.call(cx.props.id),
             }
         }
     ))

--- a/ui/src/components/mod.rs
+++ b/ui/src/components/mod.rs
@@ -3,3 +3,4 @@ pub mod chat;
 pub mod friends;
 pub mod media;
 pub mod settings;
+pub mod toast;

--- a/ui/src/components/toast/mod.rs
+++ b/ui/src/components/toast/mod.rs
@@ -1,0 +1,32 @@
+use dioxus::prelude::*;
+use kit::{elements::Appearance, icons::Icon};
+use uuid::Uuid;
+
+use crate::state::State;
+
+#[derive(PartialEq, Props)]
+pub struct Props {
+    id: Uuid,
+    #[props(optional)]
+    icon: Option<Icon>,
+    #[props(optional)]
+    with_title: Option<String>,
+    #[props(optional)]
+    with_content: Option<String>,
+    #[props(optional)]
+    appearance: Option<Appearance>,
+}
+
+#[allow(non_snake_case)]
+pub fn Toast(cx: Scope<Props>) -> Element {
+    let state: UseSharedState<State> = use_context::<State>(&cx).unwrap();
+    cx.render(rsx!(kit::components::toast::Toast {
+        id: cx.props.id,
+        on_hover: move |_| state.write_silent().reset_toast_timer(&cx.props.id),
+        on_close: move |_| state.write().remove_toast(&cx.props.id),
+        icon: cx.props.icon,
+        with_title: cx.props.with_title.clone(),
+        with_content: cx.props.with_content.clone(),
+        appearance: cx.props.appearance
+    }))
+}

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -11,14 +11,14 @@ use dioxus::prelude::*;
 use kit::elements::Appearance;
 use tokio::time::{sleep, Duration};
 
-use kit::components::toast::Toast;
 use kit::icons::IconElement;
 use kit::{components::nav::Route as UIRoute, icons::Icon};
-use state::{State, ToastNotification};
+use state::State;
 use tao::menu::{MenuBar as Menu, MenuItem};
 use tao::window::WindowBuilder;
 
 use crate::components::media::popout_player::PopoutPlayer;
+use crate::components::toast::Toast;
 use crate::layouts::files::FilesLayout;
 use crate::layouts::friends::FriendsLayout;
 use crate::layouts::settings::SettingsLayout;
@@ -194,32 +194,21 @@ fn app(cx: Scope) -> Element {
 
     let desktop = use_window(&cx);
 
-    let has_toasts = state.read().ui.toast_notifications.len() > 0;
-    let toast = if has_toasts {
-        state
-            .read()
-            .ui
-            .toast_notifications
-            .values()
-            .next()
-            .cloned()
-            .unwrap_or_default()
-    } else {
-        ToastNotification::default()
-    };
-
     cx.render(rsx! (
         style { "{UIKIT_STYLES} {APP_STYLE}" },
         div {
             id: "app-wrap",
-            has_toasts.then(|| rsx!(
-                Toast {
-                    with_title: toast.title,
-                    with_content: toast.content,
-                    icon: toast.icon.unwrap_or(Icon::InformationCircle),
-                    appearance: Appearance::Secondary,
-                },
-            ))
+            state.read().ui.toast_notifications.iter().map(|(id, toast)| {
+                rsx! (
+                    Toast {
+                        id: *id,
+                        with_title: toast.title.clone(),
+                        with_content: toast.content.clone(),
+                        icon: toast.icon.unwrap_or(Icon::InformationCircle),
+                        appearance: Appearance::Secondary,
+                    },
+                )
+            }),
             // CallDialog {
             //     caller: cx.render(rsx!(UserImage {
             //         platform: Platform::Mobile,

--- a/ui/src/state.rs
+++ b/ui/src/state.rs
@@ -686,6 +686,10 @@ impl State {
             toast.reset_time();
         }
     }
+
+    pub fn remove_toast(&mut self, id: &Uuid) {
+        let _ = self.ui.toast_notifications.remove(id);
+    }
 }
 
 impl State {


### PR DESCRIPTION
added callbacks for
- onmouseover
- button press (to dismiss the toast)

added a Toast in ui/components which modifies state in response to these events

todo: 
currently all the toasts are displayed on top of each other. i'm not sure if the desired behaviour is to show the toasts one at a time or all at once. on one hand, if multiple toasts are created simultaneously, there may be some events which should be displayed immediately. on the other hand, showing multiple toasts could clutter the screen. depending on what we want to do, either the CSS should be changed to show multiple toasts or the toast timer should be changed to only countdown the most recent toast. 

