### PR TITLE
fix(FolderLocations): don't hardcode paths for folders

### DIFF
--- a/ui/src/components/settings/sub_pages/developer.rs
+++ b/ui/src/components/settings/sub_pages/developer.rs
@@ -82,13 +82,7 @@ pub fn DeveloperSettings(cx: Scope) -> Element {
                     appearance: Appearance::Secondary,
                     icon: Icon::FolderOpen,
                     onpress: |_| {
-                        let cache_path = dirs::home_dir()
-                            .unwrap_or_default()
-                            .join(STATIC_ARGS.uplink_path.clone())
-                            .into_os_string()
-                            .into_string()
-                            .unwrap_or_default();
-                        let _ = opener::open(cache_path);
+                        let _ = opener::open(&STATIC_ARGS.uplink_path);
                     }
                 }
             },

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -70,6 +70,7 @@ pub struct StaticArgs {
     pub config_path: PathBuf,
     pub warp_path: PathBuf,
     pub logger_path: PathBuf,
+    pub themes_path: PathBuf,
     // seconds
     pub typing_indicator_refresh: u64,
     // seconds
@@ -89,6 +90,7 @@ pub static STATIC_ARGS: Lazy<StaticArgs> = Lazy::new(|| {
         config_path: uplink_path.join("Config.json"),
         warp_path: uplink_path.join("warp"),
         logger_path: uplink_path.join("debug.log"),
+        themes_path: uplink_path.join("themes"),
         typing_indicator_refresh: 5,
         typing_indicator_timeout: 6,
         use_mock: args.with_mock,

--- a/ui/src/utils/mod.rs
+++ b/ui/src/utils/mod.rs
@@ -3,7 +3,10 @@ use std::fs;
 use titlecase::titlecase;
 use walkdir::WalkDir;
 
-use crate::state::{self, Theme};
+use crate::{
+    state::{self, Theme},
+    STATIC_ARGS,
+};
 use kit::User as UserInfo;
 
 pub mod format_timestamp;
@@ -13,12 +16,7 @@ pub mod sounds;
 pub fn get_available_themes() -> Vec<Theme> {
     let mut themes = vec![];
 
-    let theme_path = dirs::home_dir()
-        .unwrap_or_default()
-        .join(".uplink/")
-        .join("themes");
-
-    for file in WalkDir::new(theme_path)
+    for file in WalkDir::new(&STATIC_ARGS.themes_path)
         .into_iter()
         .filter_map(|file| file.ok())
     {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- uses STATIC_ARGS for this so that the `--path` option works correctly.  noticed this wasn't being done for themes and cache. 
- 
### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

