### PR TITLE
chore(themes): fix themes dropdown for windows and sorts items alphabetically 

### DIFF
--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -65,6 +65,7 @@ mod window_manager;
 #[derive(Debug)]
 pub struct StaticArgs {
     pub uplink_path: PathBuf,
+    pub themes_path: PathBuf,
     pub cache_path: PathBuf,
     pub mock_cache_path: PathBuf,
     pub config_path: PathBuf,
@@ -84,6 +85,7 @@ pub static STATIC_ARGS: Lazy<StaticArgs> = Lazy::new(|| {
     };
     StaticArgs {
         uplink_path: uplink_path.clone(),
+        themes_path: uplink_path.join("themes"),
         cache_path: uplink_path.join("state.json"),
         mock_cache_path: uplink_path.join("mock-state.json"),
         config_path: uplink_path.join("Config.json"),

--- a/ui/src/utils/mod.rs
+++ b/ui/src/utils/mod.rs
@@ -23,18 +23,15 @@ pub fn get_available_themes() -> Vec<Theme> {
         .filter_map(|file| file.ok())
     {
         if file.metadata().unwrap().is_file() {
-            let theme = file.path().display().to_string();
-
-            let mut theme_str = theme.replace("\\", "/");
-            theme_str = theme_str.split('/').last().unwrap().to_string();
-
-            let pretty_theme_str = &theme_str.replace(".scss", "");
+            let theme_path = file.path().display().to_string();
+            let theme_name_str = file.path().iter().last().unwrap();
+            let pretty_theme_str = &theme_name_str.to_string_lossy().replace(".scss", "");
             let pretty_theme_str = titlecase(pretty_theme_str);
 
-            let styles = fs::read_to_string(&theme).unwrap_or_default();
+            let styles = fs::read_to_string(&theme_path).unwrap_or_default();
 
             let theme = Theme {
-                filename: theme_str.to_owned(),
+                filename: theme_path.to_owned(),
                 name: pretty_theme_str.to_owned(),
                 styles,
             };

--- a/ui/src/utils/mod.rs
+++ b/ui/src/utils/mod.rs
@@ -3,7 +3,10 @@ use std::fs;
 use titlecase::titlecase;
 use walkdir::WalkDir;
 
-use crate::state::{self, Theme};
+use crate::{
+    state::{self, Theme},
+    STATIC_ARGS,
+};
 use kit::User as UserInfo;
 
 pub mod format_timestamp;
@@ -13,10 +16,7 @@ pub mod sounds;
 pub fn get_available_themes() -> Vec<Theme> {
     let mut themes = vec![];
 
-    let theme_path = dirs::home_dir()
-        .unwrap_or_default()
-        .join(".uplink/")
-        .join("themes");
+    let theme_path = STATIC_ARGS.themes_path.clone();
 
     for file in WalkDir::new(theme_path)
         .into_iter()
@@ -25,7 +25,9 @@ pub fn get_available_themes() -> Vec<Theme> {
         if file.metadata().unwrap().is_file() {
             let theme = file.path().display().to_string();
 
-            let theme_str = theme.split('/').last().unwrap();
+            let mut theme_str = theme.replace("\\", "/");
+            theme_str = theme_str.split('/').last().unwrap().to_string();
+
             let pretty_theme_str = &theme_str.replace(".scss", "");
             let pretty_theme_str = titlecase(pretty_theme_str);
 
@@ -40,6 +42,7 @@ pub fn get_available_themes() -> Vec<Theme> {
             themes.push(theme);
         }
     }
+    themes.sort_by_key(|theme| theme.name.clone());
 
     themes
 }

--- a/ui/src/utils/mod.rs
+++ b/ui/src/utils/mod.rs
@@ -111,4 +111,9 @@ mod test {
         let r = get_pretty_name("pretty/name1.scss");
         assert_eq!(r, String::from("name1"));
     }
-}
+
+    #[test]
+    fn test_get_pretty_name_windows() {
+        let r = get_pretty_name("c:\\pretty\\name2.scss");
+        assert_eq!(r, String::from("name2"));
+    }}

--- a/ui/src/utils/mod.rs
+++ b/ui/src/utils/mod.rs
@@ -1,5 +1,5 @@
 use kit::components::indicator::{self, Status};
-use std::fs;
+use std::{fs, path::Path};
 use titlecase::titlecase;
 use walkdir::WalkDir;
 
@@ -42,6 +42,15 @@ pub fn get_available_themes() -> Vec<Theme> {
     themes.sort_by_key(|theme| theme.name.clone());
 
     themes
+}
+
+fn get_pretty_name<S: AsRef<str>>(name: S) -> String {
+    let path = Path::new(name.as_ref());
+    let last = path
+        .file_name()
+        .and_then(|p| Path::new(p).file_stem())
+        .unwrap_or_default();
+    last.to_string_lossy().into()
 }
 
 // converts from Warp IdentityStatus to ui_kit Status
@@ -90,5 +99,16 @@ pub fn build_user_from_identity(identity: state::Identity) -> UserInfo {
         status: convert_status(&identity.identity_status()),
         username: identity.username(),
         photo: identity.graphics().profile_picture(),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_get_pretty_name1() {
+        let r = get_pretty_name("pretty/name1.scss");
+        assert_eq!(r, String::from("name1"));
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- fixes the theme dropdown for windows and sorts items alphabetically 
1) the path was pulling from .uplink, the default, instead of using the static arg
2) the name of the theme was being created by splitting the path on / which doesn't work right on windows

### Which issue(s) this PR fixes 🔨

- Resolve #261

### Special notes for reviewers 🗒️

Please make sure the path fix and theme dropdown works correctly on Mac!
