### PR TITLE
chore(cargo): Updated dependency

### DIFF
--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2021"
 unic-langid = "0.9.1"
 isolang = "2.2.0"
 fluent-templates = "0.8.0"
-warp = { git = "https://github.com/Satellite-im/Warp", rev = "f36197f0fe96eab9c9bcf3da87d6bd242f06bca2" }
+warp = { git = "https://github.com/Satellite-im/Warp", rev = "cf4a18c2e88dc5d25a07a9d6048d6e0354859af5" }

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -18,10 +18,10 @@ shared = { path = "../shared" }
 arboard = "3.1.0"
 uuid = { version = "1.0", features = ["serde", "v4"] }
 lipsum = "0.8.2"
-warp = { git = "https://github.com/Satellite-im/Warp", rev = "f36197f0fe96eab9c9bcf3da87d6bd242f06bca2" }
-warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "f36197f0fe96eab9c9bcf3da87d6bd242f06bca2" }
-warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "f36197f0fe96eab9c9bcf3da87d6bd242f06bca2" }
-warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "f36197f0fe96eab9c9bcf3da87d6bd242f06bca2" }
+warp = { git = "https://github.com/Satellite-im/Warp", rev = "cf4a18c2e88dc5d25a07a9d6048d6e0354859af5" }
+warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "cf4a18c2e88dc5d25a07a9d6048d6e0354859af5" }
+warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "cf4a18c2e88dc5d25a07a9d6048d6e0354859af5" }
+warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "cf4a18c2e88dc5d25a07a9d6048d6e0354859af5" }
 rfd = "0.10.0"
 mime = "0.3.16"
 names = "0.14.0"

--- a/ui/src/warp_runner/ui_adapter/mod.rs
+++ b/ui/src/warp_runner/ui_adapter/mod.rs
@@ -144,6 +144,14 @@ pub async fn convert_multipass_event(
             let identity = did_to_identity(&did, account).await?;
             MultiPassEvent::FriendOffline(identity)
         }
+        MultiPassEventKind::Blocked { did } => {
+            let identity = did_to_identity(&did, account).await?;
+            MultiPassEvent::Blocked(identity)
+        }
+        MultiPassEventKind::Unblocked { did } => {
+            let identity = did_to_identity(&did, account).await?;
+            MultiPassEvent::Unblocked(identity)
+        }
     };
 
     Ok(evt)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Updates warp dependency

### Which issue(s) this PR fixes 🔨

- N/A

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️
No visible changes at this time since the update, while introducing a backend feature around blocking, this mostly focus on optimizations done internally.

### Additional comments 🎤
- `Relationship` introduce a field to detect if one is blocked by another. 
- Outgoing and incoming request will be removed when user is blocked.
- `MultiPass::send_request` should error when sending a request to another who blocked the user
- `MultiPassEventKind::Blocked` and `MultiPassEventKind::Unblocked` been added to indicate when another been blocked (eg when `A` blocks `B`, the event is emitted to `A`) 
- Even if user A use `MultiPass::send_request` and it goes through to user B who blocked user A public key, it would get rejected with user A outgoing request being removed.