### PR TITLE
fix(timestamp): fix "time ago" calculation in User element

### DIFF
--- a/kit/Cargo.toml
+++ b/kit/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+chrono = "0.4.23"
 dioxus =  { git = "https://github.com/DioxusLabs/dioxus", rev="d521da1991719760e271457dfe4f9ddf281afbb3" }
 dioxus-core =  { git = "https://github.com/DioxusLabs/dioxus", rev="d521da1991719760e271457dfe4f9ddf281afbb3" }
 dioxus-desktop = { git = "https://github.com/DioxusLabs/dioxus", rev="d521da1991719760e271457dfe4f9ddf281afbb3", features = ["transparent"] }

--- a/kit/src/components/user/mod.rs
+++ b/kit/src/components/user/mod.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use chrono::{DateTime, Utc};
 
 use dioxus::{
     core::Event,
@@ -16,7 +16,7 @@ pub struct Props<'a> {
     username: String,
     user_image: Element<'a>,
     subtext: String,
-    timestamp: Option<u64>,
+    timestamp: Option<DateTime<Utc>>,
     #[props(optional)]
     loading: Option<bool>,
     #[props(optional)]
@@ -29,11 +29,15 @@ pub struct Props<'a> {
 
 pub fn get_time_ago(cx: &Scope<Props>) -> String {
     let f = timeago::Formatter::new();
+    let current_time = Utc::now();
+    let c: chrono::Duration =
+        current_time - cx.props.timestamp.unwrap_or_else(|| current_time.clone());
+    let duration: std::time::Duration = match c.to_std() {
+        Ok(d) => d,
+        Err(_e) => std::time::Duration::ZERO,
+    };
 
-    match cx.props.timestamp {
-        Some(d) => f.convert(Duration::from_millis(d)),
-        None => "".into(),
-    }
+    f.convert(duration)
 }
 
 /// Generates the optional badge for the user.

--- a/ui/src/components/chat/sidebar.rs
+++ b/ui/src/components/chat/sidebar.rs
@@ -192,7 +192,7 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
                     };
 
                     let val = unwrapped_message.value();
-                    let timestamp = unwrapped_message.date().timestamp_millis() as u64;
+                    let datetime = unwrapped_message.date();
 
                     let badge = if chat.unreads > 0 {
                         chat.unreads.to_string()
@@ -242,7 +242,7 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
                             User {
                                 username: participants_name,
                                 subtext: val.join("\n"),
-                                timestamp: timestamp,
+                                timestamp: datetime,
                                 active: is_active,
                                 user_image: cx.render(rsx!(
                                     if participants.len() <= 2 {rsx! (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- in `kit/src/components/user/mod.rs` you can add a `println!` statement to see `time_ago` is correct. 
- badges don't work yet so this can't be tested visually 
- also we may want to change the UI design so that "time ago" is displayed regardless of badge. 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

