### PR TITLE
chore(profile): fix developer button to open the right path

### DIFF
--- a/ui/src/components/settings/sub_pages/developer.rs
+++ b/ui/src/components/settings/sub_pages/developer.rs
@@ -13,6 +13,7 @@ use crate::{
     state::{notifications::NotificaitonKind, Action, State},
     utils::{notifications::push_notification, sounds::Sounds},
     window_manager::{WindowManagerCmd, WindowManagerCmdTx},
+    STATIC_ARGS,
 };
 
 #[allow(non_snake_case)]
@@ -83,7 +84,7 @@ pub fn DeveloperSettings(cx: Scope) -> Element {
                     onpress: |_| {
                         let cache_path = dirs::home_dir()
                             .unwrap_or_default()
-                            .join(".uplink/")
+                            .join(STATIC_ARGS.uplink_path.clone())
                             .into_os_string()
                             .into_string()
                             .unwrap_or_default();
@@ -91,6 +92,7 @@ pub fn DeveloperSettings(cx: Scope) -> Element {
                     }
                 }
             },
+
             SettingSection {
                 section_label: get_local_text("settings-developer.compress-download-cache"),
                 section_description: get_local_text("settings-developer.compress-download-cache-description"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- fixes the issue where the default profile path was used instead of the one you pass in

### Which issue(s) this PR fixes 🔨

- Resolve #269

