### PR TITLE
chore(docs): Use tasks instead of threads 

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,7 +46,7 @@
 ## warp_runner::WarpRunner
 - provides access to `RayGun`, `MultiPass`, and `Tesseract` via the `WarpCmd` struct. Commands contain a oneshot channel for returning the result. `WARP_CMD_CH` is used to send `WarpCmd`s to `WarpRunner`.   
 - notifies Uplink of Warp events via the `WarpEvent` struct. ex: friend requests and incoming messages. Note that a Warp event may not be in a format usable by the UI, and converting the event may require Warp. `warp_runner::ui_adapter` provides utilities for converting Warp events into something usable by the UI. 
-- `WarpRunner` automatically shuts down all threads using `tokio::notify` and a `Drop` implementation.
+- `WarpRunner` automatically shuts down all tasks using `tokio::notify` and a `Drop` implementation.
 - all of the events/commands are processed inside of a `loop { select!{...} }`. It's messy but this allows all the different functions to use the same mutable references to `RayGun`, `MultiPass`, and `Tesseract`. 
 
 ## Examples

--- a/ui/src/warp_runner/mod.rs
+++ b/ui/src/warp_runner/mod.rs
@@ -97,7 +97,7 @@ impl WarpRunner {
         }
     }
 
-    // spawns a thread which will terminate when WarpRunner is dropped
+    // spawns a task which will terminate when WarpRunner is dropped
     pub fn run(&mut self, tx: WarpEventTx, rx: WarpCmdRx) {
         assert!(!self.ran_once, "WarpRunner called run() multiple times");
         self.ran_once = true;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Async tasks (either from tokio, or another async runtime) are not the same as system threads. They can be seen as lightweight threads, coroutines (if ever used anything similar in another languages like kotlin, go, etc), but not real threads so we should not confuse the two in this case.

### Which issue(s) this PR fixes 🔨

- N/A

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

