### PR TITLE
fix(sidebar): fix friends sidebar

### DIFF
--- a/ui/src/layouts/friends.rs
+++ b/ui/src/layouts/friends.rs
@@ -88,15 +88,13 @@ pub fn MinimalFriendsLayout(cx: Scope<Props>) -> Element {
                 },
                 // TODO: Will need to determine if we're loading or not once state is update, and display a loading view if so. (see friends-list)
                 render_route(cx, (*route.current()).clone()),
-                (state.read().ui.sidebar_hidden).then(|| rsx!(
-                    Nav {
-                        routes: cx.props.route_info.routes.clone(),
-                        active: cx.props.route_info.active.clone(),
-                        onnavigate: move |r| {
-                            use_router(cx).replace_route(r, None, None);
-                        }
+                Nav {
+                    routes: cx.props.route_info.routes.clone(),
+                    active: cx.props.route_info.active.clone(),
+                    onnavigate: move |r| {
+                        use_router(cx).replace_route(r, None, None);
                     }
-                ))
+                }
             }
         )
     };

--- a/ui/src/layouts/friends.rs
+++ b/ui/src/layouts/friends.rs
@@ -59,7 +59,7 @@ pub fn FriendsLayout(cx: Scope<Props>) -> Element {
                     aria_label: "friends-controls",
                 },
                 // TODO: Will need to determine if we're loading or not once state is update, and display a loading view if so. (see friends-list)
-                render_route(cx, (*route.current()).clone()),
+                render_route(cx, route.get().clone()),
             }
         }
     ))
@@ -87,7 +87,7 @@ pub fn MinimalFriendsLayout(cx: Scope<Props>) -> Element {
                     aria_label: "friends-controls",
                 },
                 // TODO: Will need to determine if we're loading or not once state is update, and display a loading view if so. (see friends-list)
-                render_route(cx, (*route.current()).clone()),
+                render_route(cx, route.get().clone()),
                 Nav {
                     routes: cx.props.route_info.routes.clone(),
                     active: cx.props.route_info.active.clone(),

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -384,6 +384,9 @@ pub fn app_bootstrap(cx: Scope) -> Element {
         minimal_view: desktop.inner_size().width < 300, // todo: why is it that on Linux, checking if desktop.inner_size().width < 600 is true?
     };
     state.ui.metadata = window_meta;
+    if state.ui.is_minimal_view() {
+        state.ui.sidebar_hidden = true;
+    }
 
     use_shared_state_provider(cx, || state);
 

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -715,6 +715,7 @@ fn get_titlebar(cx: Scope) -> Element {
                             minimal_view: true,
                             ..meta
                         }));
+                        state.write().mutate(Action::SidebarHidden(true));
                     }
                 },
                 Button {
@@ -729,6 +730,7 @@ fn get_titlebar(cx: Scope) -> Element {
                             minimal_view: false,
                             ..meta
                         }));
+                        state.write().mutate(Action::SidebarHidden(false));
                     }
                 },
                 Button {
@@ -743,6 +745,7 @@ fn get_titlebar(cx: Scope) -> Element {
                             minimal_view: false,
                             ..meta
                         }));
+                        state.write().mutate(Action::SidebarHidden(false));
                     }
                 },
                 Button {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- removes a buggy hook used to hide the sidebar in friends. it was called `first_render`. instead, default the sidebar to be hidden when using a minimal_view and use separate functions for regular and minimal views: `FriendsLayout` and `MinimalFriendsLayout`. 
- we may want to adopt this change in the other layouts, which still use the `first_render` hook. 

### Which issue(s) this PR fixes 🔨

- Resolve #217 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

