### PR TITLE
fix(input): Revert "feat(input): allow clearing the input element (#177)"

### DIFF
--- a/kit/src/elements/file/mod.rs
+++ b/kit/src/elements/file/mod.rs
@@ -50,7 +50,6 @@ pub fn File<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let placeholder = text.clone();
     let with_rename = cx.props.with_rename.unwrap_or_default();
     let disabled = cx.props.disabled.unwrap_or_default();
-    let input_val = use_ref(cx, String::new);
 
     let loading = cx.props.loading.unwrap_or_default();
 
@@ -74,7 +73,6 @@ pub fn File<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     Input {
                         disabled: disabled,
                         placeholder: placeholder,
-                        value: input_val.clone(),
                         // todo: use is_valid
                         onreturn: move |(s, _is_valid)| emit(&cx, s)
                     }

--- a/kit/src/elements/folder/mod.rs
+++ b/kit/src/elements/folder/mod.rs
@@ -47,13 +47,16 @@ pub fn emit_press(cx: &Scope<Props>) {
 
 #[allow(non_snake_case)]
 pub fn Folder<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
-    let input_val = use_ref(cx, String::new);
     let open = cx.props.open.unwrap_or_default();
     let text = get_text(&cx);
     let aria_label = get_aria_label(&cx);
     let placeholder = text.clone();
     let with_rename = cx.props.with_rename.unwrap_or_default();
-    let icon = if open { Icon::FolderOpen } else { Icon::Folder };
+    let icon = if open {
+        Icon::FolderOpen
+    } else {
+        Icon::Folder
+    };
     let disabled = cx.props.disabled.unwrap_or_default();
 
     let loading = cx.props.loading.unwrap_or_default();
@@ -78,7 +81,6 @@ pub fn Folder<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     Input {
                         disabled: disabled,
                         placeholder: placeholder,
-                        value: input_val.clone(),
                         // todo: use is_valid
                         onreturn: move |(s, _is_valid)| emit(&cx, s)
                     }

--- a/kit/src/elements/multiline/mod.rs
+++ b/kit/src/elements/multiline/mod.rs
@@ -22,19 +22,18 @@ pub struct Props<'a> {
 
 #[allow(non_snake_case)]
 pub fn Multiline<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
-    let input_val = use_ref(cx, || {
-        cx.props
-            .default_text
-            .clone()
-            .unwrap_or_else(|| "Placeholder...".to_owned())
-    });
+    let default_text = cx
+        .props
+        .default_text
+        .clone()
+        .unwrap_or_else(|| "Placeholder...".to_owned());
 
     cx.render(rsx! (
         div {
             class: "multiline",
             Input {
                 placeholder: cx.props.placeholder.clone(),
-                value: input_val.clone(),
+                default_text: default_text,
                 icon: cx.props.icon.unwrap_or(Icon::QuestionMarkCircle),
                 options: cx.props.options.unwrap_or_default(),
 

--- a/kit/src/layout/chatbar/mod.rs
+++ b/kit/src/layout/chatbar/mod.rs
@@ -78,7 +78,6 @@ pub fn Reply<'a>(cx: Scope<'a, ReplyProps<'a>>) -> Element<'a> {
 
 #[allow(non_snake_case)]
 pub fn Chatbar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
-    let input_val = use_ref(cx, String::new);
     cx.render(rsx!(
         div {
             class: "chatbar",
@@ -87,7 +86,6 @@ pub fn Chatbar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             Input {
                 disabled: cx.props.loading.unwrap_or_default(),
                 placeholder: cx.props.placeholder.clone(),
-                value: input_val.clone(),
             },
             cx.props.extensions.as_ref(),
             div {

--- a/ui/src/components/chat/sidebar.rs
+++ b/ui/src/components/chat/sidebar.rs
@@ -36,7 +36,6 @@ pub fn build_participants_names(identities: &Vec<Identity>) -> String {
 pub fn Sidebar(cx: Scope<Props>) -> Element {
     logger::trace("rendering chats sidebar layout");
     let state = use_shared_state::<State>(cx)?;
-    let input_val = use_ref(cx, String::new);
 
     // todo: display a loading page if chats is not initialized
     let (sidebar_chats, favorites, active_media_chat) = if state.read().chats.initialized { 
@@ -57,7 +56,6 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
                         disabled: true,
                         aria_label: "chat-search-input".into(),
                         icon: Icon::MagnifyingGlass,
-                        value: input_val.clone(),
                         options: Options {
                             with_clear_btn: true,
                             ..Options::default()

--- a/ui/src/components/friends/add.rs
+++ b/ui/src/components/friends/add.rs
@@ -24,7 +24,6 @@ use crate::{
 #[allow(non_snake_case)]
 pub fn AddFriend(cx: Scope) -> Element {
     let state = use_shared_state::<State>(cx)?;
-    let input_val = use_ref(cx, String::new);
     let friend_input = use_state(cx, String::new);
     let friend_input_valid = use_state(cx, || false);
     let request_sent = use_state(cx, || false);
@@ -131,7 +130,6 @@ pub fn AddFriend(cx: Scope) -> Element {
                 Input {
                     placeholder: get_local_text("friends.placeholder"),
                     icon: Icon::MagnifyingGlass,
-                    value: input_val.clone(),
                     options: Options {
                         with_validation: Some(friend_validation),
                         // Do not replace spaces with underscores

--- a/ui/src/components/settings/sidebar.rs
+++ b/ui/src/components/settings/sidebar.rs
@@ -106,7 +106,6 @@ pub fn Sidebar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
 
     let active_route = routes[0].clone();
     let state = use_shared_state::<State>(cx)?;
-    let input_val = use_ref(cx, String::new);
 
     cx.render(rsx!(
         ReusableSidebar {
@@ -119,7 +118,6 @@ pub fn Sidebar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                         aria_label: "settings-search-input".into(),
                         icon: Icon::MagnifyingGlass,
                         disabled: true,
-                        value: input_val.clone(),
                         options: Options {
                             with_clear_btn: true,
                             ..Options::default()

--- a/ui/src/components/settings/sub_pages/profile/mod.rs
+++ b/ui/src/components/settings/sub_pages/profile/mod.rs
@@ -43,12 +43,8 @@ pub fn ProfileSettings(cx: Scope) -> Element {
     let image_state = use_state(cx, String::new);
     let banner_state = use_state(cx, String::new);
 
-    // todo: don't do this?
-    let username_input = use_ref(cx, || String::from("Mock Username"));
-    let status_input = use_ref(cx, || String::from("Mock status messages are so 2008."));
-
     let change_banner_text = get_local_text("settings-profile.change-banner");
-    logger::trace("rendering profile settings");
+    logger::debug("Profile settings page rendered.");
     cx.render(rsx!(
         div {
             id: "settings-profile",
@@ -109,7 +105,7 @@ pub fn ProfileSettings(cx: Scope) -> Element {
                     Input {
                         placeholder: get_local_text("uplink.username"),
                         aria_label: "username-input".into(),
-                        value: username_input.clone(),
+                        default_text: "Mock Username".into(),
                         options: get_input_options(username_validation_options),
                     },
                 },
@@ -121,7 +117,7 @@ pub fn ProfileSettings(cx: Scope) -> Element {
                     Input {
                         placeholder: get_local_text("uplink.status"),
                         aria_label: "status-input".into(),
-                        value: status_input.clone(),
+                        default_text: "Mock status messages are so 2008.".into(),
                         options: Options {
                             with_clear_btn: true,
                             ..get_input_options(status_validation_options)

--- a/ui/src/layouts/create_account.rs
+++ b/ui/src/layouts/create_account.rs
@@ -23,7 +23,6 @@ pub fn CreateAccountLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<Str
     let username = use_state(cx, String::new);
     //let error = use_state(cx, String::new);
     let button_disabled = use_state(cx, || true);
-    let input_val = use_ref(cx, String::new);
 
     let username_validation = Validation {
         // The input should have a maximum length of 32
@@ -78,7 +77,6 @@ pub fn CreateAccountLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<Str
                 aria_label: "username-input".into(),
                 disabled: false,
                 placeholder: get_local_text("auth.enter-username"),
-                value: input_val.clone(),
                 options: Options {
                     with_validation: Some(username_validation),
                     with_clear_btn: true,

--- a/ui/src/layouts/unlock.rs
+++ b/ui/src/layouts/unlock.rs
@@ -24,7 +24,6 @@ pub fn UnlockLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -
     let password_failed: &UseRef<Option<bool>> = use_ref(cx, || None);
     let no_account: &UseState<Option<bool>> = use_state(cx, || None);
     let button_disabled = use_state(cx, || true);
-    let input_val = use_ref(cx, String::new);
 
     let ch = use_coroutine(cx, |mut rx| {
         to_owned![password_failed, no_account, page];
@@ -102,7 +101,6 @@ pub fn UnlockLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -
                 aria_label: "pin-input".into(),
                 disabled: false,
                 placeholder: get_local_text("unlock.enter-pin"),
-                value: input_val.clone(),
                 options: Options {
                     with_validation: Some(pin_validation),
                     with_clear_btn: true,


### PR DESCRIPTION
This reverts commit 1af74972e04bd2746a3d397d2669385e079a8ca5.

<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- i was getting a BorrowMut error when sending a chat. i need to be more creative in figuring out how to clear the input box  :( 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

