### PR TITLE
chore(cargo): Update dependency

### DIFF
--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2021"
 unic-langid = "0.9.1"
 isolang = "2.2.0"
 fluent-templates = "0.8.0"
-warp = { git = "https://github.com/Satellite-im/Warp", rev = "cf4a18c2e88dc5d25a07a9d6048d6e0354859af5" }
+warp = { git = "https://github.com/Satellite-im/Warp", rev = "aff8e57003fbdb766f0b24c4acb4178e319d7fad" }

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -18,10 +18,10 @@ shared = { path = "../shared" }
 arboard = "3.1.0"
 uuid = { version = "1.0", features = ["serde", "v4"] }
 lipsum = "0.8.2"
-warp = { git = "https://github.com/Satellite-im/Warp", rev = "cf4a18c2e88dc5d25a07a9d6048d6e0354859af5" }
-warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "cf4a18c2e88dc5d25a07a9d6048d6e0354859af5" }
-warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "cf4a18c2e88dc5d25a07a9d6048d6e0354859af5" }
-warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "cf4a18c2e88dc5d25a07a9d6048d6e0354859af5" }
+warp = { git = "https://github.com/Satellite-im/Warp", rev = "aff8e57003fbdb766f0b24c4acb4178e319d7fad" }
+warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "aff8e57003fbdb766f0b24c4acb4178e319d7fad" }
+warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "aff8e57003fbdb766f0b24c4acb4178e319d7fad" }
+warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "aff8e57003fbdb766f0b24c4acb4178e319d7fad" }
 rfd = "0.10.0"
 mime = "0.3.16"
 names = "0.14.0"

--- a/ui/src/warp_runner/mod.rs
+++ b/ui/src/warp_runner/mod.rs
@@ -215,7 +215,9 @@ async fn warp_initialization(
 ) -> Result<manager::Warp, warp::error::Error> {
     log::debug!("warp initialization");
     let path = &STATIC_ARGS.warp_path;
-    let config = MpIpfsConfig::production(path, experimental);
+    let mut config = MpIpfsConfig::production(path, experimental);
+    config.ipfs_setting.portmapping = true;
+
 
     let account = warp_mp_ipfs::ipfs_identity_persistent(config, tesseract.clone(), None)
         .await

--- a/ui/src/warp_runner/ui_adapter/multipass_event.rs
+++ b/ui/src/warp_runner/ui_adapter/multipass_event.rs
@@ -64,6 +64,7 @@ pub async fn convert_multipass_event(
             let identity = did_to_identity(&did, account).await?;
             MultiPassEvent::Unblocked(identity)
         }
+        _ => MultiPassEvent::None,
     };
 
     Ok(evt)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Update dependency
- Adds `MultiPassEventKind::BlockedBy` and `MultiPassEventKind::UnBlockedBy` (currently not implemented or used in uplink) 
- Enables port mapping

### Which issue(s) this PR fixes 🔨

- N/A

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️
- Connectivity should be improved with this due to port mapping being enabled. 

### Additional comments 🎤
- The 2 events were recently added which is an indication when a another user blocked you (eg if user A blocks user B, user B would receive an event). This is not exposed or used in uplink, however these events may be disabled by default in the future
- Portmapping (aka UPnP or port forwarding) is enabled through a flag, however if the firewall on the computer, router, or network blocks it, it will fail and attempt to use relays (unless that is disabled by default)  

