### PR TITLE
chore(appium): add aria labels for input and buttons

### DIFF
--- a/kit/src/components/nav/mod.rs
+++ b/kit/src/components/nav/mod.rs
@@ -120,9 +120,11 @@ pub fn Nav<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 let badge = get_badge(route);
                 let key: String = route.name.clone();
                 let name: String = route.name.clone();
+                let aria_label: String = route.name.clone();
                 rsx!(
                     Button {
                         key: "{key}",
+                        aria_label: aria_label.to_lowercase() + "-button",
                         icon: route.icon,
                         onpress: move |_| {
                             active.set(route.to_owned());

--- a/kit/src/elements/button/mod.rs
+++ b/kit/src/elements/button/mod.rs
@@ -18,6 +18,8 @@ pub struct Props<'a> {
     #[props(optional)]
     tooltip: Option<Element<'a>>,
     #[props(optional)]
+    aria_label: Option<String>,
+    #[props(optional)]
     icon: Option<Icon>,
     #[props(optional)]
     disabled: Option<bool>,
@@ -33,6 +35,15 @@ pub struct Props<'a> {
 /// If there is no text provided, we'll return an empty string.
 pub fn get_text(cx: &Scope<Props>) -> String {
     match &cx.props.text {
+        Some(val)   => val.to_owned(),
+        None        => String::from(""),
+    }
+}
+
+/// Generates the optional aria label for the button.
+/// If there is no text provided, we'll return an empty string.
+pub fn get_aria_label(cx: &Scope<Props>) -> String {
+    match &cx.props.aria_label {
         Some(val)   => val.to_owned(),
         None        => String::from(""),
     }
@@ -104,6 +115,7 @@ pub fn Button<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let script = get_script(SCRIPT, &UUID);
 
     let text = get_text(&cx);
+    let aria_label = get_aria_label(&cx);
     let badge = get_badge(&cx);
     let disabled = &cx.props.disabled.unwrap_or_default();
     let appearance = get_appearence(&cx);
@@ -126,7 +138,7 @@ pub fn Button<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 )),
                 button {
                     id: "{UUID}",
-                    aria_label: "button",
+                    aria_label: "{aria_label}",
                     title: "{text}",
                     disabled: "{disabled}",
                     class: {

--- a/kit/src/elements/input/mod.rs
+++ b/kit/src/elements/input/mod.rs
@@ -37,6 +37,8 @@ pub struct Props<'a> {
     #[props(optional)]
     default_text: Option<String>,
     #[props(optional)]
+    aria_label: Option<String>,
+    #[props(optional)]
     is_password: Option<bool>,
     #[props(optional)]
     disabled: Option<bool>,
@@ -118,6 +120,13 @@ pub fn get_text(cx: &Scope<Props>) -> String {
     }
 }
 
+pub fn get_aria_label(cx: &Scope<Props>) -> String {
+    match &cx.props.aria_label {
+        Some(val)   => val.to_owned(),
+        None        => String::from(""),
+    }
+}
+
 pub fn get_label(cx: &Scope<Props>) -> String {
     let default_options = Options::default();
 
@@ -180,6 +189,7 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
         None => 0,
     };
     let apply_validation_class = options.with_validation.is_some();
+    let aria_label = get_aria_label(&cx);
     let label = get_label(&cx);
 
     let disabled = &cx.props.disabled.unwrap_or_default();
@@ -220,6 +230,7 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 )),
                 input {
                     id: "{input_id}",
+                    aria_label: "{aria_label}",
                     disabled: "{disabled}",
                     value: format_args!("{}", val.read()),
                     maxlength: "{max_length}",
@@ -263,6 +274,7 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             (!error.is_empty()).then(|| rsx!( 
                 p {
                     class: "error",
+                    aria_label: "input-error",
                     "{error}"
                 }
             ))

--- a/ui/src/components/chat/sidebar.rs
+++ b/ui/src/components/chat/sidebar.rs
@@ -79,11 +79,11 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
             with_search: cx.render(rsx!(
                 div {
                     class: "search-input",
-                    aria_label: "chat-search-input",
                     Input {
                         placeholder: get_local_text("uplink.search-placeholder"),
                         // TODO: Pending implementation
                         disabled: true,
+                        aria_label: "chat-search-input".into(),
                         icon: Icon::MagnifyingGlass,
                         options: Options {
                             with_clear_btn: true,

--- a/ui/src/components/chat/welcome/mod.rs
+++ b/ui/src/components/chat/welcome/mod.rs
@@ -34,6 +34,7 @@ pub fn Welcome(cx: Scope) -> Element {
             },
             Button {
                 icon: Icon::Plus,
+                aria_label: "add-friends-button".into(),
                 text: get_local_text("friends.add"),
                 appearance: Appearance::Secondary,
                 onpress: move |_| {

--- a/ui/src/components/settings/sidebar.rs
+++ b/ui/src/components/settings/sidebar.rs
@@ -110,9 +110,9 @@ pub fn Sidebar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             with_search: cx.render(rsx!(
                 div {
                     class: "search-input",
-                    aria_label: "settings-search-input",
                     Input {
                         placeholder: get_local_text("settings.search-placeholder"),
+                        aria_label: "settings-search-input".into(),
                         icon: Icon::MagnifyingGlass,
                         disabled: true,
                         options: Options {

--- a/ui/src/layouts/unlock.rs
+++ b/ui/src/layouts/unlock.rs
@@ -70,6 +70,7 @@ pub fn UnlockLayout(cx: Scope) -> Element {
     cx.render(rsx!(
         div {
             id: "unlock-layout",
+            aria_label: "unlock-layout",
             onmousedown: move |_| {
                 desktop.drag();
             },
@@ -77,6 +78,7 @@ pub fn UnlockLayout(cx: Scope) -> Element {
             Input {
                 is_password: true,
                 icon: Icon::Key,
+                aria_label: "pin-input".into(),
                 disabled: false,
                 placeholder: "enter pin".into(), //get_local_text("unlock.enter_pin"),
                 options: Options {
@@ -90,6 +92,7 @@ pub fn UnlockLayout(cx: Scope) -> Element {
             },
             Button {
                 text: "create account".into(), // get_local_text("unlock.create_account"),
+                aria_label: "create-account-button".into(),
                 appearance: kit::elements::Appearance::Primary,
                 icon: Icon::Check,
                 onpress: move |_| {
@@ -104,10 +107,12 @@ fn get_prompt(cx: Scope) -> Element {
     cx.render(rsx!(
         p {
             class: "info",
+            aria_label: "unlock-warning-paragraph",
             "warning: use a good password", //get_local_text("unlock.warning1")
             //"Your password is used to encrypt your data. It is never sent to any server. You should use a strong password that you don't use anywhere else."
             br {},
             span {
+                aria_label: "unlock-warning-span",
                 class: "warning",
                 //"If you forget this password we cannot help you retrieve it."
                 "warning: no password recovery", //get_local_text("unlock.warning2")


### PR DESCRIPTION
### What this PR does 📖

- Adding aria label as property for button and input elements in order to be able to use different aria labels for buttons and inputs used in the application
- Updated aria labels added on my previous PR for unlock and main screens 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

