### PR TITLE
fix(login): fix "invalid signature" error on login

### DIFF
--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -41,6 +41,7 @@ soloud = "1.0.2"
 open = "3.2.0"
 wry = { version = "0.23.4" }
 derive_more = "0.99"
+colored = "2.0.0"
 
 notify-rust = { version = "4.6.0", default-features = false, features = ["d"] }
 once_cell = "1.13"

--- a/ui/src/logger/mod.rs
+++ b/ui/src/logger/mod.rs
@@ -78,7 +78,6 @@ impl crate::log::Log for LogGlue {
             return;
         }
 
-        // todo: send .warp logs somewhere else
         // don't care about other libraries
         if record.file().map(|x| x.contains(".cargo")).unwrap_or(true) {
             if LOGGER.read().save_warp && record.file().map(|x| x.contains("warp")).unwrap_or(false)

--- a/ui/src/logger/mod.rs
+++ b/ui/src/logger/mod.rs
@@ -176,16 +176,20 @@ impl Logger {
     }
 
     fn log_warp(&mut self, level: Level, message: &str) {
-        let mut file = OpenOptions::new()
-            .append(true)
-            .open(&self.warp_file)
-            .unwrap();
-
         let new_log = Log {
             level,
             message: message.to_string(),
             datetime: Local::now(),
             colorized: false,
+        };
+
+        let mut file = match OpenOptions::new().append(true).open(&self.warp_file) {
+            Ok(f) => f,
+            Err(e) => {
+                eprintln!("failed to log_warp: {}", e);
+                eprintln!("lost log: {}", new_log);
+                return;
+            }
         };
 
         if let Err(error) = writeln!(file, "{}", new_log) {

--- a/ui/src/warp_runner/manager/commands/mod.rs
+++ b/ui/src/warp_runner/manager/commands/mod.rs
@@ -5,4 +5,4 @@ mod tesseract_commands;
 // this shortens the path required to use the functions and structs
 pub use multipass_commands::{handle_multipass_cmd, MultiPassCmd};
 pub use raygun_commands::{handle_raygun_cmd, RayGunCmd};
-pub use tesseract_commands::{handle_tesseract_cmd, TesseractCmd};
+pub use tesseract_commands::TesseractCmd;

--- a/ui/src/warp_runner/manager/commands/multipass_commands.rs
+++ b/ui/src/warp_runner/manager/commands/multipass_commands.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use futures::channel::oneshot;
-use warp::{crypto::DID, error::Error};
+use warp::{crypto::DID, error::Error, logging::tracing::log};
 
 use crate::{
     state::{self, friends},
@@ -112,6 +112,7 @@ async fn multipass_initialize_friends(
     account: &mut Account,
 ) -> Result<state::friends::Friends, Error> {
     let reqs = account.list_incoming_request().await?;
+    log::trace!("init friends with {} total", reqs.len());
     let idents = dids_to_identity(&reqs, account).await?;
     let incoming_requests = HashSet::from_iter(idents.iter().cloned());
 

--- a/ui/src/warp_runner/manager/commands/raygun_commands.rs
+++ b/ui/src/warp_runner/manager/commands/raygun_commands.rs
@@ -5,6 +5,7 @@ use uuid::Uuid;
 use warp::{
     crypto::DID,
     error::Error,
+    logging::tracing::log,
     raygun::{self, ConversationType},
 };
 
@@ -85,6 +86,7 @@ async fn raygun_initialize_conversations(
     account: &Account,
     messaging: &mut Messaging,
 ) -> Result<(state::Identity, HashMap<Uuid, chats::Chat>), Error> {
+    log::trace!("init convs with {} total", convs.len());
     let own_identity = account.get_own_identity().await?;
     let mut all_chats = HashMap::new();
     for conv in convs {

--- a/ui/src/warp_runner/manager/commands/tesseract_commands.rs
+++ b/ui/src/warp_runner/manager/commands/tesseract_commands.rs
@@ -1,29 +1,9 @@
 use futures::channel::oneshot;
 
-use warp::tesseract::Tesseract;
-
 #[derive(Debug)]
 pub enum TesseractCmd {
     KeyExists {
         key: String,
         rsp: oneshot::Sender<bool>,
     },
-    Unlock {
-        passphrase: String,
-        rsp: oneshot::Sender<Result<(), warp::error::Error>>,
-    },
-}
-
-// currently unused
-pub async fn handle_tesseract_cmd(cmd: TesseractCmd, tesseract: &mut Tesseract) {
-    match cmd {
-        TesseractCmd::KeyExists { key, rsp } => {
-            let res = tesseract.exist(&key);
-            let _ = rsp.send(res);
-        }
-        TesseractCmd::Unlock { passphrase, rsp } => {
-            let r = tesseract.unlock(passphrase.as_bytes());
-            let _ = rsp.send(r);
-        }
-    }
 }

--- a/ui/src/warp_runner/manager/events.rs
+++ b/ui/src/warp_runner/manager/events.rs
@@ -139,7 +139,7 @@ pub async fn handle_warp_command(
                     }
                 }
             }
-            handle_multipass_cmd(cmd, &mut warp.tesseract, &mut warp.multipass).await;
+            handle_multipass_cmd(cmd, warp).await;
         }
 
         WarpCmd::RayGun(cmd) => {

--- a/ui/src/warp_runner/manager/events.rs
+++ b/ui/src/warp_runner/manager/events.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 use super::{
-    commands::{handle_multipass_cmd, handle_raygun_cmd, handle_tesseract_cmd},
+    commands::{handle_multipass_cmd, handle_raygun_cmd},
     MultiPassCmd,
 };
 
@@ -113,7 +113,9 @@ pub async fn handle_warp_command(
     log::debug!("received warp command: {:?}", &cmd);
     let warp_event_tx = WARP_EVENT_CH.tx.clone();
     match cmd {
-        WarpCmd::Tesseract(cmd) => handle_tesseract_cmd(cmd, &mut warp.tesseract).await,
+        WarpCmd::Tesseract(_cmd) => {
+            // not accepted at this stage of the program. this will drop the rx channel and alert the sender
+        }
         WarpCmd::MultiPass(cmd) => {
             // if a command to block a user comes in, need to update the UI because warp doesn't generate an event for a user being blocked.
             // todo: ask for that event

--- a/ui/src/warp_runner/manager/events.rs
+++ b/ui/src/warp_runner/manager/events.rs
@@ -114,7 +114,7 @@ pub async fn handle_warp_command(
     let warp_event_tx = WARP_EVENT_CH.tx.clone();
     match cmd {
         WarpCmd::Tesseract(_cmd) => {
-            // not accepted at this stage of the program. this will drop the rx channel and alert the sender
+            // not accepted at this stage of the program. do nothing and drop the rsp channel
         }
         WarpCmd::MultiPass(cmd) => {
             // if a command to block a user comes in, need to update the UI because warp doesn't generate an event for a user being blocked.

--- a/ui/src/warp_runner/manager/mod.rs
+++ b/ui/src/warp_runner/manager/mod.rs
@@ -5,7 +5,10 @@ mod events;
 use futures::StreamExt;
 use std::sync::Arc;
 use tokio::sync::Notify;
-use warp::{multipass::MultiPassEventStream, raygun::RayGunEventStream, tesseract::Tesseract};
+use warp::{
+    logging::tracing::log, multipass::MultiPassEventStream, raygun::RayGunEventStream,
+    tesseract::Tesseract,
+};
 use warp_fs_ipfs::config::FsIpfsConfig;
 use warp_mp_ipfs::config::MpIpfsConfig;
 use warp_rg_ipfs::{config::RgIpfsConfig, Persistent};
@@ -89,6 +92,7 @@ fn init_tesseract() -> Tesseract {
         Ok(tess) => tess,
         Err(_) => {
             //doesnt exist so its set
+            log::info!("creating new tesseract");
             let tess = Tesseract::default();
             tess.set_file(tess_path);
             tess.set_autosave();

--- a/ui/src/warp_runner/manager/mod.rs
+++ b/ui/src/warp_runner/manager/mod.rs
@@ -66,7 +66,9 @@ pub async fn run(mut warp: Warp, notify: Arc<Notify>) {
         }
     }
 
-    warp.tesseract.lock();
+    // why is autosave not working? hope this works.
+    let _ = warp.tesseract.save();
+    // tesseract.lock() is called on drop. no need to do it here
     logger::debug("terminating warp_runner thread");
 }
 

--- a/ui/src/warp_runner/manager/mod.rs
+++ b/ui/src/warp_runner/manager/mod.rs
@@ -9,36 +9,18 @@ use warp::{
     logging::tracing::log, multipass::MultiPassEventStream, raygun::RayGunEventStream,
     tesseract::Tesseract,
 };
-use warp_fs_ipfs::config::FsIpfsConfig;
-use warp_mp_ipfs::config::MpIpfsConfig;
-use warp_rg_ipfs::{config::RgIpfsConfig, Persistent};
 
 use super::{conv_stream, Account, Messaging, Storage};
-use crate::{logger, STATIC_ARGS, WARP_CMD_CH};
+use crate::{logger, WARP_CMD_CH};
 
 pub use commands::{MultiPassCmd, RayGunCmd, TesseractCmd};
 
 /// Contains the structs needed for run() to handle various events
 pub struct Warp {
-    tesseract: Tesseract,
-    multipass: Account,
-    raygun: Messaging,
-    _constellation: Storage,
-}
-
-impl Warp {
-    pub async fn new() -> Result<Self, warp::error::Error> {
-        let tesseract = init_tesseract();
-        let (multipass, raygun, _constellation) =
-            warp_initialization(tesseract.clone(), false).await?;
-
-        Ok(Self {
-            tesseract,
-            multipass,
-            raygun,
-            _constellation,
-        })
-    }
+    pub tesseract: Tesseract,
+    pub multipass: Account,
+    pub raygun: Messaging,
+    pub _constellation: Storage,
 }
 
 pub async fn run(mut warp: Warp, notify: Arc<Notify>) {
@@ -48,14 +30,15 @@ pub async fn run(mut warp: Warp, notify: Arc<Notify>) {
     // using a mutex was the only way to get a mutable static variable. this channel should only be read here and only needs to be acquired once
     let mut warp_cmd_rx = warp_cmd_rx.lock().await;
 
-    // receive events from RayGun and MultiPass
-    let mut raygun_stream = get_raygun_stream(&mut warp.raygun).await;
-    let mut multipass_stream = get_multipass_stream(&mut warp.multipass).await;
-
     // gather incoming messages from all conversations and read them from conversation_msg_rx
     let (conversation_msg_tx, mut conversation_msg_rx) = tokio::sync::mpsc::unbounded_channel();
     let mut conversation_manager = conv_stream::Manager::new(conversation_msg_tx.clone());
 
+    // receive events from RayGun and MultiPass
+    let mut raygun_stream = get_raygun_stream(&mut warp.raygun).await;
+    let mut multipass_stream = get_multipass_stream(&mut warp.multipass).await;
+
+    log::debug!("warp_runner::manager::run");
     loop {
         tokio::select! {
             opt = multipass_stream.next() => {
@@ -84,55 +67,6 @@ pub async fn run(mut warp: Warp, notify: Arc<Notify>) {
     }
 
     logger::debug("terminating warp_runner thread");
-}
-
-fn init_tesseract() -> Tesseract {
-    let tess_path = STATIC_ARGS.warp_path.join(".keystore");
-    match Tesseract::from_file(&tess_path) {
-        Ok(tess) => tess,
-        Err(_) => {
-            //doesnt exist so its set
-            log::info!("creating new tesseract");
-            let tess = Tesseract::default();
-            tess.set_file(tess_path);
-            tess.set_autosave();
-            tess
-        }
-    }
-}
-
-// tesseract needs to be initialized before warp is initialized. need to call this function again once tesseract is unlocked by the password
-async fn warp_initialization(
-    tesseract: Tesseract,
-    experimental: bool,
-) -> Result<(Account, Messaging, Storage), warp::error::Error> {
-    let path = &STATIC_ARGS.warp_path;
-    let config = MpIpfsConfig::production(path, experimental);
-
-    let account = warp_mp_ipfs::ipfs_identity_persistent(config, tesseract, None)
-        .await
-        .map(|mp| Box::new(mp) as Account)?;
-
-    let storage = warp_fs_ipfs::IpfsFileSystem::<warp_fs_ipfs::Persistent>::new(
-        account.clone(),
-        Some(FsIpfsConfig::production(path)),
-    )
-    .await
-    .map(|ct| Box::new(ct) as Storage)?;
-
-    // FYI: setting `rg_config.store_setting.disable_sender_event_emit` to `true` will prevent broadcasting `ConversationCreated` on the sender side
-    let rg_config = RgIpfsConfig::production(path);
-
-    let messaging = warp_rg_ipfs::IpfsMessaging::<Persistent>::new(
-        Some(rg_config),
-        account.clone(),
-        Some(storage.clone()),
-        None,
-    )
-    .await
-    .map(|rg| Box::new(rg) as Messaging)?;
-
-    Ok((account, messaging, storage))
 }
 
 async fn get_raygun_stream(rg: &mut Messaging) -> RayGunEventStream {

--- a/ui/src/warp_runner/manager/mod.rs
+++ b/ui/src/warp_runner/manager/mod.rs
@@ -66,6 +66,7 @@ pub async fn run(mut warp: Warp, notify: Arc<Notify>) {
         }
     }
 
+    warp.tesseract.lock();
     logger::debug("terminating warp_runner thread");
 }
 

--- a/ui/src/warp_runner/manager/mod.rs
+++ b/ui/src/warp_runner/manager/mod.rs
@@ -101,6 +101,7 @@ fn init_tesseract() -> Tesseract {
     }
 }
 
+// tesseract needs to be initialized before warp is initialized. need to call this function again once tesseract is unlocked by the password
 async fn warp_initialization(
     tesseract: Tesseract,
     experimental: bool,

--- a/ui/src/warp_runner/mod.rs
+++ b/ui/src/warp_runner/mod.rs
@@ -199,11 +199,9 @@ async fn login(
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
 
-    if !new_account {
-        if !tesseract.exist("keypair") {
-            log::info!("string keypair not found in tesseract");
-            return Err(warp::error::Error::IdentityNotCreated);
-        }
+    if !new_account && !tesseract.exist("keypair") {
+        log::info!("string keypair not found in tesseract");
+        return Err(warp::error::Error::IdentityNotCreated);
     }
     let res = warp_initialization(tesseract, false).await;
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- sometimes i got that error when logging in, especially when logging in a second time and especially when loading multiple conversations. it seems that the other devs didn't have that error today - no one else mentioned it. 
- I changed the flow of `warp_runner` to first only respond to commands related to login. 
- I got paranoid about how multipass and raygun worked with teseract, and made sure they were only initialized with an unlocked tesseract. 
- i changed the logic for logins, to check for a "keypair" in tesseract when not creating a new account. 
- I  improved the way logs are displayed in the terminal. this shouldn't affect how they are saved to file and thus have no effect on the debug_logger element.
- I made the `trace` debugging option save warp logs in a single file. it isn't ideal but helps debug problems involving warp. 


### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

