### PR TITLE
fix(serialize): fix custom serializers for state

### DIFF
--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -360,6 +360,11 @@ pub fn app_bootstrap(cx: Scope) -> Element {
     log::trace!("rendering app_bootstrap");
     let mut state = State::load();
 
+    if STATIC_ARGS.use_mock {
+        assert!(state.friends.initialized);
+        assert!(state.chats.initialized);
+    }
+
     // set the window to the normal size.
     // todo: perhaps when the user resizes the window, store that in State, and load that here
     let desktop = use_window(cx);

--- a/ui/src/state/chats.rs
+++ b/ui/src/state/chats.rs
@@ -38,10 +38,10 @@ pub struct Chat {
     pub typing_indicator: HashMap<DID, Instant>,
 }
 
-// TODO: Properly wrap data which is expected to persist remotely in options, so we can know if we're still figuring out what exists "remotely", i.e. loading.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+// warning: Chats implements Serialize
+#[derive(Clone, Debug, Default, Deserialize)]
 pub struct Chats {
-    #[serde(skip)]
+    #[serde(default)]
     pub initialized: bool,
     // All active chats from warp.
     #[serde(default)]
@@ -70,6 +70,29 @@ impl Chats {
         for (k, v) in other.drain() {
             self.all.insert(k, v);
         }
+    }
+}
+
+impl Serialize for Chats {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("Chats", 6)?;
+
+        if STATIC_ARGS.use_mock {
+            state.serialize_field("initialized", &self.initialized)?;
+        } else {
+            state.skip_field("initialized")?;
+        }
+
+        state.serialize_field("all", &self.all)?;
+        state.serialize_field("active", &self.active)?;
+        state.skip_field("active_media")?;
+        state.serialize_field("in_sidebar", &self.in_sidebar)?;
+        state.serialize_field("favorites", &self.favorites)?;
+
+        state.end()
     }
 }
 

--- a/ui/src/state/chats.rs
+++ b/ui/src/state/chats.rs
@@ -65,14 +65,6 @@ pub enum Direction {
     Outgoing,
 }
 
-impl Chats {
-    pub fn join(&mut self, mut other: HashMap<Uuid, Chat>) {
-        for (k, v) in other.drain() {
-            self.all.insert(k, v);
-        }
-    }
-}
-
 impl Serialize for Chats {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/ui/src/state/friends.rs
+++ b/ui/src/state/friends.rs
@@ -24,26 +24,6 @@ pub struct Friends {
     pub outgoing_requests: HashSet<Identity>,
 }
 
-impl Friends {
-    pub fn join(&mut self, mut other: Friends) {
-        for (k, v) in other.all.drain() {
-            self.all.insert(k, v);
-        }
-
-        for v in other.blocked.drain() {
-            self.blocked.insert(v);
-        }
-
-        for v in other.incoming_requests.drain() {
-            self.incoming_requests.insert(v);
-        }
-
-        for v in other.outgoing_requests.drain() {
-            self.outgoing_requests.insert(v);
-        }
-    }
-}
-
 // don't skip friends data when using mock data
 impl Serialize for Friends {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/ui/src/state/friends.rs
+++ b/ui/src/state/friends.rs
@@ -51,13 +51,14 @@ impl Serialize for Friends {
         S: Serializer,
     {
         let mut state = serializer.serialize_struct("Friends", 5)?;
-        state.skip_field("initialized")?;
         if STATIC_ARGS.use_mock {
+            state.serialize_field("initialized", &self.initialized)?;
             state.serialize_field("all", &self.all)?;
             state.serialize_field("blocked", &self.blocked)?;
             state.serialize_field("incoming_requests", &self.incoming_requests)?;
             state.serialize_field("outgoing_requests", &self.outgoing_requests)?;
         } else {
+            state.skip_field("initialized")?;
             state.skip_field("all")?;
             state.skip_field("blocked")?;
             state.skip_field("incoming_requests")?;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- if you log in using mock data (for the first time), close the program, then re-open it, State::Friends and State::Chats will be uninitialized, even though for mock data they are always supposed to be initialized. 
- the problem is the `Serialize` implementation was skipping a field that shouldn't have been skipped when mock data is enabled. 
- This PR fixes that, and adds an assertion in `main.rs` to check for this.  

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
ideally there would be unit tests for this, but it seems overly complicated to try to give `STATIC_ARGS` custom values during unit tests. i'd be open to making unit tests for the non-mock scenario though. 
