### PR TITLE
chore(drag): move desktop drag up so its across the entire top of app…

### DIFF
--- a/ui/src/components/chat/sidebar.rs
+++ b/ui/src/components/chat/sidebar.rs
@@ -2,7 +2,6 @@
 use dioxus::prelude::*;
 use warp::{raygun::Message};
 use dioxus_router::*;
-use dioxus_desktop::use_window;
 use kit::{User as UserInfo, elements::{input::{Input, Options}, label::Label}, icons::Icon, components::{nav::Nav, context_menu::{ContextMenu, ContextItem}, user::User, user_image::UserImage, indicator::{Platform, Status}, user_image_group::UserImageGroup}, layout::sidebar::Sidebar as ReusableSidebar};
 
 use crate::{components::{chat::RouteInfo, media::remote_control::RemoteControls}, state::{State, Action, Chat, Identity}, utils::language::get_local_text};
@@ -74,8 +73,6 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
     let binding = state.read();
     let active_media_chat = binding.get_active_media_chat();
 
-    let desktop = use_window(cx);
-
     cx.render(rsx!(
         ReusableSidebar {
             with_search: cx.render(rsx!(
@@ -102,10 +99,6 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
                     }
                 },
             )),
-            div {
-                class: "drag-handle",
-                onmousedown: move |_| desktop.drag(),
-            },
             // Only display favorites if we have some.
             (!favorites.is_empty()).then(|| rsx!(
                 div {

--- a/ui/src/components/chat/style.scss
+++ b/ui/src/components/chat/style.scss
@@ -82,14 +82,6 @@
     padding: 0 var(--gap);
 }
 
-.drag-handle {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: var(--sidebar-width);
-    height: 2rem;
-}
-
 .user-info {
     height: 100%;
     flex: 1;

--- a/ui/src/components/settings/sub_pages/profile/style.scss
+++ b/ui/src/components/settings/sub_pages/profile/style.scss
@@ -19,6 +19,7 @@
 
     .change-banner-text {
       position: absolute;
+      z-index: 3;
       pointer-events: none;
       font-size: var(--text-size);
       color: var(--text-color-muted);

--- a/ui/src/components/settings/sub_pages/profile/style.scss
+++ b/ui/src/components/settings/sub_pages/profile/style.scss
@@ -19,7 +19,6 @@
 
     .change-banner-text {
       position: absolute;
-      z-index: 3;
       pointer-events: none;
       font-size: var(--text-size);
       color: var(--text-color-muted);

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -272,6 +272,10 @@ fn app(cx: Scope) -> Element {
     cx.render(rsx! (
         style { "{UIKIT_STYLES} {APP_STYLE} {theme}" },
         div {
+            class: "drag-handle",
+            onmousedown: move |_| desktop.drag(),
+        },
+        div {
             id: "app-wrap",
             get_toasts(cx, &state.read()),
             get_call_dialog(cx),

--- a/ui/src/style.scss
+++ b/ui/src/style.scss
@@ -95,3 +95,12 @@ html, body {
 ::-webkit-scrollbar-thumb:hover {
     background: var(--primary);
 }    
+
+.drag-handle {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 2rem;
+    z-index: 1;
+}


### PR DESCRIPTION
…, and on the sidebar and main windows

<!--  Thanks for sending a pull request!-->

### What this PR does 📖
This makes all the sidebars and content areas have the top area be draggable. Before only some of the sidebars were draggable.

https://github.com/Satellite-im/Uplink/issues/68

- 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

