### PR TITLE
update(ui): add aria labels for ui elements

### DIFF
--- a/kit/src/elements/button/mod.rs
+++ b/kit/src/elements/button/mod.rs
@@ -43,10 +43,7 @@ pub fn get_text(cx: &Scope<Props>) -> String {
 /// Generates the optional aria label for the button.
 /// If there is no text provided, we'll return an empty string.
 pub fn get_aria_label(cx: &Scope<Props>) -> String {
-    match &cx.props.aria_label {
-        Some(val)   => val.to_owned(),
-        None        => String::from(""),
-    }
+    cx.props.aria_label.clone().unwrap_or_default()
 }
 
 /// Generates the optional badge for the button.

--- a/kit/src/elements/file/mod.rs
+++ b/kit/src/elements/file/mod.rs
@@ -12,6 +12,8 @@ pub struct Props<'a> {
     #[props(optional)]
     disabled: Option<bool>,
     #[props(optional)]
+    aria_label: Option<String>,
+    #[props(optional)]
     with_rename: Option<bool>,
     #[props(optional)]
     onrename: Option<EventHandler<'a, String>>,
@@ -25,6 +27,13 @@ pub fn get_text(cx: &Scope<Props>) -> String {
     match &cx.props.text {
         Some(val) => val.to_owned(),
         None => String::from(""),
+    }
+}
+
+pub fn get_aria_label(cx: &Scope<Props>) -> String {
+    match &cx.props.aria_label {
+        Some(val)   => val.to_owned(),
+        None        => String::from(""),
     }
 }
 
@@ -45,6 +54,7 @@ pub fn emit_press(cx: &Scope<Props>) {
 #[allow(non_snake_case)]
 pub fn File<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let text = get_text(&cx);
+    let aria_label = get_aria_label(&cx);
     let placeholder = text.clone();
     let with_rename = cx.props.with_rename.unwrap_or_default();
     let disabled = &cx.props.disabled.unwrap_or_default();
@@ -59,6 +69,7 @@ pub fn File<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 class: {
                     format_args!("file {}", if *disabled { "disabled" } else { "" })
                 },
+                aria_label: "{aria_label}",
                 div {
                     class: "icon",
                     onclick: move |_| emit_press(&cx),

--- a/kit/src/elements/file/mod.rs
+++ b/kit/src/elements/file/mod.rs
@@ -31,10 +31,7 @@ pub fn get_text(cx: &Scope<Props>) -> String {
 }
 
 pub fn get_aria_label(cx: &Scope<Props>) -> String {
-    match &cx.props.aria_label {
-        Some(val)   => val.to_owned(),
-        None        => String::from(""),
-    }
+    cx.props.aria_label.clone().unwrap_or_default()
 }
 
 pub fn emit(cx: &Scope<Props>, s: String) {

--- a/kit/src/elements/folder/mod.rs
+++ b/kit/src/elements/folder/mod.rs
@@ -12,6 +12,8 @@ pub struct Props<'a> {
     #[props(optional)]
     text: Option<String>,
     #[props(optional)]
+    aria_label: Option<String>,
+    #[props(optional)]
     disabled: Option<bool>,
     #[props(optional)]
     with_rename: Option<bool>,
@@ -27,6 +29,13 @@ pub fn get_text(cx: &Scope<Props>) -> String {
     match &cx.props.text {
         Some(val) => val.to_owned(),
         None => String::from(""),
+    }
+}
+
+pub fn get_aria_label(cx: &Scope<Props>) -> String {
+    match &cx.props.aria_label {
+        Some(val)   => val.to_owned(),
+        None        => String::from(""),
     }
 }
 
@@ -48,6 +57,7 @@ pub fn emit_press(cx: &Scope<Props>) {
 pub fn Folder<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let open = &cx.props.open.unwrap_or_default();
     let text = get_text(&cx);
+    let aria_label = get_aria_label(&cx);
     let placeholder = text.clone();
     let with_rename = cx.props.with_rename.unwrap_or_default();
     let icon = if *open {
@@ -67,6 +77,7 @@ pub fn Folder<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 class: {
                     format_args!("folder {}", if *disabled { "disabled" } else { "" })
                 },
+                aria_label: "{aria_label}",
                 div {
                     class: "icon",
                     onclick: move |_| emit_press(&cx),

--- a/kit/src/elements/folder/mod.rs
+++ b/kit/src/elements/folder/mod.rs
@@ -33,10 +33,7 @@ pub fn get_text(cx: &Scope<Props>) -> String {
 }
 
 pub fn get_aria_label(cx: &Scope<Props>) -> String {
-    match &cx.props.aria_label {
-        Some(val)   => val.to_owned(),
-        None        => String::from(""),
-    }
+    cx.props.aria_label.clone().unwrap_or_default()
 }
 
 pub fn emit(cx: &Scope<Props>, s: String) {

--- a/kit/src/elements/input/mod.rs
+++ b/kit/src/elements/input/mod.rs
@@ -121,10 +121,7 @@ pub fn get_text(cx: &Scope<Props>) -> String {
 }
 
 pub fn get_aria_label(cx: &Scope<Props>) -> String {
-    match &cx.props.aria_label {
-        Some(val)   => val.to_owned(),
-        None        => String::from(""),
-    }
+    cx.props.aria_label.clone().unwrap_or_default()
 }
 
 pub fn get_label(cx: &Scope<Props>) -> String {

--- a/ui/src/components/settings/mod.rs
+++ b/ui/src/components/settings/mod.rs
@@ -18,8 +18,10 @@ pub fn SettingSection<'a>(cx: Scope<'a, SectionProps<'a>>) -> Element<'a> {
     cx.render(rsx!(
         div {
             class: "settings-section",
+            aria_label: "settings-section",
             div {
                 class: "settings-info",
+                aria_label: "settings-info",
                 Label {
                     text: cx.props.section_label.clone(),
                 },
@@ -29,6 +31,7 @@ pub fn SettingSection<'a>(cx: Scope<'a, SectionProps<'a>>) -> Element<'a> {
             },
             div {
                 class: "settings-control",
+                aria_label: "settings-control",
                 &cx.props.children
             }
         }

--- a/ui/src/components/settings/sub_pages/audio.rs
+++ b/ui/src/components/settings/sub_pages/audio.rs
@@ -9,6 +9,7 @@ pub fn AudioSettings(cx: Scope) -> Element {
     cx.render(rsx!(
         div {
             id: "settings-audio",
+            aria_label: "settings-audio",
             SettingSection {
                 section_label: get_local_text("settings-audio.call-timer"),
                 section_description: get_local_text("settings-audio.call-timer-description"),

--- a/ui/src/components/settings/sub_pages/developer.rs
+++ b/ui/src/components/settings/sub_pages/developer.rs
@@ -18,6 +18,7 @@ pub fn DeveloperSettings(cx: Scope) -> Element {
     cx.render(rsx!(
         div {
             id: "settings-developer",
+            aria_label: "settings-developer",
             SettingSection {
                 section_label: get_local_text("settings-developer.developer-mode"),
                 section_description: get_local_text("settings-developer.developer-mode-description"),
@@ -33,6 +34,7 @@ pub fn DeveloperSettings(cx: Scope) -> Element {
                 section_description: get_local_text("settings-developer.open-codebase-description"),
                 Button {
                     text: get_local_text("settings-developer.open-codebase"),
+                    aria_label: "open-codebase-button".into(),
                     appearance: Appearance::Secondary,
                     icon: Icon::CodeBracketSquare,
                     onpress: |_| {
@@ -45,6 +47,7 @@ pub fn DeveloperSettings(cx: Scope) -> Element {
                 section_description: get_local_text("settings-developer.open-cache-description"),
                 Button {
                     text: get_local_text("settings-developer.open-cache-folder"),
+                    aria_label: "open-cache-folder-button".into(),
                     appearance: Appearance::Secondary,
                     icon: Icon::FolderOpen,
                     onpress: |_| {
@@ -63,6 +66,7 @@ pub fn DeveloperSettings(cx: Scope) -> Element {
                 section_description: get_local_text("settings-developer.compress-download-cache-description"),
                 Button {
                     text: get_local_text("settings-developer.compress"),
+                    aria_label: "compress-button".into(),
                     appearance: Appearance::Secondary,
                     icon: Icon::ArchiveBoxArrowDown,
                     onpress: |_| {
@@ -74,6 +78,7 @@ pub fn DeveloperSettings(cx: Scope) -> Element {
                 section_description: get_local_text("settings-developer.clear-cache-description"),
                 Button {
                     text: get_local_text("settings-developer.clear"),
+                    aria_label: "clear-button".into(),
                     appearance: Appearance::Danger,
                     icon: Icon::Trash,
                     onpress: move |_| {

--- a/ui/src/components/settings/sub_pages/extensions.rs
+++ b/ui/src/components/settings/sub_pages/extensions.rs
@@ -14,9 +14,11 @@ pub fn ExtensionSettings(cx: Scope) -> Element {
     cx.render(rsx!(
         div {
             id: "settings-extensions",
+            aria_label: "settings-extensions",
             Button {
                 icon: Icon::FolderOpen,
                 text: open_folder,
+                aria_label: "open-extensions-folder-button".into(),
             },
             ExtensionSetting {
                 title: placeholder,

--- a/ui/src/components/settings/sub_pages/files.rs
+++ b/ui/src/components/settings/sub_pages/files.rs
@@ -9,6 +9,7 @@ pub fn FilesSettings(cx: Scope) -> Element {
     cx.render(rsx!(
         div {
             id: "settings-files",
+            aria_label: "settings-files",
             SettingSection {
                 section_label: get_local_text("settings-files.local-sync"),
                 section_description: get_local_text("settings-files.local-sync-description"),
@@ -21,6 +22,7 @@ pub fn FilesSettings(cx: Scope) -> Element {
                 section_description: get_local_text("settings-files.open-sync-folder-description"),
                 Button {
                     text: get_local_text("settings-files.open-sync-folder"),
+                    aria_label: "open-sync-folder-button".into(),
                     appearance: kit::elements::Appearance::Secondary,
                     icon: kit::icons::Icon::FolderOpen,
                     onpress: |_| {

--- a/ui/src/components/settings/sub_pages/general.rs
+++ b/ui/src/components/settings/sub_pages/general.rs
@@ -24,6 +24,7 @@ pub fn GeneralSettings(cx: Scope) -> Element {
     cx.render(rsx!(
         div {
             id: "settings-general",
+            aria_label: "settings-general",
             SettingSection {
                 section_label: get_local_text("settings-general.overlay"),
                 section_description: get_local_text("settings-general.overlay-description"),
@@ -65,6 +66,7 @@ pub fn GeneralSettings(cx: Scope) -> Element {
                 section_description: get_local_text("settings-general.theme-reset-description"),
                 Button {
                     text: get_local_text("settings-general.theme-reset-cta"),
+                    aria_label: "clear-theme-button".into(),
                     icon: Icon::Trash,
                     appearance: kit::elements::Appearance::Secondary,
                     onpress: move |_| {

--- a/ui/src/components/settings/sub_pages/privacy.rs
+++ b/ui/src/components/settings/sub_pages/privacy.rs
@@ -12,11 +12,13 @@ pub fn PrivacySettings(cx: Scope) -> Element {
     cx.render(rsx!(
         div {
             id: "settings-privacy",
+            aria_label: "settings-privacy",
             SettingSection {
                 section_label: get_local_text("settings-privacy.backup-recovery-phrase"),
                 section_description: get_local_text("settings-privacy.backup-phrase-description"),
                 Button {
                     text: get_local_text("settings-privacy.backup-phrase"),
+                    aria_label: "backup-phrase-button".into(),
                     appearance: Appearance::Secondary,
                     icon: Icon::DocumentText,
                 }

--- a/ui/src/components/settings/sub_pages/profile/mod.rs
+++ b/ui/src/components/settings/sub_pages/profile/mod.rs
@@ -93,7 +93,6 @@ pub fn ProfileSettings(cx: Scope) -> Element {
                 },
                 div {
                     class: "content-item",
-                    aria_label: "content-item",
                     Label {
                         text: get_local_text("uplink.username"),
                     },

--- a/ui/src/components/settings/sub_pages/profile/mod.rs
+++ b/ui/src/components/settings/sub_pages/profile/mod.rs
@@ -42,10 +42,13 @@ pub fn ProfileSettings(cx: Scope) -> Element {
     cx.render(rsx!(
         div {
             id: "settings-profile",
+            aria_label: "settings-profile",
             div {
                 class: "profile-header",
+                aria_label: "profile-header",
                 div {
                     class: "profile-banner",
+                    aria_label: "profile-banner",
                     style: "background-image: url({banner_state});",
                     onclick: move |_| {
                         if let Err(error) = change_profile_image(banner_state) {
@@ -56,6 +59,7 @@ pub fn ProfileSettings(cx: Scope) -> Element {
                 },
                 div {
                     class: "profile-picture",
+                    aria_label: "profile-picture",
                     style: "background-image: url({image_state});",
                     onclick: move |_| {
                         if let Err(error) = change_profile_image(image_state) {
@@ -64,6 +68,7 @@ pub fn ProfileSettings(cx: Scope) -> Element {
                     },
                     Button {
                         icon: kit::icons::Icon::Plus,
+                        aria_label: "add-picture-button".into(),
                         onpress: move |_| {
                             if let Err(error) = change_profile_image(image_state) {
                                 log::error!("Error to change profile avatar image {error}");
@@ -74,6 +79,7 @@ pub fn ProfileSettings(cx: Scope) -> Element {
             },
             div{
                 class: "profile-content",
+                aria_label: "profile-content",
                 div {
                     class: "plus-button",
                     Button {
@@ -87,11 +93,13 @@ pub fn ProfileSettings(cx: Scope) -> Element {
                 },
                 div {
                     class: "content-item",
+                    aria_label: "content-item",
                     Label {
                         text: get_local_text("uplink.username"),
                     },
                     Input {
                         placeholder: get_local_text("uplink.username"),
+                        aria_label: "username-input".into(),
                         default_text: "Mock Username".into(),
                         options: get_input_options(username_validation_options),
                     },
@@ -103,6 +111,7 @@ pub fn ProfileSettings(cx: Scope) -> Element {
                     },
                     Input { 
                         placeholder: get_local_text("uplink.status"),
+                        aria_label: "status-input".into(),
                         default_text: "Mock status messages are so 2008.".into(),
                         options: Options {
                             with_clear_btn: true,

--- a/ui/src/layouts/auth.rs
+++ b/ui/src/layouts/auth.rs
@@ -80,9 +80,11 @@ pub fn AuthLayout(cx: Scope) -> Element {
     cx.render(rsx!(
         div {
             id: "unlock-layout",
+            aria_label: "unlock-layout",
             Input {
                 is_password: false,
                 icon: Icon::Identification,
+                aria_label: "username-input".into(),
                 disabled: false,
                 placeholder: "enter username".into(), //get_local_text("auth.enter_username"),
                 options: Options {
@@ -98,6 +100,7 @@ pub fn AuthLayout(cx: Scope) -> Element {
             Input {
                 is_password: true,
                 icon: Icon::Key,
+                aria_label: "pin-input".into(),
                 disabled: false,
                 placeholder: "enter pin".into(), //get_local_text("unlock.enter_pin"),
                 options: Options {
@@ -112,6 +115,7 @@ pub fn AuthLayout(cx: Scope) -> Element {
             },
             Button {
                 text: "create account".into(), // get_local_text("unlock.create_account"),
+                aria_label: "create-account-button".into(),
                 appearance: kit::elements::Appearance::Primary,
                 icon: Icon::Check,
                 onpress: move |_| {

--- a/ui/src/layouts/chat.rs
+++ b/ui/src/layouts/chat.rs
@@ -23,6 +23,7 @@ pub fn ChatLayout(cx: Scope<Props>) -> Element {
     cx.render(rsx!(
         div {
             id: "chat-layout",
+            aria_label: "chat-layout",
             span {
                 class: "full-width-on-mobile",
                 ChatSidebar {

--- a/ui/src/layouts/files.rs
+++ b/ui/src/layouts/files.rs
@@ -102,10 +102,8 @@ pub fn FilesLayout(cx: Scope<Props>) -> Element {
                 },
                 div {
                     class: "files-bar-track",
-                    aria_label: "files-bar-track",
                     div {
                         class: "files-bar",
-                        aria_label: "files-bar",
                     }
                 },
                 div {
@@ -155,12 +153,10 @@ pub fn FilesLayout(cx: Scope<Props>) -> Element {
                         Folder {
                             loading: true,
                             text: "Fake Folder 1".into(),
-                            aria_label: "fake-folder-3".into(),
                         },
                         File {
                             loading: true,
                             text: "Fake File".into(),
-                            aria_label: "fake-file-1".into(),
                         }
                     }
                 },

--- a/ui/src/layouts/files.rs
+++ b/ui/src/layouts/files.rs
@@ -35,6 +35,7 @@ pub fn FilesLayout(cx: Scope<Props>) -> Element {
     cx.render(rsx!(
         div {
             id: "files-layout",
+            aria_label: "files-layout",
             span {
                 class: "hide-on-mobile",
                 ChatSidebar {
@@ -43,6 +44,7 @@ pub fn FilesLayout(cx: Scope<Props>) -> Element {
             }
             div {
                 class: "files-body",
+                aria_label: "files-body",
                 div {
                     onmousedown: move |_| { desktop.drag(); },
                     Topbar {
@@ -52,6 +54,7 @@ pub fn FilesLayout(cx: Scope<Props>) -> Element {
                                 Button {
                                     icon: Icon::FolderPlus,
                                     appearance: Appearance::Secondary,
+                                    aria_label: "add-folder".into(),
                                     tooltip: cx.render(rsx!(
                                         Tooltip {
                                             arrow_position: ArrowPosition::Top,
@@ -65,6 +68,7 @@ pub fn FilesLayout(cx: Scope<Props>) -> Element {
                                 Button {
                                     icon: Icon::Plus,
                                     appearance: Appearance::Secondary,
+                                    aria_label: "upload-file".into(),
                                     tooltip: cx.render(rsx!(
                                         Tooltip {
                                             arrow_position: ArrowPosition::Top,
@@ -76,6 +80,7 @@ pub fn FilesLayout(cx: Scope<Props>) -> Element {
                         ),
                         div {
                             class: "files-info",
+                            aria_label: "files-info",
                             p {
                                 class: "free-space",
                                 "{free_space_text}",
@@ -97,14 +102,18 @@ pub fn FilesLayout(cx: Scope<Props>) -> Element {
                 },
                 div {
                     class: "files-bar-track",
+                    aria_label: "files-bar-track",
                     div {
-                        class: "files-bar"
+                        class: "files-bar",
+                        aria_label: "files-bar",
                     }
                 },
                 div {
                     class: "files-breadcrumbs",
+                    aria_label: "files-breadcrumbs",
                     div {
                         class: "crumb",
+                        aria_label: "crumb",
                         IconElement {
                             icon: Icon::Home,
                         },
@@ -114,12 +123,14 @@ pub fn FilesLayout(cx: Scope<Props>) -> Element {
                     },
                     div {
                         class: "crumb",
+                        aria_label: "crumb",
                         p {
                             "Folder 1"
                         }
                     },
                     div {
                         class: "crumb",
+                        aria_label: "crumb",
                         p {
                             "Folder 3"
                         }
@@ -127,23 +138,29 @@ pub fn FilesLayout(cx: Scope<Props>) -> Element {
                 },
                 div {
                     class: "files-list",
+                    aria_label: "files-list",
                     span {
                         Folder {
-                            text: "Fake Folder 1".into()
+                            text: "Fake Folder 1".into(),
+                            aria_label: "fake-folder-1".into(),
                         },
                         File {
-                            text: "fake_2.png".into()
+                            text: "fake_2.png".into(),
+                            aria_label: "fake-file-1".into(),
                         },
                         Folder {
                             text: "New Fake".into(),
+                            aria_label: "fake-folder-2".into(),
                         },
                         Folder {
                             loading: true,
-                            text: "Fake Folder 1".into()
+                            text: "Fake Folder 1".into(),
+                            aria_label: "fake-folder-3".into(),
                         },
                         File {
                             loading: true,
-                            text: "Fake File".into()
+                            text: "Fake File".into(),
+                            aria_label: "fake-file-1".into(),
                         }
                     }
                 },

--- a/ui/src/layouts/friends.rs
+++ b/ui/src/layouts/friends.rs
@@ -41,6 +41,7 @@ pub fn FriendsLayout(cx: Scope<Props>) -> Element {
     cx.render(rsx!(
         div {
             id: "friends-layout",
+            aria_label: "friends-layout",
             span {
                 class: "hide-on-mobile",
                 ChatSidebar {
@@ -49,12 +50,15 @@ pub fn FriendsLayout(cx: Scope<Props>) -> Element {
             },
             div {
                 class: "friends-body",
+                aria_label: "friends-body",
                 AddFriend {},
                 div {
                     class: "friends-controls",
+                    aria_label: "friends-controls",
                     Button {
                         icon: Icon::Users,
                         text: get_local_text("friends.all"),
+                        aria_label: "all-friends-button".into(),
                         appearance: if route.clone() == FriendRoute::All { Appearance::Primary } else { Appearance::Secondary },
                         onpress: move |_| {
                             route.set(FriendRoute::All);
@@ -64,6 +68,7 @@ pub fn FriendsLayout(cx: Scope<Props>) -> Element {
                         icon: Icon::Clock,
                         appearance: if route.clone() == FriendRoute::Pending { Appearance::Primary } else { Appearance::Secondary },
                         text: get_local_text("friends.pending"),
+                        aria_label: "pending-friends-button".into(),
                         with_badge:  if pending_friends > 0 {
                             pending_friends.to_string()
                         } else {
@@ -77,6 +82,7 @@ pub fn FriendsLayout(cx: Scope<Props>) -> Element {
                         icon: Icon::NoSymbol,
                         appearance: if route.clone() == FriendRoute::Blocked { Appearance::Primary } else { Appearance::Secondary },
                         text: get_local_text("friends.blocked"),
+                        aria_label: "blocked-friends-button".into(),
                         onpress: move |_| {
                             route.set(FriendRoute::Blocked);
                         }

--- a/ui/src/layouts/settings.rs
+++ b/ui/src/layouts/settings.rs
@@ -24,6 +24,7 @@ pub fn SettingsLayout(cx: Scope<Props>) -> Element {
     cx.render(rsx!(
         div {
             id: "settings-layout",
+            aria_label: "settings-layout",
             div {
                 class: "full-width-on-mobile",
                 Sidebar {


### PR DESCRIPTION
### What this PR does 📖
- Adding aria labels for UI elements in Kit and UI folders for Files/Folders, Settings, Chat, Friends and Auth Screen
- Having these aria labels will allow to keep adding screen object files in the tests repository

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

