### PR TITLE
update(Chat): Go to the end of chat when enter on it

### DIFF
--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -4,7 +4,7 @@ use dioxus::prelude::*;
 
 use kit::{layout::{topbar::Topbar, chatbar::{Chatbar, Reply}}, components::{user_image::UserImage, indicator::{Status, Platform}, context_menu::{ContextMenu, ContextItem}, message_group::{MessageGroup, MessageGroupSkeletal}, message::{Message, Order}, user_image_group::UserImageGroup}, elements::{button::Button, tooltip::{Tooltip, ArrowPosition}, Appearance}, icons::Icon};
 
-use dioxus_desktop::use_window;
+use dioxus_desktop::{use_window, use_eval};
 use shared::language::get_local_text;
 
 
@@ -43,7 +43,7 @@ pub fn Compose(cx: Scope) -> Element {
     let state = use_shared_state::<State>(cx)?;
     let data = get_compose_data(cx);
     let data2 = data.clone();
-    
+
     cx.render(rsx!(
         div {
             id: "compose",
@@ -241,6 +241,9 @@ fn get_topbar_children(cx: Scope<ComposeProps>) -> Element {
 fn get_messages(cx: Scope<ComposeProps>) -> Element {
     let state = use_shared_state::<State>(cx)?;
 
+    let script = include_str!("./script.js");
+    use_eval(cx)(script.to_string());
+
     let data = match &cx.props.data {
         Some(d) => d.clone(),
         None => {
@@ -253,6 +256,7 @@ fn get_messages(cx: Scope<ComposeProps>) -> Element {
             ))
         }
     };
+
     cx.render(rsx!(
         div {
             id: "messages",

--- a/ui/src/components/chat/script.js
+++ b/ui/src/components/chat/script.js
@@ -1,0 +1,4 @@
+const chat = document.getElementById("messages")
+const lastChild = chat.lastElementChild
+chat.scrollTop = chat.scrollHeight
+lastChild.scrollIntoView({ behavior: 'smooth', block: 'end' })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
### 1. Go to the end of chat when enter on it

https://user-images.githubusercontent.com/63157656/214367603-fb42e5c0-5690-4362-a510-96076bfd9567.mov

### 2. There is a small UI bug, when we enter in a new chat from friends, scrollbar element is on the initial position, but it will fixed later

https://user-images.githubusercontent.com/63157656/214367810-ad7aafe2-a9b4-43a7-9db9-3208d63a4b85.mov

- 

### Which issue(s) this PR fixes 🔨

- Resolve #150 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

