### PR TITLE
chore(appium): fix build job on UI tests GH action

### DIFF
--- a/.github/workflows/ui-test-execution.yml
+++ b/.github/workflows/ui-test-execution.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Install Protobuf 💿
         uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{env.GITHUB_TOKEN}}
 
       - name: Build executable 🖥️
         continue-on-error: true


### PR DESCRIPTION
### What this PR does 📖
- Adding env repo token on Setup Protobuf step to avoid API rate limit issues on the build job for the UI tests GH action
- The action used to setup protobuf (arduino/setup-protoc@v1) queries the GitHub API to fetch releases data and to avoid rate limiting, they suggest to pass the default token with the repo-token (https://github.com/arduino/setup-protoc)

### Which issue(s) this PR fixes 🔨
- Resolve #158 

### Special notes for reviewers 🗒️

### Additional comments 🎤

