### PR TITLE
chore(ci): lint PR title

### DIFF
--- a/.github/workflows/lint-PR-title.yml
+++ b/.github/workflows/lint-PR-title.yml
@@ -1,0 +1,31 @@
+name: Lint Pull Request Title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-ecosystem/action-regex-match@v2
+        id: regex-match
+        with:
+          text: ${{ github.event.pull_request.title }}
+          regex: '(?:add|update|task|chore|feat|fix)\([a-z-A-Z]+\):\s.+'
+
+      - uses: actions-ecosystem/action-create-comment@v1
+        if: ${{ steps.regex-match.outputs.match == '' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          body: |
+            :warning: The title of this PR is invalid.
+            Please make the title match the regex `(?:add|update|task|chore|feat|fix)\([a-z-A-Z]+\):\s.+`.
+            e.g.) `add(cli): enable --verbose flag`, `fix(api): avoid unexpected error in handler`
+      - run: exit 1
+        if: ${{ steps.regex-match.outputs.match == '' }}


### PR DESCRIPTION

**What this PR does** 📖

This enforces the good practices of the PR title convention that are used


in case it's not how it should this will add a comment with the following

<img width="958" alt="Captura de ecrã 2021-12-15, às 01 48 09" src="https://user-images.githubusercontent.com/29093946/146107963-3e685a4e-f0ec-4597-934b-4aa025988fab.png">


