### PR TITLE
feat(friends): improve friend removal

### DIFF
--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -87,7 +87,7 @@ fn get_compose_data(cx: Scope) -> Option<Rc<ComposeData>> {
         None => return None
     };
     let message_groups = s.get_sort_messages(&active_chat);
-    let other_participants = s.get_without_me(active_chat.participants.clone());
+    let other_participants = s.get_without_me(&active_chat.participants);
     let active_participant = other_participants.first().cloned().expect("chat should have at least 2 participants");
     let subtext = active_participant.status_message().unwrap_or_default();
     let is_favorite = s.is_favorite(&active_chat);

--- a/ui/src/components/chat/sidebar.rs
+++ b/ui/src/components/chat/sidebar.rs
@@ -89,7 +89,7 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
                             };
                             let favorites_chat = chat.clone();
                             let remove_favorite = chat.clone();
-                            let without_me = state.read().get_without_me(chat.participants.clone());
+                            let without_me = state.read().get_without_me(&chat.participants);
                             let participants_name = build_participants_names(&without_me);
                             
                             rsx! (
@@ -150,7 +150,7 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
                         Some(c) => c.clone(),
                         None => return rsx!("")
                     };
-                    let without_me = state.read().get_without_me(chat.participants.clone());
+                    let without_me = state.read().get_without_me(&chat.participants);
                     let user = without_me.first();
                     let default_message = Message::default();
                     let parsed_user = user.cloned().unwrap_or_default();

--- a/ui/src/components/friends/friends_list/mod.rs
+++ b/ui/src/components/friends/friends_list/mod.rs
@@ -31,7 +31,8 @@ enum ChanCmd {
     CreateConversation { recipient: DID, chat: Option<Chat> },
     RemoveFriend(DID),
     BlockFriend(DID),
-    RemoveConversation(DID),
+    // will remove direct conversations involving the friend
+    RemoveDirectConvs(DID),
 }
 
 #[allow(non_snake_case)]
@@ -115,10 +116,10 @@ pub fn Friends(cx: Scope) -> Element {
                             logger::error(&format!("failed to block friend: {}", e));
                         }
                     }
