### PR TITLE
feat(input): allow clearing the input element

### DIFF
--- a/kit/src/elements/file/mod.rs
+++ b/kit/src/elements/file/mod.rs
@@ -50,7 +50,7 @@ pub fn File<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let placeholder = text.clone();
     let with_rename = cx.props.with_rename.unwrap_or_default();
     let disabled = cx.props.disabled.unwrap_or_default();
-    let input_val = use_state(cx, String::new);
+    let input_val = use_ref(cx, String::new);
 
     let loading = cx.props.loading.unwrap_or_default();
 

--- a/kit/src/elements/file/mod.rs
+++ b/kit/src/elements/file/mod.rs
@@ -50,6 +50,7 @@ pub fn File<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let placeholder = text.clone();
     let with_rename = cx.props.with_rename.unwrap_or_default();
     let disabled = cx.props.disabled.unwrap_or_default();
+    let input_val = use_state(cx, String::new);
 
     let loading = cx.props.loading.unwrap_or_default();
 
@@ -73,6 +74,7 @@ pub fn File<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     Input {
                         disabled: disabled,
                         placeholder: placeholder,
+                        value: input_val.clone(),
                         // todo: use is_valid
                         onreturn: move |(s, _is_valid)| emit(&cx, s)
                     }

--- a/kit/src/elements/folder/mod.rs
+++ b/kit/src/elements/folder/mod.rs
@@ -47,16 +47,13 @@ pub fn emit_press(cx: &Scope<Props>) {
 
 #[allow(non_snake_case)]
 pub fn Folder<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
+    let input_val = use_state(cx, String::new);
     let open = cx.props.open.unwrap_or_default();
     let text = get_text(&cx);
     let aria_label = get_aria_label(&cx);
     let placeholder = text.clone();
     let with_rename = cx.props.with_rename.unwrap_or_default();
-    let icon = if open {
-        Icon::FolderOpen
-    } else {
-        Icon::Folder
-    };
+    let icon = if open { Icon::FolderOpen } else { Icon::Folder };
     let disabled = cx.props.disabled.unwrap_or_default();
 
     let loading = cx.props.loading.unwrap_or_default();
@@ -81,6 +78,7 @@ pub fn Folder<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     Input {
                         disabled: disabled,
                         placeholder: placeholder,
+                        value: input_val.clone(),
                         // todo: use is_valid
                         onreturn: move |(s, _is_valid)| emit(&cx, s)
                     }

--- a/kit/src/elements/folder/mod.rs
+++ b/kit/src/elements/folder/mod.rs
@@ -47,7 +47,7 @@ pub fn emit_press(cx: &Scope<Props>) {
 
 #[allow(non_snake_case)]
 pub fn Folder<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
-    let input_val = use_state(cx, String::new);
+    let input_val = use_ref(cx, String::new);
     let open = cx.props.open.unwrap_or_default();
     let text = get_text(&cx);
     let aria_label = get_aria_label(&cx);

--- a/kit/src/elements/input/mod.rs
+++ b/kit/src/elements/input/mod.rs
@@ -33,10 +33,10 @@ pub struct Props<'a> {
     #[props(optional)]
     _loading: Option<bool>,
     placeholder: String,
+    // need to be able to clear the input box on button press
+    value: UseState<String>,
     #[props(optional)]
     max_length: Option<i32>,
-    #[props(optional)]
-    default_text: Option<String>,
     #[props(optional)]
     aria_label: Option<String>,
     #[props(optional)]
@@ -116,10 +116,6 @@ pub fn get_icon(cx: &Scope<Props>) -> Icon {
     cx.props.icon.unwrap_or(Icon::QuestionMarkCircle)
 }
 
-pub fn get_text(cx: &Scope<Props>) -> String {
-    cx.props.default_text.clone().unwrap_or_default()
-}
-
 pub fn get_aria_label(cx: &Scope<Props>) -> String {
     cx.props.aria_label.clone().unwrap_or_default()
 }
@@ -159,7 +155,6 @@ pub fn validate(cx: &Scope<Props>, val: &str) -> Option<ValidationError> {
 #[allow(non_snake_case)]
 pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let error = use_state(cx, || String::from(""));
-    let val = use_ref(cx, || get_text(&cx));
     let max_length = cx.props.max_length.unwrap_or(std::i32::MAX);
     let options = cx.props.options.unwrap_or_default();
 
@@ -206,7 +201,7 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     id: "{input_id}",
                     aria_label: "{aria_label}",
                     disabled: "{disabled}",
-                    value: format_args!("{}", val.read()),
+                    value: "{cx.props.value}",
                     maxlength: "{max_length}",
                     "type": "{typ}",
                     placeholder: "{cx.props.placeholder}",
@@ -214,7 +209,7 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                         let current_val = evt.value.clone();
                         let validation_result = validate(&cx, &current_val).unwrap_or_default();
                         error.set(validation_result.clone());
-                        *val.write_silent() = current_val.to_string();
+                        cx.props.value.set(current_val.to_string());
 
                         if !validation_result.is_empty() {
                             valid.set(false);
@@ -222,20 +217,20 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                         } else if current_val.len() >= min_len as usize {
                             valid.set(true);
                         }
-                        emit(&cx, val.read().to_string(), *valid.current());
+                        emit(&cx, cx.props.value.get().to_string(), *valid.current());
                     },
                     onkeyup: move |evt| {
                         if evt.code() == Code::Enter {
-                            emit_return(&cx, val.read().to_string(), *valid.current());
+                            emit_return(&cx, cx.props.value.get().to_string(), *valid.current());
                         }
                     }
                 }
-                (options.with_clear_btn && !val.read().is_empty()).then(|| rsx!(
+                (options.with_clear_btn && !cx.props.value.get().is_empty()).then(|| rsx!(
                     div {
                         class: "clear-btn",
                         onclick: move |_| {
-                            *val.write() = "".into();
-                            emit(&cx, val.read().to_string(), false);
+                            cx.props.value.set("".into());
+                            emit(&cx, cx.props.value.get().to_string(), false);
                             error.set("".into());
                             valid.set(false);
                         },

--- a/kit/src/elements/multiline/mod.rs
+++ b/kit/src/elements/multiline/mod.rs
@@ -22,7 +22,7 @@ pub struct Props<'a> {
 
 #[allow(non_snake_case)]
 pub fn Multiline<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
-    let input_val = use_state(cx, || {
+    let input_val = use_ref(cx, || {
         cx.props
             .default_text
             .clone()

--- a/kit/src/elements/multiline/mod.rs
+++ b/kit/src/elements/multiline/mod.rs
@@ -22,18 +22,19 @@ pub struct Props<'a> {
 
 #[allow(non_snake_case)]
 pub fn Multiline<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
-    let default_text = cx
-        .props
-        .default_text
-        .clone()
-        .unwrap_or_else(|| "Placeholder...".to_owned());
+    let input_val = use_state(cx, || {
+        cx.props
+            .default_text
+            .clone()
+            .unwrap_or_else(|| "Placeholder...".to_owned())
+    });
 
     cx.render(rsx! (
         div {
             class: "multiline",
             Input {
                 placeholder: cx.props.placeholder.clone(),
-                default_text: default_text,
+                value: input_val.clone(),
                 icon: cx.props.icon.unwrap_or(Icon::QuestionMarkCircle),
                 options: cx.props.options.unwrap_or_default(),
 

--- a/kit/src/layout/chatbar/mod.rs
+++ b/kit/src/layout/chatbar/mod.rs
@@ -78,6 +78,7 @@ pub fn Reply<'a>(cx: Scope<'a, ReplyProps<'a>>) -> Element<'a> {
 
 #[allow(non_snake_case)]
 pub fn Chatbar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
+    let input_val = use_state(cx, String::new);
     cx.render(rsx!(
         div {
             class: "chatbar",
@@ -86,6 +87,7 @@ pub fn Chatbar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             Input {
                 disabled: cx.props.loading.unwrap_or_default(),
                 placeholder: cx.props.placeholder.clone(),
+                value: input_val.clone(),
             },
             cx.props.extensions.as_ref(),
             div {

--- a/kit/src/layout/chatbar/mod.rs
+++ b/kit/src/layout/chatbar/mod.rs
@@ -78,7 +78,7 @@ pub fn Reply<'a>(cx: Scope<'a, ReplyProps<'a>>) -> Element<'a> {
 
 #[allow(non_snake_case)]
 pub fn Chatbar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
-    let input_val = use_state(cx, String::new);
+    let input_val = use_ref(cx, String::new);
     cx.render(rsx!(
         div {
             class: "chatbar",

--- a/ui/src/components/chat/sidebar.rs
+++ b/ui/src/components/chat/sidebar.rs
@@ -36,7 +36,7 @@ pub fn build_participants_names(identities: &Vec<Identity>) -> String {
 pub fn Sidebar(cx: Scope<Props>) -> Element {
     logger::trace("rendering chats sidebar layout");
     let state = use_shared_state::<State>(cx)?;
-    let input_val = use_state(cx, String::new);
+    let input_val = use_ref(cx, String::new);
 
     // todo: display a loading page if chats is not initialized
     let (sidebar_chats, favorites, active_media_chat) = if state.read().chats.initialized { 

--- a/ui/src/components/chat/sidebar.rs
+++ b/ui/src/components/chat/sidebar.rs
@@ -36,6 +36,7 @@ pub fn build_participants_names(identities: &Vec<Identity>) -> String {
 pub fn Sidebar(cx: Scope<Props>) -> Element {
     logger::trace("rendering chats sidebar layout");
     let state = use_shared_state::<State>(cx)?;
+    let input_val = use_state(cx, String::new);
 
     // todo: display a loading page if chats is not initialized
     let (sidebar_chats, favorites, active_media_chat) = if state.read().chats.initialized { 
@@ -56,6 +57,7 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
                         disabled: true,
                         aria_label: "chat-search-input".into(),
                         icon: Icon::MagnifyingGlass,
+                        value: input_val.clone(),
                         options: Options {
                             with_clear_btn: true,
                             ..Options::default()

--- a/ui/src/components/friends/add.rs
+++ b/ui/src/components/friends/add.rs
@@ -24,6 +24,7 @@ use crate::{
 #[allow(non_snake_case)]
 pub fn AddFriend(cx: Scope) -> Element {
     let state = use_shared_state::<State>(cx)?;
+    let input_val = use_state(cx, String::new);
     let friend_input = use_state(cx, String::new);
     let friend_input_valid = use_state(cx, || false);
     let request_sent = use_state(cx, || false);
@@ -130,6 +131,7 @@ pub fn AddFriend(cx: Scope) -> Element {
                 Input {
                     placeholder: get_local_text("friends.placeholder"),
                     icon: Icon::MagnifyingGlass,
+                    value: input_val.clone(),
                     options: Options {
                         with_validation: Some(friend_validation),
                         // Do not replace spaces with underscores

--- a/ui/src/components/friends/add.rs
+++ b/ui/src/components/friends/add.rs
@@ -24,7 +24,7 @@ use crate::{
 #[allow(non_snake_case)]
 pub fn AddFriend(cx: Scope) -> Element {
     let state = use_shared_state::<State>(cx)?;
-    let input_val = use_state(cx, String::new);
+    let input_val = use_ref(cx, String::new);
     let friend_input = use_state(cx, String::new);
     let friend_input_valid = use_state(cx, || false);
     let request_sent = use_state(cx, || false);

--- a/ui/src/components/settings/sidebar.rs
+++ b/ui/src/components/settings/sidebar.rs
@@ -106,6 +106,7 @@ pub fn Sidebar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
 
     let active_route = routes[0].clone();
     let state = use_shared_state::<State>(cx)?;
+    let input_val = use_state(cx, String::new);
 
     cx.render(rsx!(
         ReusableSidebar {
@@ -118,6 +119,7 @@ pub fn Sidebar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                         aria_label: "settings-search-input".into(),
                         icon: Icon::MagnifyingGlass,
                         disabled: true,
+                        value: input_val.clone(),
                         options: Options {
                             with_clear_btn: true,
                             ..Options::default()

--- a/ui/src/components/settings/sidebar.rs
+++ b/ui/src/components/settings/sidebar.rs
@@ -106,7 +106,7 @@ pub fn Sidebar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
 
     let active_route = routes[0].clone();
     let state = use_shared_state::<State>(cx)?;
-    let input_val = use_state(cx, String::new);
+    let input_val = use_ref(cx, String::new);
 
     cx.render(rsx!(
         ReusableSidebar {

--- a/ui/src/components/settings/sub_pages/profile/mod.rs
+++ b/ui/src/components/settings/sub_pages/profile/mod.rs
@@ -43,8 +43,12 @@ pub fn ProfileSettings(cx: Scope) -> Element {
     let image_state = use_state(cx, String::new);
     let banner_state = use_state(cx, String::new);
 
+    // todo: don't do this?
+    let username_input = use_state(cx, || String::from("Mock Username"));
+    let status_input = use_state(cx, || String::from("Mock status messages are so 2008."));
+
     let change_banner_text = get_local_text("settings-profile.change-banner");
-    logger::error("Profile settings opened");
+    logger::trace("Profile settings opened");
     cx.render(rsx!(
         div {
             id: "settings-profile",
@@ -105,7 +109,7 @@ pub fn ProfileSettings(cx: Scope) -> Element {
                     Input {
                         placeholder: get_local_text("uplink.username"),
                         aria_label: "username-input".into(),
-                        default_text: "Mock Username".into(),
+                        value: username_input.clone(),
                         options: get_input_options(username_validation_options),
                     },
                 },
@@ -117,7 +121,7 @@ pub fn ProfileSettings(cx: Scope) -> Element {
                     Input {
                         placeholder: get_local_text("uplink.status"),
                         aria_label: "status-input".into(),
-                        default_text: "Mock status messages are so 2008.".into(),
+                        value: status_input.clone(),
                         options: Options {
                             with_clear_btn: true,
                             ..get_input_options(status_validation_options)

--- a/ui/src/components/settings/sub_pages/profile/mod.rs
+++ b/ui/src/components/settings/sub_pages/profile/mod.rs
@@ -44,8 +44,8 @@ pub fn ProfileSettings(cx: Scope) -> Element {
     let banner_state = use_state(cx, String::new);
 
     // todo: don't do this?
-    let username_input = use_state(cx, || String::from("Mock Username"));
-    let status_input = use_state(cx, || String::from("Mock status messages are so 2008."));
+    let username_input = use_ref(cx, || String::from("Mock Username"));
+    let status_input = use_ref(cx, || String::from("Mock status messages are so 2008."));
 
     let change_banner_text = get_local_text("settings-profile.change-banner");
     logger::trace("Profile settings opened");

--- a/ui/src/layouts/create_account.rs
+++ b/ui/src/layouts/create_account.rs
@@ -23,6 +23,7 @@ pub fn CreateAccountLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<Str
     let username = use_state(cx, String::new);
     //let error = use_state(cx, String::new);
     let button_disabled = use_state(cx, || true);
+    let input_val = use_state(cx, String::new);
 
     let username_validation = Validation {
         // The input should have a maximum length of 32
@@ -77,6 +78,7 @@ pub fn CreateAccountLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<Str
                 aria_label: "username-input".into(),
                 disabled: false,
                 placeholder: get_local_text("auth.enter-username"),
+                value: input_val.clone(),
                 options: Options {
                     with_validation: Some(username_validation),
                     with_clear_btn: true,

--- a/ui/src/layouts/create_account.rs
+++ b/ui/src/layouts/create_account.rs
@@ -23,7 +23,7 @@ pub fn CreateAccountLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<Str
     let username = use_state(cx, String::new);
     //let error = use_state(cx, String::new);
     let button_disabled = use_state(cx, || true);
-    let input_val = use_state(cx, String::new);
+    let input_val = use_ref(cx, String::new);
 
     let username_validation = Validation {
         // The input should have a maximum length of 32

--- a/ui/src/layouts/unlock.rs
+++ b/ui/src/layouts/unlock.rs
@@ -24,6 +24,7 @@ pub fn UnlockLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -
     let password_failed: &UseRef<Option<bool>> = use_ref(cx, || None);
     let no_account: &UseState<Option<bool>> = use_state(cx, || None);
     let button_disabled = use_state(cx, || true);
+    let input_val = use_state(cx, String::new);
 
     let ch = use_coroutine(cx, |mut rx| {
         to_owned![password_failed, no_account, page];
@@ -101,6 +102,7 @@ pub fn UnlockLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -
                 aria_label: "pin-input".into(),
                 disabled: false,
                 placeholder: get_local_text("unlock.enter-pin"),
+                value: input_val.clone(),
                 options: Options {
                     with_validation: Some(pin_validation),
                     with_clear_btn: true,

--- a/ui/src/layouts/unlock.rs
+++ b/ui/src/layouts/unlock.rs
@@ -24,7 +24,7 @@ pub fn UnlockLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -
     let password_failed: &UseRef<Option<bool>> = use_ref(cx, || None);
     let no_account: &UseState<Option<bool>> = use_state(cx, || None);
     let button_disabled = use_state(cx, || true);
-    let input_val = use_state(cx, String::new);
+    let input_val = use_ref(cx, String::new);
 
     let ch = use_coroutine(cx, |mut rx| {
         to_owned![password_failed, no_account, page];


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- The chatbar needs to be cleared when a message is sent. the Input element doesn't allow for that. this PR fixes that
- the Input element used to have an option for a default value. that field has been replaced with a `UseRef<String>` for the actual value. Anything wishing to create an Input element with a default value should create the `value` field as follows: `use_ref(cx || String::from(<default value>)`

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

