### PR TITLE
chore(inputValidation): Fix input validation

### DIFF
--- a/kit/Cargo.toml
+++ b/kit/Cargo.toml
@@ -15,7 +15,6 @@ icons = { path="../icons" }
 timeago = "0.4.0"
 humansize = "2.0.0"
 shared = { path = "../shared" }
-unic = "0.9.0"
 
 derive_more = "0.99"
 

--- a/kit/Cargo.toml
+++ b/kit/Cargo.toml
@@ -15,6 +15,7 @@ icons = { path="../icons" }
 timeago = "0.4.0"
 humansize = "2.0.0"
 shared = { path = "../shared" }
+unic = "0.9.0"
 
 derive_more = "0.99"
 

--- a/kit/src/elements/input/mod.rs
+++ b/kit/src/elements/input/mod.rs
@@ -1,7 +1,6 @@
 use dioxus::{prelude::*};
 use dioxus_html::input_data::keyboard_types::Code;
 use shared::language::get_local_text;
-use unic::emoji::char::is_emoji;
 
 pub type ValidationError = String;
 use crate::{icons::{Icon, IconElement}, elements::label::Label};

--- a/kit/src/elements/input/mod.rs
+++ b/kit/src/elements/input/mod.rs
@@ -80,11 +80,8 @@ pub fn validate_no_whitespace(val: &str) -> Option<ValidationError> {
 }
 
 pub fn validate_alphanumeric(val: &str) -> Option<ValidationError> {
-    let val_char = val.chars();
-    for c in val_char {
-        if is_emoji(c) || !val.chars().all(char::is_alphanumeric) {
-            return Some(get_local_text("warning-messages.only-alpha-chars"));
-        }
+    if !val.chars().all(char::is_alphanumeric) {
+        return Some(get_local_text("warning-messages.only-alpha-chars"));
     }
     None
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
-
The if statements would always overwrite the error message variable to be whatever the last if statement was in the validate function, so if the length validation if statement was last, and it was not in error, it would set any errors from the prior validations to be nothing.


### Which issue(s) this PR fixes 🔨

- Resolve #80 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

