### PR TITLE
fix(tooltip): videocall tooltip clipped offscreen

### DIFF
--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -209,16 +209,16 @@ fn get_controls(cx: Scope<ComposeProps>) -> Element {
                 }
             }
         },
-        (!state.read().ui.is_minimal_view()).then(|| rsx!(Button {
+        Button {
             icon: Icon::VideoCamera,
             disabled: data.is_none(),
             aria_label: "Videocall".into(),
             appearance: Appearance::Secondary,
             tooltip: cx.render(rsx!(Tooltip {
-                arrow_position: ArrowPosition::Top,
+                arrow_position: ArrowPosition::TopRight,
                 text: get_local_text("uplink.video-call"),
             })),
-        },))
+        },
     ))
 }
 

--- a/ui/src/components/chat/style.scss
+++ b/ui/src/components/chat/style.scss
@@ -105,7 +105,9 @@
         animation: none;
     }
 }
-
+.tooltip-arrow-top-right {
+    margin-right: 50px;
+}
 #compose {
     .typing-indicator {
         width: 100%;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

The tooltip for the video icon is being rendered offscreen

### Which issue(s) this PR fixes 🔨

- Resolve #
- #151 
also fixes #139 
### Special notes for reviewers 🗒️
