### PR TITLE
chore(ci): avoid typos

### DIFF
--- a/.github/workflows/avoid-typos.yml
+++ b/.github/workflows/avoid-typos.yml
@@ -1,0 +1,20 @@
+name: reviewdog
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  misspell:
+    name: runner / misspell
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code.
+        uses: actions/checkout@v1
+      - name: misspell
+        uses: reviewdog/action-misspell@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          locale: "US"
+          reporter: github-pr-review
+          level: error
+          exclude: "*.css"


### PR DESCRIPTION
### What this PR does 📖
- Adds a Github Action that adds annotations if there's an typo 

<img width="987" alt="Captura de ecrã 2022-12-27, às 00 24 17" src="https://user-images.githubusercontent.com/29093946/209590251-c3522cb9-9c8b-4dbf-afbc-2e75dcaebed8.png">
