### PR TITLE
chore(unlock): let unlock screen focus on pin

### DIFF
--- a/ui/src/layouts/unlock.rs
+++ b/ui/src/layouts/unlock.rs
@@ -119,6 +119,8 @@ pub fn UnlockLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -
                 }
             },
             Input {
+                id: "unlock-input".to_owned(),
+                focus: true,
                 is_password: true,
                 icon: Icon::Key,
                 aria_label: "pin-input".into(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- has the unlock screen focus on the pin so you don't have to click on it all the time

