### PR TITLE
fix(warp_runner): clear tesseract and store warp_runner in use_ref

### DIFF
--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -282,8 +282,9 @@ fn bootstrap(cx: Scope) -> Element {
     logger::trace("rendering bootstrap");
 
     // warp_runner must be started from within a tokio reactor
-    let mut warp_runner = warp_runner::WarpRunner::new();
-    warp_runner.run();
+    // store in a use_ref to make it not get dropped
+    let warp_runner = use_ref(cx, || warp_runner::WarpRunner::new());
+    warp_runner.write_silent().run();
 
     // make the window smaller while the user authenticates
     let desktop = use_window(cx);

--- a/ui/src/warp_runner/manager/commands/multipass_commands.rs
+++ b/ui/src/warp_runner/manager/commands/multipass_commands.rs
@@ -71,7 +71,8 @@ pub async fn handle_multipass_cmd(
             passphrase,
             rsp,
         } => {
-            //println!("create_identity: unlock tesseract");
+            // needed if an old password exists
+            tesseract.clear();
             let r = multipass_create_identity(&username, &passphrase, tesseract, account).await;
             let _ = rsp.send(r);
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- when creating a new account, clear tesseract first. this will delete your old messages
- store warp_runner in a use_ref to prevent it from dropping on certain platforms
- add logging for warp events. these logs will not be displayed until a future PR is merged in
-
### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

