### PR TITLE
fix(hovers): fix hover jitter on button

### DIFF
--- a/kit/src/style.scss
+++ b/kit/src/style.scss
@@ -18,10 +18,16 @@
 *::after {
     box-sizing: border-box;
 }
-
+p, label {
+    cursor: default;
+}
 /* Reapply the pointer cursor for anchor tags */
-a, button {
+a {
     cursor: revert;
+}
+
+button {
+	cursor: pointer;
 }
 
 /* Remove list styles (bullets/numbers) */


### PR DESCRIPTION
### What this PR does 📖

When we hover our cursor over text within the app, the cursor changes from an arrow to the text cursor. Instead it should remain an arrow no matter what you hover over

### Which issue(s) this PR fixes 🔨

- Resolve #

#191 

### Special notes for reviewers 🗒️

I also fixed a conflicting pointer hover issue on buttons

