### PR TITLE
feat(logger): use log crate

### DIFF
--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -41,7 +41,6 @@ soloud = "1.0.2"
 open = "3.2.0"
 wry = { version = "0.23.4" }
 derive_more = "0.99"
-colored = "2.0.0"
 
 notify-rust = { version = "4.6.0", default-features = false, features = ["d"] }
 once_cell = "1.13"

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -41,6 +41,7 @@ soloud = "1.0.2"
 open = "3.2.0"
 wry = { version = "0.23.4" }
 derive_more = "0.99"
+colored = "2.0.0"
 
 notify-rust = { version = "4.6.0", default-features = false, features = ["d"] }
 once_cell = "1.13"

--- a/ui/src/components/debug_logger/mod.rs
+++ b/ui/src/components/debug_logger/mod.rs
@@ -46,6 +46,7 @@ pub fn DebugLogger(cx: Scope, _drop_handler: WindowDropHandler) -> Element {
                     text: format!("{}: {}", "Logger Debug opened on".to_owned(), *debug_logger_started_time.read())},
             },
             logs_to_show.iter().map(|log| {
+               
                 let mut fields = log.split('|');
                 let log_datetime = fields.next().unwrap_or_default();
                 let log_level = fields.next().unwrap_or_default();

--- a/ui/src/components/debug_logger/mod.rs
+++ b/ui/src/components/debug_logger/mod.rs
@@ -55,7 +55,7 @@ pub fn DebugLogger(cx: Scope, _drop_handler: WindowDropHandler) -> Element {
             logs_to_show.iter().map(|log| {
                 let log_level = log.level.to_string();
                 let log_message = log.message.clone();
-                let log_datetime = format!("[{}]",log.datetime);
+                let log_datetime = format!("[{}]", &log.datetime.to_string()[0..19]);
                 let log_color = logger::get_color_string(log.level);
                 rsx!(
                     div {

--- a/ui/src/components/debug_logger/mod.rs
+++ b/ui/src/components/debug_logger/mod.rs
@@ -56,7 +56,7 @@ pub fn DebugLogger(cx: Scope, _drop_handler: WindowDropHandler) -> Element {
                 let log_level = log.level.to_string();
                 let log_message = log.message.clone();
                 let log_datetime = format!("[{}]",log.datetime);
-                let log_color = log.level.color();
+                let log_color = logger::get_color_string(log.level);
                 rsx!(
                     div {
                         display: "flex",

--- a/ui/src/logger/mod.rs
+++ b/ui/src/logger/mod.rs
@@ -150,6 +150,7 @@ impl Logger {
             println!("{}", new_log)
         }
 
+        // if a subscriber closes a channel, send() will fail. remove from subscribers
         self.subscribers.retain(|x| x.send(new_log.clone()).is_ok());
     }
 

--- a/ui/src/logger/mod.rs
+++ b/ui/src/logger/mod.rs
@@ -1,3 +1,20 @@
+//! custom logging implementation
+//! use with the log crate
+//! has options to save logs to a file, print to the terminal, and send new logs to anyone who asks (via logger::subscribe())
+//! this hopefully satisfies the needs of everyone:
+//!     - people who prefer to view logs in the terminal (with and without saving the logs)
+//!     - people who prefer to view logs in the debug_logger GUI
+//!
+//! the debug_logger GUI loads all entries from debug.log and then adds new logs to the display.
+//!
+//! for simplicity, the logger will not keep a circular buffer of logs in memory, because it would have to track
+//! which logs were in memory and which were written to the file, and prevent duplicates. that's just too complicated.
+//!
+//! for readability, the `Log` struct implements display, and logs are written to the file in a regular log format, rather than using Serde::Serialize
+//!
+//! for simplicity, the debug_logger should parse these fields directly. this seems better than converting the
+//! debug log back into a Log struct (would be easier for debug_logger but more difficult overall)
+
 use colored::Colorize;
 use once_cell::sync::Lazy;
 use std::fs::OpenOptions;

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -26,7 +26,7 @@ use tao::menu::{MenuBar as Menu, MenuItem};
 use tao::window::WindowBuilder;
 use tokio::sync::Mutex;
 use tokio::time::{sleep, Duration};
-use warp::logging::tracing::log;
+use warp::logging::tracing::log::{self, LevelFilter};
 
 use crate::components::toast::Toast;
 use crate::layouts::create_account::CreateAccountLayout;
@@ -182,18 +182,23 @@ fn copy_assets() {
 fn main() {
     // configure logging
     let args = Args::parse();
-    if let Some(profile) = args.profile {
+    let max_log_level = if let Some(profile) = args.profile {
         match profile {
             LogProfile::Debug => {
                 logger::set_write_to_stdout(true);
+                LevelFilter::Debug
             }
             LogProfile::Trace => {
                 logger::set_display_trace(true);
                 logger::set_write_to_stdout(true);
+                LevelFilter::Trace
             }
-            _ => {}
+            _ => LevelFilter::Debug,
         }
-    }
+    } else {
+        LevelFilter::Debug
+    };
+    logger::init_with_level(max_log_level).expect("failed to init logger");
 
     // Initializes the cache dir if needed
     std::fs::create_dir_all(STATIC_ARGS.uplink_path.clone())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- allows for easier logging. eliminates the need to pass `&format!("...{}", arg)` to a `logger` function. instead can do this: `log::debug!("...{}", arg)`. 
- still captures logs for the `debug_logger` element 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

