### PR TITLE
feat(MediaPlayer): improve handling of calls and MediaPlayer

### DIFF
--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -14,6 +14,7 @@ use super::sidebar::build_participants_names;
 pub fn Compose(cx: Scope) -> Element {
     let state = use_shared_state::<State>(cx)?;
     let active_chat = state.read().get_active_chat().unwrap_or_default();
+    let active_chat_id = active_chat.id;
     let message_groups = state.read().get_sort_messages(&active_chat);
 
     let without_me = state.read().get_without_me(active_chat.participants.clone());
@@ -34,8 +35,6 @@ pub fn Compose(cx: Scope) -> Element {
     let participants_name = build_participants_names(&without_me);
 
     let active_media = Some(active_chat.id) == state.read().chats.active_media;
-    // used to make this chat the active media chat
-    let active_media_chat = active_chat.clone();
  
     // TODO: Pending new message divider implementation
     // let _new_message_text = LOCALES
@@ -91,7 +90,7 @@ pub fn Compose(cx: Scope) -> Element {
                                     }
                                 )),
                                 onpress: move |_| {
-                                    state.write().mutate(Action::ToggleMedia(active_media_chat.clone()));
+                                    state.write().mutate(Action::SetActiveMedia(active_chat_id));
                                 }
                             },
                             Button {

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -33,7 +33,8 @@ pub fn Compose(cx: Scope) -> Element {
     let first_image = active_participant.graphics().profile_picture();
     let participants_name = build_participants_names(&without_me);
 
-    let active_media = active_chat.active_media;
+    let active_media = Some(active_chat.id) == state.read().chats.active_media;
+    // used to make this chat the active media chat
     let active_media_chat = active_chat.clone();
  
     // TODO: Pending new message divider implementation

--- a/ui/src/components/media/player.rs
+++ b/ui/src/components/media/player.rs
@@ -92,12 +92,13 @@ pub fn MediaPlayer(cx: Scope<Props>) -> Element {
                        state.write_silent().mutate(Action::AddWindow(window));
                     }
                 },
-                /*state.read().ui.popout_player.then(|| rsx!(
+                // don't render MediadPlayer if the video is popped out
+                state.read().ui.popout_player.then(|| rsx!(
                     span {
                         class: "popped-out",
                         video {}
                     }
-                )),*/
+                )),
                 (!state.read().ui.popout_player).then(|| rsx!(
                     video {
                         src: "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/Sintel.mp4",

--- a/ui/src/components/media/player.rs
+++ b/ui/src/components/media/player.rs
@@ -33,7 +33,6 @@ pub struct Props {
 pub fn MediaPlayer(cx: Scope<Props>) -> Element {
     let state = use_shared_state::<State>(cx)?;
     let window = use_window(cx);
-    let active_chat = state.read().get_active_chat().unwrap_or_default();
 
     let silenced = state
         .read()
@@ -137,7 +136,7 @@ pub fn MediaPlayer(cx: Scope<Props>) -> Element {
                 appearance: Appearance::Danger,
                 text: cx.props.end_text.clone(),
                 onpress: move |_| {
-                    state.write().mutate(Action::SetActiveMedia(active_chat.id));
+                    state.write().mutate(Action::DisableMedia);
                 }
             },
             Button {

--- a/ui/src/components/media/player.rs
+++ b/ui/src/components/media/player.rs
@@ -88,7 +88,7 @@ pub fn MediaPlayer(cx: Scope<Props>) -> Element {
                         // if the same, do nothing
                        let popout = VirtualDom::new_with_props(PopoutPlayer, ());
                        let window = window.new_window(popout, Default::default());
-                       state.write_silent().mutate(Action::AddOverlay(window));
+                       state.write_silent().mutate(Action::SetMediaWebview(window));
                     }
                 },
                 // don't render MediadPlayer if the video is popped out

--- a/ui/src/components/media/player.rs
+++ b/ui/src/components/media/player.rs
@@ -1,3 +1,5 @@
+use std::rc::Weak;
+
 use crate::{
     components::media::popout_player::PopoutPlayer,
     state::{Action, State},
@@ -88,7 +90,7 @@ pub fn MediaPlayer(cx: Scope<Props>) -> Element {
                         // if the same, do nothing
                        let popout = VirtualDom::new_with_props(PopoutPlayer, ());
                        let window = window.new_window(popout, Default::default());
-                       state.write_silent().mutate(Action::SetMediaWebview(window));
+                       state.write_silent().mutate(Action::SetMediaWebview(Weak::upgrade(&window).unwrap()));
                     }
                 },
                 // don't render MediadPlayer if the video is popped out

--- a/ui/src/components/media/player.rs
+++ b/ui/src/components/media/player.rs
@@ -1,6 +1,10 @@
-use crate::state::{Action, State};
+use crate::{
+    components::media::popout_player::PopoutPlayer,
+    state::{Action, State},
+};
 
 use dioxus::prelude::*;
+use dioxus_desktop::use_window;
 use dioxus_router::*;
 
 use kit::{
@@ -28,9 +32,16 @@ pub struct Props {
 #[allow(non_snake_case)]
 pub fn MediaPlayer(cx: Scope<Props>) -> Element {
     let state = use_shared_state::<State>(cx)?;
+    let window = use_window(cx);
     let active_chat = state.read().get_active_chat().unwrap_or_default();
 
-    let silenced = state.read().ui.silenced;
+    let silenced = state
+        .read()
+        .ui
+        .current_call
+        .clone()
+        .map(|x| x.silenced)
+        .unwrap_or(false);
 
     let silenced_str = silenced.to_string();
 
@@ -73,16 +84,20 @@ pub fn MediaPlayer(cx: Scope<Props>) -> Element {
                         }
                     )),
                     onpress: move |_| {
-                        // todo: open a window but...need one call at a time
-                        state.write().mutate(Action::TogglePopout);
+                        // check id of current media player
+                        // if changed, close the old one
+                        // if the same, do nothing
+                       let popout = VirtualDom::new_with_props(PopoutPlayer, ());
+                       let window = window.new_window(popout, Default::default());
+                       state.write_silent().mutate(Action::AddWindow(window));
                     }
                 },
-                state.read().ui.popout_player.then(|| rsx!(
+                /*state.read().ui.popout_player.then(|| rsx!(
                     span {
                         class: "popped-out",
                         video {}
                     }
-                )),
+                )),*/
                 (!state.read().ui.popout_player).then(|| rsx!(
                     video {
                         src: "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/Sintel.mp4",

--- a/ui/src/components/media/player.rs
+++ b/ui/src/components/media/player.rs
@@ -90,7 +90,8 @@ pub fn MediaPlayer(cx: Scope<Props>) -> Element {
                         } else {
                              let popout = VirtualDom::new_with_props(PopoutPlayer, ());
                             let window = window.new_window(popout, Default::default());
-                            state.write().mutate(Action::SetPopout(Weak::upgrade(&window).unwrap()));
+                            // for some reason using write() prevents the video from loading but using write_silent() works
+                            state.write_silent().mutate(Action::SetPopout(Weak::upgrade(&window).unwrap()));
                         }
                     }
                 },

--- a/ui/src/components/media/player.rs
+++ b/ui/src/components/media/player.rs
@@ -137,7 +137,7 @@ pub fn MediaPlayer(cx: Scope<Props>) -> Element {
                 appearance: Appearance::Danger,
                 text: cx.props.end_text.clone(),
                 onpress: move |_| {
-                    state.write().mutate(Action::ToggleMedia(active_chat.clone()));
+                    state.write().mutate(Action::SetActiveMedia(active_chat.id));
                 }
             },
             Button {

--- a/ui/src/components/media/player.rs
+++ b/ui/src/components/media/player.rs
@@ -85,12 +85,13 @@ pub fn MediaPlayer(cx: Scope<Props>) -> Element {
                         }
                     )),
                     onpress: move |_| {
-                        // check id of current media player
-                        // if changed, close the old one
-                        // if the same, do nothing
-                       let popout = VirtualDom::new_with_props(PopoutPlayer, ());
-                       let window = window.new_window(popout, Default::default());
-                       state.write_silent().mutate(Action::SetMediaWebview(Weak::upgrade(&window).unwrap()));
+                        if state.read().ui.popout_player {
+                            state.write().mutate(Action::ClearPopout);
+                        } else {
+                             let popout = VirtualDom::new_with_props(PopoutPlayer, ());
+                            let window = window.new_window(popout, Default::default());
+                            state.write().mutate(Action::SetPopout(Weak::upgrade(&window).unwrap()));
+                        }
                     }
                 },
                 // don't render MediadPlayer if the video is popped out

--- a/ui/src/components/media/player.rs
+++ b/ui/src/components/media/player.rs
@@ -88,7 +88,7 @@ pub fn MediaPlayer(cx: Scope<Props>) -> Element {
                         // if the same, do nothing
                        let popout = VirtualDom::new_with_props(PopoutPlayer, ());
                        let window = window.new_window(popout, Default::default());
-                       state.write_silent().mutate(Action::AddWindow(window));
+                       state.write_silent().mutate(Action::AddOverlay(window));
                     }
                 },
                 // don't render MediadPlayer if the video is popped out

--- a/ui/src/components/media/popout_player.rs
+++ b/ui/src/components/media/popout_player.rs
@@ -27,12 +27,11 @@ pub fn PopoutPlayer(cx: Scope) -> Element {
                         size: 40,
                     },
                 },
-                
                 video {
                     src: "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/Sintel.mp4",
                     autoplay: "true",
                     "loop": "true",
-                    "muted": "true",
+                    muted: "false"
                 },
                 div {
                     class: "controls",

--- a/ui/src/components/media/popout_player.rs
+++ b/ui/src/components/media/popout_player.rs
@@ -10,20 +10,11 @@ use kit::{
     icons::{Icon, IconElement},
 };
 
-use crate::state::{State, Action};
-
 pub const SCRIPT: &str = include_str!("./script.js");
 
-#[derive(Eq, PartialEq, Props)]
-pub struct Props {
-    #[props(optional)]
-    larger: Option<bool>,
-}
-
 #[allow(non_snake_case)]
-pub fn PopoutPlayer(cx: Scope<Props>) -> Element {
-    let state = use_shared_state::<State>(cx)?;
-
+pub fn PopoutPlayer(cx: Scope) -> Element {
+    //let window = use_window(cx);
     cx.render(rsx! (
         div {
             class: "popout-player",
@@ -55,8 +46,7 @@ pub fn PopoutPlayer(cx: Scope<Props>) -> Element {
                             }
                         )),
                         onpress: move |_| {
-                            // todo: close the window
-                            state.write().mutate(Action::TogglePopout);
+                          
                         }
                     },
                     Button {

--- a/ui/src/components/media/remote_control.rs
+++ b/ui/src/components/media/remote_control.rs
@@ -10,7 +10,7 @@ use kit::{
     icons::Icon,
 };
 
-use crate::state::{ui::Call, Action, State};
+use crate::state::{Action, State};
 
 #[derive(Eq, PartialEq, Props)]
 pub struct Props {

--- a/ui/src/components/media/remote_control.rs
+++ b/ui/src/components/media/remote_control.rs
@@ -80,7 +80,7 @@ pub fn RemoteControls(cx: Scope<Props>) -> Element {
                 appearance: Appearance::Danger,
                 text: cx.props.end_text.clone(),
                 onpress: move |_| {
-                    state.write().mutate(Action::EndAll);
+                    state.write().mutate(Action::DisableMedia);
                 },
             }
         }

--- a/ui/src/components/media/remote_control.rs
+++ b/ui/src/components/media/remote_control.rs
@@ -10,7 +10,7 @@ use kit::{
     icons::Icon,
 };
 
-use crate::state::{Action, State};
+use crate::state::{ui::Call, Action, State};
 
 #[derive(Eq, PartialEq, Props)]
 pub struct Props {
@@ -25,6 +25,15 @@ pub struct Props {
 #[allow(non_snake_case)]
 pub fn RemoteControls(cx: Scope<Props>) -> Element {
     let state = use_shared_state::<State>(cx)?;
+    let call = state.read().ui.current_call.clone();
+
+    let call = match call {
+        None => {
+            // RemoteControls should only be rendered when there's a call
+            return cx.render(rsx!(""));
+        }
+        Some(c) => c,
+    };
 
     cx.render(rsx!(div {
         id: "remote-controls",
@@ -42,11 +51,11 @@ pub fn RemoteControls(cx: Scope<Props>) -> Element {
             Button {
                 // TODO: we need to add an icon for this `if state.read().ui.silenced { Icon::Microphone } else { Icon::Microphone }`
                 icon: Icon::Microphone,
-                appearance: if state.read().ui.muted { Appearance::Danger } else { Appearance::Secondary },
+                appearance: if call.muted { Appearance::Danger } else { Appearance::Secondary },
                 tooltip: cx.render(rsx!(
                     Tooltip {
                         arrow_position: ArrowPosition::Bottom,
-                        text: if state.read().ui.muted { cx.props.unmute_text.clone() } else { cx.props.mute_text.clone() }
+                        text: if call.muted { cx.props.unmute_text.clone() } else { cx.props.mute_text.clone() }
                     }
                 )),
                 onpress: move |_| {
@@ -54,12 +63,12 @@ pub fn RemoteControls(cx: Scope<Props>) -> Element {
                 }
             },
             Button {
-                icon: if state.read().ui.silenced { Icon::SignalSlash } else { Icon::Signal },
-                appearance: if state.read().ui.silenced { Appearance::Danger } else { Appearance::Secondary },
+                icon: if call.silenced { Icon::SignalSlash } else { Icon::Signal },
+                appearance: if call.silenced { Appearance::Danger } else { Appearance::Secondary },
                 tooltip: cx.render(rsx!(
                     Tooltip {
                         arrow_position: ArrowPosition::Bottom,
-                        text: if state.read().ui.silenced { cx.props.listen_text.clone() } else { cx.props.silence_text.clone() }
+                        text: if call.silenced { cx.props.listen_text.clone() } else { cx.props.silence_text.clone() }
                     }
                 )),
                 onpress: move |_| {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -371,9 +371,9 @@ fn app(cx: Scope) -> Element {
                     "{pre_release_text}",
                 }
             },
-            state.read().ui.popout_player.then(|| rsx!(
-                PopoutPlayer {}
-            )),
+            //state.read().ui.popout_player.then(|| rsx!(
+           //     PopoutPlayer {}
+           // )),
             Router {
                 Route {
                     to: "/",

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -299,6 +299,7 @@ fn app(cx: Scope) -> Element {
         None => String::from(""),
     };
 
+    // todo: get rid of this. it makes zero sense to add an overlay every time the app is rendered
     if !*first_render.read() {
         *first_render.write_silent() = false;
         // Create a window rendering the overlay.

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -24,7 +24,6 @@ use tokio::sync::Mutex;
 use tokio::time::{sleep, Duration};
 use warp::logging::tracing::log;
 
-
 use crate::components::toast::Toast;
 use crate::layouts::files::FilesLayout;
 use crate::layouts::friends::FriendsLayout;
@@ -306,7 +305,7 @@ fn app(cx: Scope) -> Element {
         if Configuration::load_or_default().general.enable_overlay {
             let overlay_test = VirtualDom::new(OverlayDom);
             let window = desktop.new_window(overlay_test, make_config());
-            state.write_silent().mutate(Action::AddWindow(window));
+            state.write_silent().mutate(Action::AddOverlay(window));
         }
     }
 

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -24,7 +24,7 @@ use tokio::sync::Mutex;
 use tokio::time::{sleep, Duration};
 use warp::logging::tracing::log;
 
-use crate::components::media::popout_player::PopoutPlayer;
+
 use crate::components::toast::Toast;
 use crate::layouts::files::FilesLayout;
 use crate::layouts::friends::FriendsLayout;

--- a/ui/src/state/action.rs
+++ b/ui/src/state/action.rs
@@ -1,6 +1,8 @@
+use std::rc::Weak;
+
 use either::Either;
-use serde::{Deserialize, Serialize};
 use warp::raygun::{Message, Reaction};
+use wry::webview::WebView;
 
 use super::{
     chats::Chat,
@@ -18,7 +20,6 @@ pub struct ActionHook {
     pub callback: Callback,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub enum Action {
     // UI
     TogglePopout,
@@ -34,6 +35,7 @@ pub enum Action {
     // Account
     /// Sets the ID for the user.
     SetId(Identity),
+    AddWindow(Weak<WebView>),
 
     // Settings
     /// Sets the selected language.

--- a/ui/src/state/action.rs
+++ b/ui/src/state/action.rs
@@ -40,7 +40,7 @@ pub enum Action {
     // Account
     /// Sets the ID for the user.
     SetId(Identity),
-    AddWindow(Weak<WebView>),
+    AddOverlay(Weak<WebView>),
 
     // Settings
     /// Sets the selected language.

--- a/ui/src/state/action.rs
+++ b/ui/src/state/action.rs
@@ -1,4 +1,4 @@
-use std::rc::Weak;
+use std::rc::{Rc, Weak};
 
 use either::Either;
 use uuid::Uuid;
@@ -43,7 +43,7 @@ pub enum Action {
     /// adds an overlay. currently only used for demonstration purposes
     AddOverlay(Weak<WebView>),
     /// used for the popout player or media player
-    SetMediaWebview(Weak<WebView>),
+    SetMediaWebview(Rc<WebView>),
 
     // Settings
     /// Sets the selected language.

--- a/ui/src/state/action.rs
+++ b/ui/src/state/action.rs
@@ -40,7 +40,10 @@ pub enum Action {
     // Account
     /// Sets the ID for the user.
     SetId(Identity),
+    /// adds an overlay. currently only used for demonstration purposes
     AddOverlay(Weak<WebView>),
+    /// used for the popout player or media player
+    SetMediaWebview(Weak<WebView>),
 
     // Settings
     /// Sets the selected language.

--- a/ui/src/state/action.rs
+++ b/ui/src/state/action.rs
@@ -20,8 +20,10 @@ pub struct ActionHook {
     pub callback: Callback,
 }
 
+/// used exclusively by State::mutate
 pub enum Action {
     // UI
+    /// change ui::UI::popout_player, which determines if the media_view is anchored in place or moves around
     TogglePopout,
     EndAll,
     ToggleSilence,
@@ -31,6 +33,7 @@ pub enum Action {
     SetTheme(Theme),
     ClearTheme,
     // RemoveToastNotification,
+    /// Toggles the display of media on the provided chat in the `State` struct.
     ToggleMedia(Chat),
     // Account
     /// Sets the ID for the user.

--- a/ui/src/state/action.rs
+++ b/ui/src/state/action.rs
@@ -24,8 +24,6 @@ pub struct ActionHook {
 /// used exclusively by State::mutate
 pub enum Action {
     // UI
-    /// change ui::UI::popout_player, which determines if the media_view is anchored in place or moves around
-    TogglePopout,
     // hang up for the active media stream
     DisableMedia,
     ToggleSilence,
@@ -43,7 +41,8 @@ pub enum Action {
     /// adds an overlay. currently only used for demonstration purposes
     AddOverlay(Weak<WebView>),
     /// used for the popout player or media player
-    SetMediaWebview(Rc<WebView>),
+    SetPopout(Rc<WebView>),
+    ClearPopout,
 
     // Settings
     /// Sets the selected language.

--- a/ui/src/state/action.rs
+++ b/ui/src/state/action.rs
@@ -1,6 +1,7 @@
 use std::rc::Weak;
 
 use either::Either;
+use uuid::Uuid;
 use warp::raygun::{Message, Reaction};
 use wry::webview::WebView;
 
@@ -25,7 +26,8 @@ pub enum Action {
     // UI
     /// change ui::UI::popout_player, which determines if the media_view is anchored in place or moves around
     TogglePopout,
-    EndAll,
+    // hang up for the active media stream
+    DisableMedia,
     ToggleSilence,
     ToggleMute,
     SetOverlay(bool),
@@ -33,8 +35,8 @@ pub enum Action {
     SetTheme(Theme),
     ClearTheme,
     // RemoveToastNotification,
-    /// Toggles the display of media on the provided chat in the `State` struct.
-    ToggleMedia(Chat),
+    /// sets the active media to the corresponding conversation uuid
+    SetActiveMedia(Uuid),
     // Account
     /// Sets the ID for the user.
     SetId(Identity),

--- a/ui/src/state/chats.rs
+++ b/ui/src/state/chats.rs
@@ -11,9 +11,6 @@ pub struct Chat {
     // TODO: This should be wired up to warp conversation id's
     #[serde(default)]
     pub id: Uuid,
-    // Warp generated UUID of the chat
-    #[serde(default)]
-    pub active_media: bool, // TODO: in the future, this should probably be a vec of media streams or something
     // Includes the list of participants within a given chat.
     #[serde(default)]
     pub participants: Vec<Identity>,
@@ -37,6 +34,9 @@ pub struct Chats {
     // Chat to display / interact with currently.
     #[serde(default)]
     pub active: Option<Uuid>,
+    // Chat associated with the current call
+    #[serde(default)]
+    pub active_media: Option<Uuid>, // TODO: in the future, this should probably be a vec of media streams or something
     // Chats to show in the sidebar
     #[serde(default)]
     pub in_sidebar: Vec<Uuid>,

--- a/ui/src/state/chats.rs
+++ b/ui/src/state/chats.rs
@@ -34,8 +34,9 @@ pub struct Chats {
     // Chat to display / interact with currently.
     #[serde(default)]
     pub active: Option<Uuid>,
-    // Chat associated with the current call
-    #[serde(default)]
+    // don't persist a call across restarts
+    // the Uuid is the chat associated with the current call
+    #[serde(skip)]
     pub active_media: Option<Uuid>, // TODO: in the future, this should probably be a vec of media streams or something
     // Chats to show in the sidebar
     #[serde(default)]

--- a/ui/src/state/mod.rs
+++ b/ui/src/state/mod.rs
@@ -24,7 +24,6 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fmt, fs,
-    rc::Weak,
 };
 use uuid::Uuid;
 use warp::{crypto::DID, raygun::Message};

--- a/ui/src/state/mod.rs
+++ b/ui/src/state/mod.rs
@@ -284,10 +284,6 @@ impl State {
         self.friends.incoming_requests.push(identity.clone());
     }
 
-    fn toggle_popout(&mut self) {
-        self.ui.popout_player = !self.ui.popout_player;
-    }
-
     fn new_outgoing_request(&mut self, identity: &Identity) {
         self.friends.outgoing_requests.push(identity.clone());
     }
@@ -533,8 +529,11 @@ impl State {
         self.call_hooks(&action);
 
         match action {
-            Action::SetMediaWebview(webview) => {
-                self.ui.set_media_webview(webview);
+            Action::ClearPopout => {
+                self.ui.clear_popout();
+            }
+            Action::SetPopout(webview) => {
+                self.ui.set_popout(webview);
             }
             Action::AddOverlay(window) => {
                 self.ui.overlays.push(window);
@@ -606,9 +605,6 @@ impl State {
                 self.set_active_route(to);
             }
             // UI
-            Action::TogglePopout => {
-                self.toggle_popout();
-            }
             Action::SetTheme(theme) => self.set_theme(Some(theme)),
             Action::ClearTheme => self.set_theme(None),
         }

--- a/ui/src/state/mod.rs
+++ b/ui/src/state/mod.rs
@@ -110,24 +110,15 @@ impl State {
         self.ui.enable_overlay = enabled;
     }
 
-    /// Toggles the display of media on the provided chat in the `State` struct.
-    fn toggle_media(&mut self, chat: &Chat) {
-        todo!()
-        /*if let Some(c) = self.chats.all.get_mut(&chat.id) {
-            c.active_media = !c.active_media;
-            // When we "close" active media, we should hide the popout player.
-            if !c.active_media {
-                self.ui.popout_player = false;
-            }
-        }*/
+    /// Sets the active media to the specified conversation id
+    fn set_active_media(&mut self, id: Uuid) {
+        self.chats.active_media = Some(id);
     }
 
-    fn disable_all_active_media(&mut self) {
-        todo!()
-        /*for (_, chat) in self.chats.all.iter_mut() {
-            chat.active_media = false;
-        }
-        self.ui.popout_player = false;*/
+    /// Analogous to Hang Up
+    fn disable_media(&mut self) {
+        self.chats.active_media = None;
+        self.ui.popout_player = false;
     }
 
     /// Adds a chat to the sidebar in the `State` struct.
@@ -554,8 +545,8 @@ impl State {
             Action::ToggleMute => self.toggle_mute(),
             Action::ToggleSilence => self.toggle_silence(),
             Action::SetId(identity) => self.set_identity(&identity),
-            Action::ToggleMedia(chat) => self.toggle_media(&chat),
-            Action::EndAll => self.disable_all_active_media(),
+            Action::SetActiveMedia(id) => self.set_active_media(id),
+            Action::DisableMedia => self.disable_media(),
             Action::SetLanguage(language) => self.set_language(&language),
             Action::SendRequest(identity) => self.new_outgoing_request(&identity),
             Action::RequestAccepted(identity) => {

--- a/ui/src/state/mod.rs
+++ b/ui/src/state/mod.rs
@@ -117,12 +117,7 @@ impl State {
     /// Sets the active media to the specified conversation id
     fn set_active_media(&mut self, id: Uuid) {
         self.chats.active_media = Some(id);
-        self.ui.current_call = Some(Call {
-            media_view: None,
-            muted: false,
-            silenced: false,
-            chat_id: id,
-        });
+        self.ui.current_call = Some(Call::new(None));
     }
 
     /// Analogous to Hang Up
@@ -539,6 +534,9 @@ impl State {
         self.call_hooks(&action);
 
         match action {
+            Action::SetMediaWebview(webview) => {
+                self.ui.set_media_webview(webview);
+            }
             Action::AddOverlay(window) => {
                 self.ui.overlays.push(window);
             }

--- a/ui/src/state/ui.rs
+++ b/ui/src/state/ui.rs
@@ -24,17 +24,14 @@ pub struct UI {
 
 impl Drop for UI {
     fn drop(&mut self) {
-        for window in &self.overlays {
-            if let Some(window) = Weak::upgrade(window) {
-                window
-                    .evaluate_script("close()")
-                    .expect("failed to close window when dropping State");
-            }
-        }
+        self.clear_overlays();
     }
 }
 
 impl UI {
+    pub fn set_media_webview(&mut self, view: Weak<WebView>) {
+        self.current_call = Some(Call::new(Some(view)));
+    }
     pub fn clear_overlays(&mut self) {
         for overlay in &self.overlays {
             if let Some(window) = Weak::upgrade(overlay) {
@@ -92,7 +89,6 @@ pub struct Call {
     pub muted: bool,
     #[serde(default)]
     pub silenced: bool,
-    pub chat_id: Uuid,
 }
 
 impl Drop for Call {
@@ -103,6 +99,16 @@ impl Drop for Call {
                     .expect("failed to close webview");
             }
         });
+    }
+}
+
+impl Call {
+    pub fn new(media_view: Option<Weak<WebView>>) -> Self {
+        Self {
+            media_view,
+            muted: false,
+            silenced: false,
+        }
     }
 }
 

--- a/ui/src/state/ui.rs
+++ b/ui/src/state/ui.rs
@@ -1,13 +1,14 @@
 use kit::icons::Icon;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{collections::HashMap, rc::Weak};
 use uuid::Uuid;
+use wry::webview::WebView;
 
 #[derive(Clone, Default, Deserialize, Serialize)]
 pub struct UI {
     // things like the overlay and popout player get created via DesktopContext::new_window. they are stored here so they can be closed later.
-    // #[serde(skip)]
-    //pub windows: Vec<Weak<WebView>>,
+    #[serde(skip)]
+    pub windows: Vec<Weak<WebView>>,
     // Should the active video play in popout?
     #[serde(default)]
     pub popout_player: bool,

--- a/ui/src/state/ui.rs
+++ b/ui/src/state/ui.rs
@@ -1,7 +1,10 @@
 use dioxus_desktop::tao::window::WindowId;
 use kit::icons::Icon;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, rc::Weak};
+use std::{
+    collections::HashMap,
+    rc::{Rc, Weak},
+};
 use uuid::Uuid;
 use wry::webview::WebView;
 
@@ -29,7 +32,7 @@ impl Drop for UI {
 }
 
 impl UI {
-    pub fn set_media_webview(&mut self, view: Weak<WebView>) {
+    pub fn set_media_webview(&mut self, view: Rc<WebView>) {
         self.current_call = Some(Call::new(Some(view)));
     }
     pub fn clear_overlays(&mut self) {
@@ -84,7 +87,7 @@ pub struct Call {
     // displays the current  video stream
     // may need changing later to accommodate video streams from multiple participants
     #[serde(skip)]
-    pub media_view: Option<Weak<WebView>>,
+    pub media_view: Option<Rc<WebView>>,
     #[serde(default)]
     pub muted: bool,
     #[serde(default)]
@@ -94,16 +97,14 @@ pub struct Call {
 impl Drop for Call {
     fn drop(&mut self) {
         if let Some(view) = self.media_view.as_ref() {
-            if let Some(v) = Weak::upgrade(view) {
-                v.evaluate_script("close()")
-                    .expect("failed to close webview");
-            }
+            view.evaluate_script("close()")
+                .expect("failed to close webview");
         };
     }
 }
 
 impl Call {
-    pub fn new(media_view: Option<Weak<WebView>>) -> Self {
+    pub fn new(media_view: Option<Rc<WebView>>) -> Self {
         Self {
             media_view,
             muted: false,

--- a/ui/src/state/ui.rs
+++ b/ui/src/state/ui.rs
@@ -93,12 +93,12 @@ pub struct Call {
 
 impl Drop for Call {
     fn drop(&mut self) {
-        self.media_view.as_ref().map(|view| {
-            if let Some(v) = Weak::upgrade(&view) {
+        if let Some(view) = self.media_view.as_ref() {
+            if let Some(v) = Weak::upgrade(view) {
                 v.evaluate_script("close()")
                     .expect("failed to close webview");
             }
-        });
+        };
     }
 }
 

--- a/ui/src/testing/mock.rs
+++ b/ui/src/testing/mock.rs
@@ -56,7 +56,7 @@ pub fn generate_mock() -> State {
 
     State {
         ui: UI {
-            //windows: vec![],
+            windows: vec![],
             popout_player: false,
             silenced: false,
             muted: false,

--- a/ui/src/testing/mock.rs
+++ b/ui/src/testing/mock.rs
@@ -56,10 +56,9 @@ pub fn generate_mock() -> State {
 
     State {
         ui: UI {
-            windows: vec![],
+            current_call: None,
+            overlays: vec![],
             popout_player: false,
-            silenced: false,
-            muted: false,
             toast_notifications,
             theme: None,
             // TODO: Until this is more functional, we should keep it disabled by default.
@@ -75,6 +74,7 @@ pub fn generate_mock() -> State {
         chats: Chats {
             all: all_chats.clone(),
             active: None,
+            active_media: None,
             in_sidebar,
             favorites: vec![],
         },
@@ -114,7 +114,6 @@ fn generate_fake_chat(participants: Vec<Identity>, conversation: Uuid) -> Chat {
         id: conversation,
         participants,
         messages,
-        active_media: false,
         unreads: rng.gen_range(0..2),
         replying_to: None,
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- the controls for the current call (mute, silence, ect) were moved from State::UI to State::UI::Call
- for a video call, UI::Call stores the WebView (currently this only happens when the video is popped out). the popout_player persists when one switches chats. 
- ToggleMedia and EndAll were changed because
    1) ToggleMedia allowed for setting multiple chats to having active media but only one media should be active at a time. 
    2) EndAll only makes sense if every chat can have active media (see previous point about this) 

### Which issue(s) this PR fixes 🔨

- Resolve Satellite-im/Uplink#44 

<!--Add the ticket Github number such as #Resolve Satellite-im/Uplink#1 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
for some reason if overlays are toggled some number of times, ending with them being enabled, and the app is closed, the app crashes. But the WebViews close themselves when the UI struct is dropped. I suspect the test code in main.rs has something to do with this, and have left the problem for now in hopes that when overlays are actually used, this bug will go away. 