### PR TITLE
feat(typing): add backend for typing indicator

### DIFF
--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -397,7 +397,20 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
     let input = use_ref(cx, Vec::<String>::new);
     let should_clear_input = use_state(cx,|| false);
     let active_chat_id = data.as_ref().map(|d| d.active_chat.id);
+
+    // todo: use this to render the typing indicator
+    let  _users_typing = match active_chat_id.and_then(|id| state.read().chats.all.get(&id).cloned()) {
+        Some(chat) => {
+            let users_typing = chat.participants.iter().filter(|x| chat.typing_indicator.contains_key(&x.did_key())).collect::<Vec<_>>();
+            let names = users_typing.iter().map(|x| x.username()).collect::<Vec<_>>();
+            Some(names)
+        }
+        None => None
+    };
     
+    //println!("active chat: {:?}", &active_chat_id);
+    //println!("users typing: {:?}", &users_typing);
+
     let msg_ch = use_coroutine(cx, |mut rx: UnboundedReceiver<(Vec<String>, Uuid)>| {
         //to_owned![];
         async move {

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -399,14 +399,7 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
     let active_chat_id = data.as_ref().map(|d| d.active_chat.id);
 
     // todo: use this to render the typing indicator
-    let  _users_typing = match active_chat_id.and_then(|id| state.read().chats.all.get(&id).cloned()) {
-        Some(chat) => {
-            let users_typing = chat.participants.iter().filter(|x| chat.typing_indicator.contains_key(&x.did_key())).collect::<Vec<_>>();
-            let names = users_typing.iter().map(|x| x.username()).collect::<Vec<_>>();
-            Some(names)
-        }
-        None => None
-    };
+    let  _users_typing = active_chat_id.and_then(|id| state.read().chats.all.get(&id).cloned()).map(|chat| chat.participants.iter().filter(|x| chat.typing_indicator.contains_key(&x.did_key())).map(|x| x.username()).collect::<Vec<_>>());
     
     //println!("active chat: {:?}", &active_chat_id);
     //println!("users typing: {:?}", &users_typing);

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -474,7 +474,7 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
                         }
                         // todo: verify duration for timeout
                         let now = Instant::now();
-                        if now - info.last_update <= Duration::from_secs(6) {
+                        if now - info.last_update <= (Duration::from_secs(STATIC_ARGS.typing_indicator_timeout) - Duration::from_millis(500)) {
                             send_typing_indicator.clone()(conv_id).await;
                         }
                     }
@@ -490,7 +490,7 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
         &active_chat_id.clone(),
         |current_chat| async move {
             loop {
-                tokio::time::sleep(Duration::from_secs(5)).await;
+                tokio::time::sleep(Duration::from_secs(STATIC_ARGS.typing_indicator_refresh)).await;
                 if let Some(c) = current_chat {
                     local_typing_ch1.send(TypingIndicator::Refresh(c));
                 }

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -474,7 +474,7 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
                         }
                         // todo: verify duration for timeout
                         let now = Instant::now();
-                        if now - info.last_update <= Duration::from_secs(3) {
+                        if now - info.last_update <= Duration::from_secs(6) {
                             send_typing_indicator.clone()(conv_id).await;
                         }
                     }
@@ -490,7 +490,7 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
         &active_chat_id.clone(),
         |current_chat| async move {
             loop {
-                tokio::time::sleep(Duration::from_secs(4)).await;
+                tokio::time::sleep(Duration::from_secs(5)).await;
                 if let Some(c) = current_chat {
                     local_typing_ch1.send(TypingIndicator::Refresh(c));
                 }

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -1,4 +1,4 @@
-use std::{rc::Rc};
+use std::{rc::Rc, time::{Instant, Duration}};
 
 use dioxus::prelude::*;
 
@@ -373,6 +373,21 @@ fn get_messages(cx: Scope<ComposeProps>) -> Element {
     ))
 }
 
+#[derive(Eq, PartialEq)]
+enum TypingIndicator {
+    // reset the typing indicator timer
+    Typing(Uuid),
+    // clears the typing indicator, ensuring the indicator
+    // will not be refreshed
+    NotTyping,
+    // resend the typing indicator
+    Refresh(Uuid),
+}
+#[derive(Clone)]
+struct TypingInfo {
+    pub chat_id: Uuid,
+    pub last_update: Instant
+}
 
 fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
     log::trace!("get_chatbar");
@@ -383,7 +398,7 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
     let should_clear_input = use_state(cx,|| false);
     let active_chat_id = data.as_ref().map(|d| d.active_chat.id);
     
-    let ch = use_coroutine(cx, |mut rx: UnboundedReceiver<(Vec<String>, Uuid)>| {
+    let msg_ch = use_coroutine(cx, |mut rx: UnboundedReceiver<(Vec<String>, Uuid)>| {
         //to_owned![];
         async move {
             let warp_cmd_tx = WARP_CMD_CH.tx.clone();
@@ -407,6 +422,82 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
         }
     });
 
+    // typing indicator notes
+    // consider side A, the local side, and side B, the remote side
+    // side A -> (typing indicator) -> side B
+    // side B removes the typing indicator after a timeout
+    // side A doesn't want to send too many typing indicators, say once every 4-5 seconds
+
+    // tracks if the local participant is typing
+    // re-sends typing indicator in response to the Refresh command
+    let local_typing_ch = use_coroutine(cx, |mut rx: UnboundedReceiver<TypingIndicator>| {
+        // to_owned![];
+        async move {
+           
+            let mut typing_info: Option<TypingInfo> = None;
+            let warp_cmd_tx = WARP_CMD_CH.tx.clone();
+
+            let send_typing_indicator = |conv_id| async move {
+                let (tx, rx) = oneshot::channel::<Result<(), warp::error::Error>>();
+                let event = raygun::MessageEvent::Typing;
+                warp_cmd_tx.send(WarpCmd::RayGun(RayGunCmd::SendEvent { conv_id, event, rsp: tx })).expect("failed to send command");
+                let rsp = rx.await.expect("command canceled");
+                if let Err(e) = rsp {
+                    log::error!("failed to send typing indicator: {}", e);
+                }
+            };
+
+            while let Some(indicator) = rx.next().await {
+                match indicator {
+                    TypingIndicator::Typing(chat_id) => {
+                        // if typing_info was none or the chat id changed, send the indicator immediately
+                        let should_send_indicator = match typing_info {
+                            None =>  true,
+                            Some(info) => info.chat_id != chat_id,
+                        };
+                        if should_send_indicator {
+                            send_typing_indicator.clone()(chat_id).await;
+                        }
+                        typing_info = Some(TypingInfo{chat_id, last_update: Instant::now()});
+                    }
+                    TypingIndicator::NotTyping => {
+                        typing_info = None;
+                    }
+                    TypingIndicator::Refresh(conv_id) => {
+                        let info = match &typing_info {
+                            Some(i) => i.clone(),
+                            None => continue
+                        };
+                        if info.chat_id != conv_id {
+                            typing_info = None;
+                            continue;
+                        }
+                        // todo: verify duration for timeout
+                        let now = Instant::now();
+                        if now - info.last_update <= Duration::from_secs(3) {
+                            send_typing_indicator.clone()(conv_id).await;
+                        }
+                    }
+                } 
+            }
+        }
+    });
+
+    // drives the sending of TypingIndicator
+    let local_typing_ch1 = local_typing_ch.clone();
+    use_future(
+        cx,
+        &active_chat_id.clone(),
+        |current_chat| async move {
+            loop {
+                tokio::time::sleep(Duration::from_secs(4)).await;
+                if let Some(c) = current_chat {
+                    local_typing_ch1.send(TypingIndicator::Refresh(c));
+                }
+            }
+        },
+    );
+
     let msg_valid = |msg: &[String]| {
         !msg.is_empty() && msg.iter().any(|line| !line.trim().is_empty())
     };
@@ -418,8 +509,13 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
             reset: should_clear_input.clone(),
             onchange: move |v: String| {
                 *input.write_silent() = v.lines().map(|x| x.to_string()).collect::<Vec<String>>();
+                if let Some(id) = &active_chat_id {
+                    local_typing_ch.send(TypingIndicator::Typing(*id));
+                }
             },
             onreturn: move |_| {
+                local_typing_ch.send(TypingIndicator::NotTyping);
+
                 let msg = input.read().clone();
                 // clearing input here should prevent the possibility to double send a message if enter is pressed twice
                 input.write().clear();
@@ -436,7 +532,7 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
                 if STATIC_ARGS.use_mock {
                     state.write().mutate(Action::MockSend(id, msg));
                 } else {
-                    ch.send((msg, id));
+                    msg_ch.send((msg, id));
                 }
             },
             controls: cx.render(rsx!(
@@ -445,6 +541,8 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
                     disabled: loading,
                     appearance: Appearance::Secondary,
                     onpress: move |_| {
+                        local_typing_ch.send(TypingIndicator::NotTyping);
+
                         let msg = input.read().clone();
                         // clearing input here should prevent the possibility to double send a message if enter is pressed twice
                         input.write().clear();
@@ -462,7 +560,7 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
                         if STATIC_ARGS.use_mock {
                             state.write().mutate(Action::MockSend(id, msg));
                         } else {
-                            ch.send((msg, id));
+                            msg_ch.send((msg, id));
                         }
                     },
                     tooltip: cx.render(rsx!(

--- a/ui/src/components/chat/style.scss
+++ b/ui/src/components/chat/style.scss
@@ -105,3 +105,56 @@
         animation: none;
     }
 }
+
+#compose {
+    .typing-indicator {
+        width: 100%;
+        user-select: none;
+        display: flex;
+        align-items: center;
+        color: var(--theme-text-bright);
+        .loader {
+            width: 4px;
+            height: 4px;
+            border-radius: 50%;
+            margin-right: 32px;
+            position: relative;
+            flex-shrink: 0;
+            animation: typing 1s linear infinite alternate;
+        }
+        .primary {
+            height: 20px;
+            padding-right: 4px;
+            font-weight: bold;
+            word-break: break-all;
+            overflow: hidden;
+            box-sizing: border-box;
+            text-transform: capitalize;
+        }
+        .secondary {
+            height: 20px;
+            flex-shrink: 0;
+            word-wrap: nowrap;
+        }
+    }
+    
+    @keyframes typing {
+        0% {
+            background: rgba(255, 255, 255, 1);
+            box-shadow: 10px 0px 0px 0px rgba(255, 255, 255, 0.2),
+            20px 0px 0px 0px rgba(255, 255, 255, 0.2);
+        }
+        50% {
+            background: rgba(255, 255, 255, 0.4);
+            box-shadow: 10px 0px 0px 0px rgba(255, 255, 255, 2),
+            20px 0px 0px 0px rgba(255, 255, 255, 0.2);
+        }
+        100% {
+            background: rgba(255, 255, 255, 0.4);
+            box-shadow: 10px 0px 0px 0px rgba(255, 255, 255, 0.2),
+            20px 0px 0px 0px rgba(255, 255, 255, 1);
+        }
+    }
+}
+
+  

--- a/ui/src/components/settings/sub_pages/general.rs
+++ b/ui/src/components/settings/sub_pages/general.rs
@@ -46,7 +46,7 @@ pub fn GeneralSettings(cx: Scope) -> Element {
                 section_label: get_local_text("settings-general.theme"),
                 section_description: get_local_text("settings-general.theme-description"),
                 Select {
-                    initial_value: state.read().ui.theme.clone().map(|t| t.name).unwrap_or("Default".into()),
+                    initial_value: state.read().ui.theme.clone().map(|t| t.name).unwrap_or_else(|| "Default".into()),
                     options: themes.iter().map(|t| t.name.clone()).collect(),
                     onselect: move |value| {
                         themes.iter().for_each(|t| {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -287,7 +287,7 @@ fn bootstrap(cx: Scope) -> Element {
 
     // warp_runner must be started from within a tokio reactor
     // store in a use_ref to make it not get dropped
-    let warp_runner = use_ref(cx, || warp_runner::WarpRunner::new());
+    let warp_runner = use_ref(cx, warp_runner::WarpRunner::new);
     warp_runner.write_silent().run();
 
     // make the window smaller while the user authenticates

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -19,6 +19,7 @@ use shared::language::{change_language, get_local_text};
 use state::State;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::time::Instant;
 use uuid::Uuid;
 
 use std::sync::Arc;
@@ -398,6 +399,7 @@ fn app(cx: Scope) -> Element {
         state.write();
     }
 
+    // clear toasts
     let inner = state.inner();
     use_future(cx, (), |_| {
         to_owned![needs_update];
@@ -412,6 +414,24 @@ fn app(cx: Scope) -> Element {
                     }
                     if state.write().decrement_toasts() {
                         //println!("decrement toasts");
+                        needs_update.set(true);
+                    }
+                }
+            }
+        }
+    });
+
+    // clear typing indicator
+    let inner = state.inner();
+    use_future(cx, (), |_| {
+        to_owned![needs_update];
+        async move {
+            loop {
+                sleep(Duration::from_secs(6)).await;
+                {
+                    let state = inner.borrow();
+                    let now = Instant::now();
+                    if state.write().clear_typing_indicator(now) {
                         needs_update.set(true);
                     }
                 }

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -63,6 +63,10 @@ pub struct StaticArgs {
     pub config_path: PathBuf,
     pub warp_path: PathBuf,
     pub logger_path: PathBuf,
+    // seconds
+    pub typing_indicator_refresh: u64,
+    // seconds
+    pub typing_indicator_timeout: u64,
     pub use_mock: bool,
 }
 pub static STATIC_ARGS: Lazy<StaticArgs> = Lazy::new(|| {
@@ -77,6 +81,8 @@ pub static STATIC_ARGS: Lazy<StaticArgs> = Lazy::new(|| {
         config_path: uplink_path.join("Config.json"),
         warp_path: uplink_path.join("warp"),
         logger_path: uplink_path.join("debug.log"),
+        typing_indicator_refresh: 5,
+        typing_indicator_timeout: 6,
         use_mock: !args.no_mock,
     }
 });
@@ -427,7 +433,7 @@ fn app(cx: Scope) -> Element {
         to_owned![needs_update];
         async move {
             loop {
-                sleep(Duration::from_secs(6)).await;
+                sleep(Duration::from_secs(STATIC_ARGS.typing_indicator_timeout)).await;
                 {
                     let state = inner.borrow();
                     let now = Instant::now();

--- a/ui/src/state/chats.rs
+++ b/ui/src/state/chats.rs
@@ -1,8 +1,11 @@
-use std::collections::{HashMap, VecDeque};
+use std::{
+    collections::{HashMap, VecDeque},
+    time::Instant,
+};
 
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-use warp::raygun::Message;
+use warp::{crypto::DID, raygun::Message};
 
 use super::identity::Identity;
 
@@ -26,6 +29,10 @@ pub struct Chat {
     // If a value exists, we will render the message we're replying to above the chatbar
     #[serde(skip)]
     pub replying_to: Option<Message>,
+    // list of users currently typing.
+    // (user id, last update time)
+    #[serde(skip)]
+    pub typing_indicator: HashMap<DID, Instant>,
 }
 
 // TODO: Properly wrap data which is expected to persist remotely in options, so we can know if we're still figuring out what exists "remotely", i.e. loading.

--- a/ui/src/state/mod.rs
+++ b/ui/src/state/mod.rs
@@ -335,6 +335,7 @@ impl State {
 
     fn add_msg_to_chat(&mut self, conversation_id: Uuid, message: raygun::Message) {
         if let Some(chat) = self.chats.all.get_mut(&conversation_id) {
+            chat.typing_indicator.remove(&message.sender());
             chat.messages.push_back(message);
         }
     }

--- a/ui/src/testing/mock.rs
+++ b/ui/src/testing/mock.rs
@@ -124,6 +124,7 @@ fn generate_fake_chat(participants: Vec<Identity>, conversation: Uuid) -> Chat {
         messages,
         unreads: rng.gen_range(0..2),
         replying_to: None,
+        typing_indicator: HashMap::new(),
     }
 }
 

--- a/ui/src/warp_runner/manager/commands/raygun_commands.rs
+++ b/ui/src/warp_runner/manager/commands/raygun_commands.rs
@@ -47,6 +47,11 @@ pub enum RayGunCmd {
         emoji: String,
         rsp: oneshot::Sender<Result<(), warp::error::Error>>,
     },
+    SendEvent {
+        conv_id: Uuid,
+        event: raygun::MessageEvent,
+        rsp: oneshot::Sender<Result<(), warp::error::Error>>,
+    },
 }
 
 pub async fn handle_raygun_cmd(
@@ -94,6 +99,14 @@ pub async fn handle_raygun_cmd(
             let r = messaging
                 .react(conversation_id, message_id, reaction_state, emoji)
                 .await;
+            let _ = rsp.send(r);
+        }
+        RayGunCmd::SendEvent {
+            conv_id,
+            event,
+            rsp,
+        } => {
+            let r = messaging.send_event(conv_id, event).await;
             let _ = rsp.send(r);
         }
     }

--- a/ui/src/warp_runner/ui_adapter/message_event.rs
+++ b/ui/src/warp_runner/ui_adapter/message_event.rs
@@ -1,5 +1,6 @@
 use uuid::Uuid;
 use warp::{
+    crypto::DID,
     error::Error,
     logging::tracing::log,
     raygun::{self, MessageEventKind},
@@ -23,6 +24,10 @@ pub enum MessageEvent {
         conversation_id: Uuid,
         message_id: Uuid,
         reaction: String,
+    },
+    TypingIndicator {
+        conversation_id: Uuid,
+        participant: DID,
     },
 }
 
@@ -72,6 +77,16 @@ pub async fn convert_message_event(
             conversation_id,
             message_id,
             reaction,
+        },
+        MessageEventKind::EventReceived {
+            conversation_id,
+            did_key,
+            event,
+        } => match event {
+            raygun::MessageEvent::Typing => MessageEvent::TypingIndicator {
+                conversation_id,
+                participant: did_key,
+            },
         },
         _ => {
             println!("evt received: {:?}", event);

--- a/ui/src/warp_runner/ui_adapter/mod.rs
+++ b/ui/src/warp_runner/ui_adapter/mod.rs
@@ -10,7 +10,7 @@ pub use message_event::{convert_message_event, MessageEvent};
 pub use multipass_event::{convert_multipass_event, MultiPassEvent};
 pub use raygun_event::{convert_raygun_event, RayGunEvent};
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 
 use warp::{
     crypto::DID,
@@ -72,5 +72,6 @@ pub async fn conversation_to_chat(
         messages,
         unreads: unreads as u32,
         replying_to: None,
+        typing_indicator: HashMap::new(),
     })
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- sends and receives events to trigger the typing indicator 
- introduces a task to refresh message timestamps (unrelated to the typing indicator)
- adds documentation to `main::app()`
- copied the `scss` code for the typing indicator animation from the old Uplink app. 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

