### PR TITLE
chore(ci): add github action for conflicts label

### DIFF
--- a/.github/workflows/add-conflicts-label.yml
+++ b/.github/workflows/add-conflicts-label.yml
@@ -1,0 +1,15 @@
+name: Add Conflicts Label
+on:
+  push:
+    branches:
+      - dev
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mschilde/auto-label-merge-conflicts@master
+        with:
+          CONFLICT_LABEL_NAME: 'missing fixing conflict'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAX_RETRIES: 5
+          WAIT_MS: 5000


### PR DESCRIPTION

**What this PR does** 📖

This action checks all open Pull Requests for merge conflicts and marks them with a Github label.

Once a conflict is resolved the label is automatically removed.