### PR TITLE
chore(validation): added ability to ignore colons on inputs, which lets us insert friend codes but still otherwise limit alpha numeric chars

### DIFF
--- a/kit/src/elements/input/mod.rs
+++ b/kit/src/elements/input/mod.rs
@@ -81,7 +81,7 @@ pub fn validate_no_whitespace(val: &str) -> Option<ValidationError> {
 
 // Default to requireing alpha-numeric inputs, unless ignore_colon override is set on the input field
 pub fn validate_alphanumeric(val: &str, ignore_colon: bool) -> Option<ValidationError> {
-    val_no_colons = val.to_string();
+    let mut val_no_colons = val.to_string();
     if val.contains(":") && ignore_colon {
         val_no_colons = val.replace(":", "a");
     }

--- a/kit/src/elements/input/mod.rs
+++ b/kit/src/elements/input/mod.rs
@@ -81,7 +81,6 @@ pub fn validate_no_whitespace(val: &str) -> Option<ValidationError> {
 
 // Default to requireing alpha-numeric inputs, unless ignore_colon override is set on the input field
 pub fn validate_alphanumeric(val: &str, ignore_colon: bool) -> Option<ValidationError> {
-    let mut val_no_colons: String;
     val_no_colons = val.to_string();
     if val.contains(":") && ignore_colon {
         val_no_colons = val.replace(":", "a");

--- a/kit/src/elements/input/mod.rs
+++ b/kit/src/elements/input/mod.rs
@@ -83,7 +83,7 @@ pub fn validate_no_whitespace(val: &str) -> Option<ValidationError> {
 pub fn validate_alphanumeric(val: &str, ignore_colon: bool) -> Option<ValidationError> {
     let mut val_no_colons: String;
     val_no_colons = val.to_string();
-    if val.contains(":") && ignore_colon == true {
+    if val.contains(":") && ignore_colon {
         val_no_colons = val.replace(":", "a");
     }
     if !val_no_colons.chars().all(char::is_alphanumeric) {

--- a/kit/src/elements/input/mod.rs
+++ b/kit/src/elements/input/mod.rs
@@ -138,7 +138,7 @@ pub fn validate(cx: &Scope<Props>, val: &str) -> Option<ValidationError> {
 
     if validation.alpha_numeric_only 
         && validate_alphanumeric(val, validation.ignore_colons).is_some() {
-            error = validate_alphanumeric(val);
+            error = validate_alphanumeric(val, validation.ignore_colons);
     }
 
     if validation.no_whitespace 

--- a/kit/src/elements/input/mod.rs
+++ b/kit/src/elements/input/mod.rs
@@ -81,11 +81,11 @@ pub fn validate_no_whitespace(val: &str) -> Option<ValidationError> {
 
 // Default to requireing alpha-numeric inputs, unless ignore_colon override is set on the input field
 pub fn validate_alphanumeric(val: &str, ignore_colon: bool) -> Option<ValidationError> {
-    let mut val_no_colons = val.to_string();
-    if val.contains(":") && ignore_colon {
-        val_no_colons = val.replace(':', "a");
+    let mut val = val.to_string();
+    if ignore_colon {
+        val.retain(|c| c != ':');
     }
-    if !val_no_colons.chars().all(char::is_alphanumeric) {
+    if !val.chars().all(char::is_alphanumeric) {
         return Some(get_local_text("warning-messages.only-alpha-chars"));
     }
 

--- a/kit/src/elements/input/mod.rs
+++ b/kit/src/elements/input/mod.rs
@@ -83,7 +83,7 @@ pub fn validate_no_whitespace(val: &str) -> Option<ValidationError> {
 pub fn validate_alphanumeric(val: &str, ignore_colon: bool) -> Option<ValidationError> {
     let mut val_no_colons = val.to_string();
     if val.contains(":") && ignore_colon {
-        val_no_colons = val.replace(":", "a");
+        val_no_colons = val.replace(':', "a");
     }
     if !val_no_colons.chars().all(char::is_alphanumeric) {
         return Some(get_local_text("warning-messages.only-alpha-chars"));

--- a/kit/src/elements/input/mod.rs
+++ b/kit/src/elements/input/mod.rs
@@ -11,6 +11,7 @@ pub struct Validation {
     pub max_length: Option<i32>,
     pub min_length: Option<i32>,
     pub alpha_numeric_only: bool,
+    pub ignore_colons: bool,
     pub no_whitespace: bool,
 }
 
@@ -78,10 +79,17 @@ pub fn validate_no_whitespace(val: &str) -> Option<ValidationError> {
     None
 }
 
-pub fn validate_alphanumeric(val: &str) -> Option<ValidationError> {
-    if !val.chars().all(char::is_alphanumeric) {
+// Default to requireing alpha-numeric inputs, unless ignore_colon override is set on the input field
+pub fn validate_alphanumeric(val: &str, ignore_colon: bool) -> Option<ValidationError> {
+    let mut val_no_colons: String;
+    val_no_colons = val.to_string();
+    if val.contains(":") && ignore_colon == true {
+        val_no_colons = val.replace(":", "a");
+    }
+    if !val_no_colons.chars().all(char::is_alphanumeric) {
         return Some(get_local_text("warning-messages.only-alpha-chars"));
     }
+
     None
 }
 
@@ -130,8 +138,8 @@ pub fn validate(cx: &Scope<Props>, val: &str) -> Option<ValidationError> {
     let validation = options.with_validation.unwrap_or_default();
 
     if validation.alpha_numeric_only {
-        if validate_alphanumeric(val).is_some() {
-            error = validate_alphanumeric(val);
+        if validate_alphanumeric(val, validation.ignore_colons).is_some() {
+            error = validate_alphanumeric(val, validation.ignore_colons);
         }
     }
 

--- a/ui/src/components/friends/add.rs
+++ b/ui/src/components/friends/add.rs
@@ -34,6 +34,7 @@ pub fn AddFriend(cx: Scope) -> Element {
         min_length: Some(56),
         alpha_numeric_only: true,
         no_whitespace: true,
+        ignore_colons: true,
     };
 
     // todo: add translations for toasts

--- a/ui/src/components/friends/add.rs
+++ b/ui/src/components/friends/add.rs
@@ -33,7 +33,7 @@ pub fn AddFriend(cx: Scope) -> Element {
     let friend_validation = Validation {
         max_length: Some(56),
         min_length: Some(56),
-        alpha_numeric_only: false,
+        alpha_numeric_only: true,
         no_whitespace: true,
         ignore_colons: true,
     };

--- a/ui/src/components/settings/sub_pages/profile/mod.rs
+++ b/ui/src/components/settings/sub_pages/profile/mod.rs
@@ -23,6 +23,8 @@ pub fn ProfileSettings(cx: Scope) -> Element {
         alpha_numeric_only: true,
         // The input should not contain any whitespace
         no_whitespace: true,
+        // The input component validation is shared - if you need to allow just colons in, set this to true
+        ignore_colons: false,
     };
 
     let status_validation_options = Validation {
@@ -34,6 +36,8 @@ pub fn ProfileSettings(cx: Scope) -> Element {
         alpha_numeric_only: false,
         // The input should not contain any whitespace
         no_whitespace: false,
+        // The input component validation is shared - if you need to allow just colons in, set this to true
+        ignore_colons: false,
     };
 
     let image_state = use_state(cx, String::new);

--- a/ui/src/layouts/create_account.rs
+++ b/ui/src/layouts/create_account.rs
@@ -31,6 +31,8 @@ pub fn CreateAccountLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<Str
         alpha_numeric_only: true,
         // The input should not contain any whitespace
         no_whitespace: true,
+        // The input component validation is shared - if you need to allow just colons in, set this to true
+        ignore_colons: false,
     };
 
     let ch = use_coroutine(cx, |mut rx: UnboundedReceiver<(String, String)>| {

--- a/ui/src/layouts/unlock.rs
+++ b/ui/src/layouts/unlock.rs
@@ -76,6 +76,8 @@ pub fn UnlockLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -
         alpha_numeric_only: false,
         // The input should not contain any whitespace
         no_whitespace: true,
+        // The input component validation is shared - if you need to allow just colons in, set this to true
+        ignore_colons: false,
     };
 
     // todo: use password_failed to display an error message


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
This adds a boolean override to the validation struct on the input that allows you to allow colons while continuing to disallow all the other not alpha numeric inputs. This makes it so the add friend input can have colons and the other inputs with the validator can not.

I tried

- making it an char vector so it was more customizable, but could not figure it out.
- making the override input an Option<String> that i could then split, but you cant derive Copy on an optional string
- checked the char methods available, to see if there was something we could use in place of is_alphanumeric, but didn't find anything
- A few other things i can't recall off hand

if you guys can think of a better way for me to do this, I would be glad to give it another go

- 

### Which issue(s) this PR fixes 🔨

- Resolve #157 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

