### PR TITLE
fix(misc): Increase file desc limit

### DIFF
--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -43,6 +43,8 @@ wry = { version = "0.23.4" }
 derive_more = "0.99"
 colored = "2.0.0"
 
+fdlimit = "0.2"
+
 notify-rust = { version = "4.6.0", default-features = false, features = ["d"] }
 once_cell = "1.13"
 

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -191,6 +191,10 @@ fn copy_assets() {
 }
 
 fn main() {
+    // Attempts to increase the file desc limit on unix-like systems
+    // Note: Will be changed out in the future 
+    if fdlimit::raise_fd_limit().is_none() {}
+
     // configure logging
     let args = Args::parse();
     let max_log_level = if let Some(profile) = args.profile {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Fixes the "too many file" error that users might see on unix-like systems (eg linux, mac, etc). 

### Which issue(s) this PR fixes 🔨

- N/A

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
The error is due to the soft file descriptor limit being hit. Some systems like mac may have low soft limits (of around 256 or 512) while others may have it a bit higher. On linux, it varies on the distribution but the avg soft limit is around 2048.  With network applications, they will open a file descriptor for connections and sometimes may hold that open, which is why it may show that error. Some applications get around this by increasing the soft limits for that process only, which is what we are doing here in this case. 