### PR TITLE
update(ui): add aria labels for context menu and chat ui elements

### DIFF
--- a/kit/src/components/context_menu/mod.rs
+++ b/kit/src/components/context_menu/mod.rs
@@ -35,6 +35,7 @@ pub fn ContextItem<'a>(cx: Scope<'a, ItemProps<'a>>) -> Element<'a> {
     cx.render(rsx! {
         button {
             class: "{class}",
+            aria_label: "Context Item",
             onclick: move |e| emit(&cx, e),
             (cx.props.icon.is_some()).then(|| {
                 let icon = cx.props.icon.unwrap_or(Shape::Cog6Tooth);
@@ -73,6 +74,7 @@ pub fn ContextMenu<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             div {
                 id: "{id}",
                 class: "context-menu hidden",
+                aria_label: "Context Menu",
                 &cx.props.items,
                 cx.props.devmode.is_some().then(|| rsx!(
                     hr {},

--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -61,6 +61,7 @@ pub fn Message<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     } else { "".into() }
                 )
             },
+            aria_label: "Message",
             (cx.props.with_content.is_some()).then(|| rsx! (
                     div {
                     class: "content",

--- a/kit/src/components/user/mod.rs
+++ b/kit/src/components/user/mod.rs
@@ -69,9 +69,11 @@ pub fn User<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                         format_args!("user {} noselect defaultcursor", if active { "active" } else { "" })
                     },
                     onclick: move |e| emit(&cx, e),
+                    aria_label: "User",
                     (!badge.is_empty()).then(|| rsx!(
                         span {
                             class: "badge",
+                            aria_label: "User Badge",
                             span {
                                 class: "badge-prefix",
                                 "{time_ago}"
@@ -85,12 +87,15 @@ pub fn User<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     &cx.props.user_image,
                     div {
                         class: "info",
+                        aria_label: "User Info",
                         p {
                             class: "username",
+                            aria_label: "Username",
                             "{cx.props.username}"
                         },
                         p {
                             class: "subtext",
+                            aria_label: "User Status",
                             "{cx.props.subtext}"
                         }
                     }

--- a/kit/src/components/user_image/mod.rs
+++ b/kit/src/components/user_image/mod.rs
@@ -59,6 +59,7 @@ pub fn UserImage<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 onclick: move |e| emit(&cx, e),
                 div {
                     class: "user-image",
+                    aria_label: "User Image",
                     div {
                         class: "image",
                         style: "background-image: url('{image_data}');"

--- a/kit/src/layout/topbar/mod.rs
+++ b/kit/src/layout/topbar/mod.rs
@@ -39,6 +39,7 @@ pub fn Topbar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     cx.render(rsx!(
         div {
             class: "topbar",
+            aria_label: "Topbar",
             (show_back_button(&cx)).then(|| rsx!(
                 Button {
                     icon: if currently_back { Icon::ChevronLeft } else { Icon::SidebarArrowLeft },

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -130,6 +130,7 @@ fn get_controls(cx: Scope, data: Option<Rc<ComposeData>>) -> Element {
         Button {
             icon: Icon::Heart,
             disabled: data.is_none(),
+            aria_label: "Add to Favorites".into(),
             appearance: data.as_ref().map(|data| if data.is_favorite { Appearance::Primary } else { Appearance::Secondary }).unwrap_or(Appearance::Secondary),
             tooltip: cx.render(rsx!(
                 Tooltip { 
@@ -146,6 +147,7 @@ fn get_controls(cx: Scope, data: Option<Rc<ComposeData>>) -> Element {
         Button {
             icon: Icon::PhoneArrowUpRight,
             disabled: data.is_none(),
+            aria_label: "Call".into(),
             appearance: Appearance::Secondary,
             tooltip: cx.render(rsx!(
                 Tooltip { 
@@ -165,6 +167,7 @@ fn get_controls(cx: Scope, data: Option<Rc<ComposeData>>) -> Element {
             Button {
                 icon: Icon::VideoCamera,
                 disabled: data.is_none(),
+                aria_label: "Videocall".into(),
                 appearance: Appearance::Secondary,
                 tooltip: cx.render(rsx!(
                     Tooltip { 

--- a/ui/src/components/chat/sidebar.rs
+++ b/ui/src/components/chat/sidebar.rs
@@ -75,6 +75,7 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
             (!favorites.is_empty()).then(|| rsx!(
                 div {
                     id: "favorites",
+                    aria_label: "Favorites",
                     Label {
                         text: get_local_text("favorites.favorites"),
                     },
@@ -137,6 +138,7 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
             )),
             div {
                 id: "chats",
+                aria_label: "Chats",
                 (!sidebar_chats.is_empty()).then(|| rsx!(
                     Label {
                         text: get_local_text("uplink.chats"),


### PR DESCRIPTION
### What this PR does 📖

- Add aria labels in kit/src/components and ui/src/components files for Context Menu, Context Items, Sidebar User (user, badge, name, status), User Image, Topbar, Topbar Buttons on Chat and Favorites 
- Aria labels needed to keep adding UI tests on appium repo for Friends Screen (context menu and chat with friends mostly)

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

