### PR TITLE
chore(ci): add missing dev review label automatically

### DIFF
--- a/.github/workflows/add-label.yml
+++ b/.github/workflows/add-label.yml
@@ -1,0 +1,17 @@
+name: Add Label
+on:
+  pull_request:
+    types:
+      - opened
+jobs:
+  add-label:
+    name: Add Label
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: christianvuerings/add-labels@v1
+        with:
+          labels: |
+            Missing dev review
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does** 📖

Adds Github Action to automatically add the `missing dev review` label whenever a PR is added, atm Phil does this manually

<img width="628" alt="Captura de ecrã 2021-12-19, às 00 31 18" src="https://user-images.githubusercontent.com/29093946/146659237-d816987f-9932-4e15-b94b-5375700a8236.png">

