### PR TITLE
fix(login): reinitialize warp with unlocked tesseract 

### DIFF
--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -41,6 +41,7 @@ soloud = "1.0.2"
 open = "3.2.0"
 wry = { version = "0.23.4" }
 derive_more = "0.99"
+colored = "2.0.0"
 
 notify-rust = { version = "4.6.0", default-features = false, features = ["d"] }
 once_cell = "1.13"

--- a/ui/src/warp_runner/manager/events.rs
+++ b/ui/src/warp_runner/manager/events.rs
@@ -139,7 +139,7 @@ pub async fn handle_warp_command(
                     }
                 }
             }
-            handle_multipass_cmd(cmd, &mut warp.tesseract, &mut warp.multipass).await;
+            handle_multipass_cmd(cmd, warp).await;
         }
 
         WarpCmd::RayGun(cmd) => {

--- a/ui/src/warp_runner/manager/mod.rs
+++ b/ui/src/warp_runner/manager/mod.rs
@@ -5,7 +5,10 @@ mod events;
 use futures::StreamExt;
 use std::sync::Arc;
 use tokio::sync::Notify;
-use warp::{multipass::MultiPassEventStream, raygun::RayGunEventStream, tesseract::Tesseract};
+use warp::{
+    logging::tracing::log, multipass::MultiPassEventStream, raygun::RayGunEventStream,
+    tesseract::Tesseract,
+};
 use warp_fs_ipfs::config::FsIpfsConfig;
 use warp_mp_ipfs::config::MpIpfsConfig;
 use warp_rg_ipfs::{config::RgIpfsConfig, Persistent};
@@ -89,6 +92,7 @@ fn init_tesseract() -> Tesseract {
         Ok(tess) => tess,
         Err(_) => {
             //doesnt exist so its set
+            log::info!("creating new tesseract");
             let tess = Tesseract::default();
             tess.set_file(tess_path);
             tess.set_autosave();

--- a/ui/src/warp_runner/manager/mod.rs
+++ b/ui/src/warp_runner/manager/mod.rs
@@ -101,6 +101,7 @@ fn init_tesseract() -> Tesseract {
     }
 }
 
+// tesseract needs to be initialized before warp is initialized. need to call this function again once tesseract is unlocked by the password
 async fn warp_initialization(
     tesseract: Tesseract,
     experimental: bool,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- i suddenly wasn't able to log into Uplink due to a cryptography error. it turns out that warp needs to be initialized with an unlocked tesseract (this may be new behavior). the fix was kind of  a hack - re-initializing warp in response to the Unlock and CreateAccount commands. if anyone has a better idea i'm open to suggestions I say it's a hack because the current design is potentially confusing: warp_runner initializes Warp with a locked tesseract and then accepts commands which will all fail until it's reinitialized with an unlocked tesseract. 
- I also improved the way logs are displayed in the terminal. this shouldn't affect how they are saved to file and thus have no effect on the debug_logger element. 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