-                    ChanCmd::RemoveConversation(recipient) => {
+                    ChanCmd::RemoveDirectConvs(recipient) => {
                         let (tx, rx) = oneshot::channel::<Result<(), warp::error::Error>>();
                         warp_cmd_tx
-                            .send(WarpCmd::RayGun(RayGunCmd::Remove2PersonConv {
+                            .send(WarpCmd::RayGun(RayGunCmd::RemoveDirectConvs {
                                 recipient: recipient.clone(),
                                 rsp: tx,
                             }))
@@ -206,7 +207,7 @@ pub fn Friends(cx: Scope) -> Element {
                                             text: get_local_text("uplink.remove"),
                                             onpress: move |_| {
                                                 ch.send(ChanCmd::RemoveFriend(remove_friend.did_key()));
-                                                ch.send(ChanCmd::RemoveConversation(remove_friend.did_key()));
+                                                ch.send(ChanCmd::RemoveDirectConvs(remove_friend.did_key()));
                                             }
                                         },
                                         ContextItem {
@@ -215,7 +216,7 @@ pub fn Friends(cx: Scope) -> Element {
                                             text: get_local_text("friends.block"),
                                             onpress: move |_| {
                                                 ch.send(ChanCmd::BlockFriend(block_friend.did_key()));
-                                                ch.send(ChanCmd::RemoveConversation(block_friend.did_key()));
+                                                ch.send(ChanCmd::RemoveDirectConvs(block_friend.did_key()));
                                             }
                                         },
                                     )),
@@ -236,11 +237,11 @@ pub fn Friends(cx: Scope) -> Element {
                                         },
                                         onremove: move |_| {
                                             ch.send(ChanCmd::RemoveFriend(remove_friend_2.did_key()));
-                                            ch.send(ChanCmd::RemoveConversation(remove_friend_2.did_key()));
+                                            ch.send(ChanCmd::RemoveDirectConvs(remove_friend_2.did_key()));
                                         },
                                         onblock: move |_| {
                                             ch.send(ChanCmd::BlockFriend(block_friend_2.did_key()));
-                                            ch.send(ChanCmd::RemoveConversation(block_friend_2.did_key()));
+                                            ch.send(ChanCmd::RemoveDirectConvs(block_friend_2.did_key()));
                                         }
                                     }
                                 }

--- a/ui/src/components/friends/friends_list/mod.rs
+++ b/ui/src/components/friends/friends_list/mod.rs
@@ -12,12 +12,12 @@ use kit::{
 };
 
 use shared::language::get_local_text;
-use warp::multipass::identity::Relationship;
+use warp::{crypto::DID, multipass::identity::Relationship};
 
 use crate::{
     components::friends::friend::{Friend, SkeletalFriend},
     logger,
-    state::{Action, Chat, Identity, State},
+    state::{Action, Chat, State},
     utils::convert_status,
     warp_runner::{
         commands::{MultiPassCmd, RayGunCmd},
@@ -28,12 +28,10 @@ use crate::{
 
 #[allow(clippy::large_enum_variant)]
 enum ChanCmd {
-    CreateConversation {
-        friend: Identity,
-        chat: Option<Chat>,
-    },
-    RemoveFriend(Identity),
-    BlockFriend(Identity),
+    CreateConversation { recipient: DID, chat: Option<Chat> },
+    RemoveFriend(DID),
+    BlockFriend(DID),
+    RemoveConversation(DID),
 }
 
 #[allow(non_snake_case)]
@@ -60,7 +58,7 @@ pub fn Friends(cx: Scope) -> Element {
             let warp_cmd_tx = WARP_CMD_CH.tx.clone();
             while let Some(cmd) = rx.next().await {
                 match cmd {
-                    ChanCmd::CreateConversation { chat, friend } => {
+                    ChanCmd::CreateConversation { chat, recipient } => {
                         // verify chat exists
                         let chat = match chat {
                             Some(c) => c,
@@ -70,7 +68,7 @@ pub fn Friends(cx: Scope) -> Element {
                                     oneshot::channel::<Result<Chat, warp::error::Error>>();
                                 warp_cmd_tx
                                     .send(WarpCmd::RayGun(RayGunCmd::CreateConversation {
-                                        recipient: friend.did_key(),
+                                        recipient,
                                         rsp: tx,
                                     }))
                                     .expect("failed to send cmd");
@@ -91,34 +89,47 @@ pub fn Friends(cx: Scope) -> Element {
                         };
                         chat_with.set(Some(chat));
                     }
-                    ChanCmd::RemoveFriend(identity) => {
+                    ChanCmd::RemoveFriend(did) => {
                         let (tx, rx) = oneshot::channel::<Result<(), warp::error::Error>>();
                         warp_cmd_tx
                             .send(WarpCmd::MultiPass(MultiPassCmd::RemoveFriend {
-                                did: identity.did_key(),
+                                did,
                                 rsp: tx,
                             }))
                             .expect("failed to send cmd");
 
                         let rsp = rx.await.expect("command canceled");
                         if let Err(e) = rsp {
-                            // todo: display message to user
                             logger::error(&format!("failed to remove friend: {}", e));
                         }
                     }
-                    ChanCmd::BlockFriend(identity) => {
+                    ChanCmd::BlockFriend(did) => {
                         let (tx, rx) = oneshot::channel::<Result<(), warp::error::Error>>();
                         warp_cmd_tx
-                            .send(WarpCmd::MultiPass(MultiPassCmd::Block {
-                                did: identity.did_key(),
-                                rsp: tx,
-                            }))
+                            .send(WarpCmd::MultiPass(MultiPassCmd::Block { did, rsp: tx }))
                             .expect("failed to send cmd");
 
                         let rsp = rx.await.expect("command canceled");
                         if let Err(e) = rsp {
                             // todo: display message to user
                             logger::error(&format!("failed to block friend: {}", e));
+                        }
+                    }
+                    ChanCmd::RemoveConversation(recipient) => {
+                        let (tx, rx) = oneshot::channel::<Result<(), warp::error::Error>>();
+                        warp_cmd_tx
+                            .send(WarpCmd::RayGun(RayGunCmd::Remove2PersonConv {
+                                recipient: recipient.clone(),
+                                rsp: tx,
+                            }))
+                            .expect("failed to send cmd");
+
+                        let rsp = rx.await.expect("command canceled");
+                        if let Err(e) = rsp {
+                            logger::error(&format!(
+                                "failed to remove conversation with friend {}: {}",
+                                recipient, e
+                            ));
                         }
                     }
                 }
@@ -169,7 +180,7 @@ pub fn Friends(cx: Scope) -> Element {
                                             icon: Icon::ChatBubbleBottomCenterText,
                                             text: get_local_text("uplink.chat"),
                                             onpress: move |_| {
-                                                ch.send(ChanCmd::CreateConversation{friend: context_friend.clone(), chat: chat2.clone()});
+                                                ch.send(ChanCmd::CreateConversation{recipient: context_friend.did_key(), chat: chat2.clone()});
                                             }
                                         },
                                         ContextItem {
@@ -194,7 +205,8 @@ pub fn Friends(cx: Scope) -> Element {
                                             icon: Icon::UserMinus,
                                             text: get_local_text("uplink.remove"),
                                             onpress: move |_| {
-                                                ch.send(ChanCmd::RemoveFriend(remove_friend.clone()));
+                                                ch.send(ChanCmd::RemoveFriend(remove_friend.did_key()));
+                                                ch.send(ChanCmd::RemoveConversation(remove_friend.did_key()));
                                             }
                                         },
                                         ContextItem {
@@ -202,7 +214,8 @@ pub fn Friends(cx: Scope) -> Element {
                                             icon: Icon::NoSymbol,
                                             text: get_local_text("friends.block"),
                                             onpress: move |_| {
-                                                ch.send(ChanCmd::BlockFriend(block_friend.clone()));
+                                                ch.send(ChanCmd::BlockFriend(block_friend.did_key()));
+                                                ch.send(ChanCmd::RemoveConversation(block_friend.did_key()));
                                             }
                                         },
                                     )),
@@ -219,13 +232,15 @@ pub fn Friends(cx: Scope) -> Element {
                                             }
                                         )),
                                         onchat: move |_| {
-                                           ch.send(ChanCmd::CreateConversation{friend: chat_with_friend.clone(), chat: chat3.clone()});
+                                           ch.send(ChanCmd::CreateConversation{recipient: chat_with_friend.did_key(), chat: chat3.clone()});
                                         },
                                         onremove: move |_| {
-                                            ch.send(ChanCmd::RemoveFriend(remove_friend_2.clone()));
+                                            ch.send(ChanCmd::RemoveFriend(remove_friend_2.did_key()));
+                                            ch.send(ChanCmd::RemoveConversation(remove_friend_2.did_key()));
                                         },
                                         onblock: move |_| {
-                                            ch.send(ChanCmd::BlockFriend(block_friend_2.clone()));
+                                            ch.send(ChanCmd::BlockFriend(block_friend_2.did_key()));
+                                            ch.send(ChanCmd::RemoveConversation(block_friend_2.did_key()));
                                         }
                                     }
                                 }

--- a/ui/src/state/mod.rs
+++ b/ui/src/state/mod.rs
@@ -29,7 +29,7 @@ use crate::{
 use either::Either;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashMap},
     fmt, fs,
 };
 use uuid::Uuid;
@@ -363,13 +363,11 @@ impl State {
             .cloned()
     }
 
-    pub fn get_without_me(&self, identities: Vec<Identity>) -> Vec<Identity> {
-        let mut set = HashSet::new();
-        set.insert(&self.account.identity);
-
+    pub fn get_without_me(&self, identities: &[Identity]) -> Vec<Identity> {
         identities
             .into_iter()
-            .filter(|identity| !set.contains(identity))
+            .filter(|identity| identity.did_key() != self.account.identity.did_key())
+            .cloned()
             .collect()
     }
 

--- a/ui/src/state/mod.rs
+++ b/ui/src/state/mod.rs
@@ -700,6 +700,9 @@ impl State {
             RayGunEvent::ConversationDeleted(id) => {
                 self.chats.in_sidebar.retain(|x| *x != id);
                 self.chats.all.remove(&id);
+                if self.chats.active == Some(id) {
+                    self.chats.active = None;
+                }
             }
         }
     }

--- a/ui/src/state/mod.rs
+++ b/ui/src/state/mod.rs
@@ -365,7 +365,7 @@ impl State {
 
     pub fn get_without_me(&self, identities: &[Identity]) -> Vec<Identity> {
         identities
-            .into_iter()
+            .iter()
             .filter(|identity| identity.did_key() != self.account.identity.did_key())
             .cloned()
             .collect()

--- a/ui/src/warp_runner/mod.rs
+++ b/ui/src/warp_runner/mod.rs
@@ -176,14 +176,14 @@ impl WarpRunner {
                                 // if a command to block a user comes in, need to update the UI because warp doesn't generate an event for a user being blocked.
                                 // todo: ask for that event
                                 if let MultiPassCmd::Block{did, .. } = &cmd {
-                                    if let Ok(ident) = did_to_identity(did.clone(), &mut account).await {
+                                    if let Ok(ident) = did_to_identity(did.clone(), &account).await {
                                         if tx.send(WarpEvent::MultiPass(MultiPassEvent::Blocked(ident))).is_err() {
                                             break;
                                         }
                                     }
                                 }
                                 if let MultiPassCmd::Unblock{did, .. } = &cmd {
-                                    if let Ok(ident) = did_to_identity(did.clone(), &mut account).await {
+                                    if let Ok(ident) = did_to_identity(did.clone(), &account).await {
                                         if tx.send(WarpEvent::MultiPass(MultiPassEvent::Unblocked(ident))).is_err() {
                                             break;
                                         }

--- a/ui/src/warp_runner/ui_adapter/mod.rs
+++ b/ui/src/warp_runner/ui_adapter/mod.rs
@@ -31,10 +31,7 @@ pub enum MultiPassEvent {
     Unblocked(state::Identity),
 }
 
-pub async fn did_to_identity(
-    did: DID,
-    account: &mut super::Account,
-) -> Result<state::Identity, Error> {
+pub async fn did_to_identity(did: DID, account: &super::Account) -> Result<state::Identity, Error> {
     account
         .get_identity(did.into())
         .await
@@ -59,8 +56,8 @@ pub async fn dids_to_identity(
 }
 
 pub async fn conversation_to_chat(
-    conv: Conversation,
-    account: &mut super::Account,
+    conv: &Conversation,
+    account: &super::Account,
     messaging: &mut super::Messaging,
 ) -> Result<chats::Chat, Error> {
     // todo: should Chat::participants include self?
@@ -146,7 +143,7 @@ pub async fn convert_raygun_event(
     let evt = match event {
         RayGunEventKind::ConversationCreated { conversation_id } => {
             let conv = messaging.get_conversation(conversation_id).await?;
-            let chat = conversation_to_chat(conv, account, messaging).await?;
+            let chat = conversation_to_chat(&conv, account, messaging).await?;
             RayGunEvent::ConversationCreated(chat)
         }
         RayGunEventKind::ConversationDeleted { conversation_id } => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- when a friend is removed or blocked, delete the conversation if the conversation has only 2 participants (leaves group conversations alone)
- initialize `Account` with a value other than Default. This fixes the problem where the conversation participants include the current user. 

### Which issue(s) this PR fixes 🔨

- Resolve #163 #146

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
- wasn't able to reproduce crash when copying DID
- received permission not to make a change for this one: "When trying to add a friend that also added you, the request will disappear and we'll add the user, which is totally fine, but maybe we should automatically jump to a conversation when we add a user or accept a request." because a user may have multiple incoming friend requests. 
