### PR TITLE
chore(uplink): add dont merge label when opening a PR

### DIFF
--- a/.github/workflows/add-label.yml
+++ b/.github/workflows/add-label.yml
@@ -13,5 +13,6 @@ jobs:
         with:
           labels: |
             Missing dev review
+            Don't merge yet
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What this PR does 📖

- Updating add-label.yml GH workflow to add the "Don't merge yet" label when opening a PR

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

