### PR TITLE
fix(config): fix default values and saving 

### DIFF
--- a/ui/src/components/chat/sidebar.rs
+++ b/ui/src/components/chat/sidebar.rs
@@ -90,7 +90,7 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
                     routes: cx.props.route_info.routes.clone(),
                     active: cx.props.route_info.active.clone(),
                     onnavigate: move |r| {
-                        if state.read().configuration.config.audiovideo.interface_sounds {
+                        if state.read().configuration.audiovideo.interface_sounds {
                             crate::utils::sounds::Play(crate::utils::sounds::Sounds::Interaction);
                         }
                         use_router(cx).replace_route(r, None, None);

--- a/ui/src/components/settings/sidebar.rs
+++ b/ui/src/components/settings/sidebar.rs
@@ -146,7 +146,7 @@ pub fn Sidebar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     routes: cx.props.route_info.routes.clone(),
                     active: cx.props.route_info.active.clone(),
                     onnavigate: move |route| {
-                        if state.read().configuration.config.audiovideo.interface_sounds {
+                        if state.read().configuration.audiovideo.interface_sounds {
                             crate::utils::sounds::Play(crate::utils::sounds::Sounds::Interaction);
                         }
                         use_router(cx).replace_route(route, None, None);
@@ -158,7 +158,7 @@ pub fn Sidebar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 active: active_route,
                 bubble: true,
                 onnavigate: move |route| {
-                    if state.read().configuration.config.audiovideo.interface_sounds {
+                    if state.read().configuration.audiovideo.interface_sounds {
                         crate::utils::sounds::Play(crate::utils::sounds::Sounds::Interaction);
                     }
                     emit(&cx, Page::from_str(route).unwrap());

--- a/ui/src/components/settings/sub_pages/audio.rs
+++ b/ui/src/components/settings/sub_pages/audio.rs
@@ -3,7 +3,10 @@ use kit::elements::switch::Switch;
 use shared::language::get_local_text;
 use warp::logging::tracing::log;
 
-use crate::{components::settings::SettingSection, state::State};
+use crate::{
+    components::settings::SettingSection,
+    state::{action::ConfigAction, Action, State},
+};
 
 #[allow(non_snake_case)]
 pub fn AudioSettings(cx: Scope) -> Element {
@@ -18,12 +21,12 @@ pub fn AudioSettings(cx: Scope) -> Element {
                 section_label: get_local_text("settings-audio.interface-sounds"),
                 section_description: get_local_text("settings-audio.interface-sounds-description"),
                 Switch {
-                    active: state.read().configuration.config.audiovideo.interface_sounds,
+                    active: state.read().configuration.audiovideo.interface_sounds,
                     onflipped: move |e| {
-                        if state.read().configuration.config.audiovideo.interface_sounds {
+                        if state.read().configuration.audiovideo.interface_sounds {
                             crate::utils::sounds::Play(crate::utils::sounds::Sounds::Flip);
                         }
-                        state.write().configuration.set_interface_sounds(e);
+                        state.write().mutate(Action::Config(ConfigAction::InterfaceSoundsEnabled(e)));
                     }
                 }
             },
@@ -31,12 +34,12 @@ pub fn AudioSettings(cx: Scope) -> Element {
                 section_label: get_local_text("settings-audio.media-sounds"),
                 section_description: get_local_text("settings-audio.media-sounds-description"),
                 Switch {
-                    active: state.read().configuration.config.audiovideo.media_sounds,
+                    active: state.read().configuration.audiovideo.media_sounds,
                     onflipped: move |e| {
-                        if state.read().configuration.config.audiovideo.interface_sounds {
+                        if state.read().configuration.audiovideo.interface_sounds {
                             crate::utils::sounds::Play(crate::utils::sounds::Sounds::Flip);
                         }
-                        state.write().configuration.set_media_sounds(e);
+                        state.write().mutate(Action::Config(ConfigAction::MediaSoundsEnabled(e)));
                     }
                 }
             },
@@ -44,12 +47,12 @@ pub fn AudioSettings(cx: Scope) -> Element {
                 section_label: get_local_text("settings-audio.message-sounds"),
                 section_description: get_local_text("settings-audio.message-sounds-description"),
                 Switch {
-                    active: state.read().configuration.config.audiovideo.message_sounds,
+                    active: state.read().configuration.audiovideo.message_sounds,
                     onflipped: move |e| {
-                        if state.read().configuration.config.audiovideo.interface_sounds {
+                        if state.read().configuration.audiovideo.interface_sounds {
                             crate::utils::sounds::Play(crate::utils::sounds::Sounds::Flip);
                         }
-                        state.write().configuration.set_message_sounds(e);
+                        state.write().mutate(Action::Config(ConfigAction::MessageSoundsEnabled(e)));
                     }
                 }
             },

--- a/ui/src/components/settings/sub_pages/audio.rs
+++ b/ui/src/components/settings/sub_pages/audio.rs
@@ -26,7 +26,7 @@ pub fn AudioSettings(cx: Scope) -> Element {
                         if state.read().configuration.audiovideo.interface_sounds {
                             crate::utils::sounds::Play(crate::utils::sounds::Sounds::Flip);
                         }
-                        state.write().mutate(Action::Config(ConfigAction::InterfaceSoundsEnabled(e)));
+                        state.write().mutate(Action::Config(ConfigAction::SetInterfaceSoundsEnabled(e)));
                     }
                 }
             },
@@ -39,7 +39,7 @@ pub fn AudioSettings(cx: Scope) -> Element {
                         if state.read().configuration.audiovideo.interface_sounds {
                             crate::utils::sounds::Play(crate::utils::sounds::Sounds::Flip);
                         }
-                        state.write().mutate(Action::Config(ConfigAction::MediaSoundsEnabled(e)));
+                        state.write().mutate(Action::Config(ConfigAction::SetMediaSoundsEnabled(e)));
                     }
                 }
             },
@@ -52,7 +52,7 @@ pub fn AudioSettings(cx: Scope) -> Element {
                         if state.read().configuration.audiovideo.interface_sounds {
                             crate::utils::sounds::Play(crate::utils::sounds::Sounds::Flip);
                         }
-                        state.write().mutate(Action::Config(ConfigAction::MessageSoundsEnabled(e)));
+                        state.write().mutate(Action::Config(ConfigAction::SetMessageSoundsEnabled(e)));
                     }
                 }
             },

--- a/ui/src/components/settings/sub_pages/developer.rs
+++ b/ui/src/components/settings/sub_pages/developer.rs
@@ -35,7 +35,7 @@ pub fn DeveloperSettings(cx: Scope) -> Element {
                             crate::utils::sounds::Play(crate::utils::sounds::Sounds::Flip);
                         }
 
-                        state.write().mutate(Action::Config(ConfigAction::DevModeEnabled(value)));
+                        state.write().mutate(Action::Config(ConfigAction::SetDevModeEnabled(value)));
                     },
                 }
             },

--- a/ui/src/components/settings/sub_pages/developer.rs
+++ b/ui/src/components/settings/sub_pages/developer.rs
@@ -10,7 +10,7 @@ use warp::logging::tracing::log;
 use crate::{
     components::settings::SettingSection,
     logger,
-    state::{notifications::NotificationKind, Action, State},
+    state::{action::ConfigAction, notifications::NotificationKind, Action, State},
     utils::{notifications::push_notification, sounds::Sounds},
     window_manager::{WindowManagerCmd, WindowManagerCmdTx},
     STATIC_ARGS,
@@ -29,13 +29,13 @@ pub fn DeveloperSettings(cx: Scope) -> Element {
                 section_label: get_local_text("settings-developer.developer-mode"),
                 section_description: get_local_text("settings-developer.developer-mode-description"),
                 Switch {
-                    active: state.read().configuration.config.developer.developer_mode,
+                    active: state.read().configuration.developer.developer_mode,
                     onflipped: move |value| {
-                        if state.read().configuration.config.audiovideo.interface_sounds {
+                        if state.read().configuration.audiovideo.interface_sounds {
                             crate::utils::sounds::Play(crate::utils::sounds::Sounds::Flip);
                         }
 
-                        state.write().configuration.set_developer_mode(value);
+                        state.write().mutate(Action::Config(ConfigAction::DevModeEnabled(value)));
                     },
                 }
             },
@@ -118,7 +118,7 @@ pub fn DeveloperSettings(cx: Scope) -> Element {
                 Switch {
                     active: logger::get_save_to_file(),
                     onflipped: move |value| {
-                        if state.read().configuration.config.audiovideo.interface_sounds {
+                        if state.read().configuration.audiovideo.interface_sounds {
                             crate::utils::sounds::Play(crate::utils::sounds::Sounds::Flip);
                         }
                         logger::set_save_to_file(value);

--- a/ui/src/components/settings/sub_pages/general.rs
+++ b/ui/src/components/settings/sub_pages/general.rs
@@ -30,7 +30,7 @@ pub fn GeneralSettings(cx: Scope) -> Element {
                 Switch {
                     active: state.read().configuration.general.enable_overlay,
                     onflipped: move |e| {
-                        state.write().mutate(Action::Config(ConfigAction::OverlayEnabled(e)));
+                        state.write().mutate(Action::Config(ConfigAction::SetOverlayEnabled(e)));
                         state.write().mutate(Action::SetOverlay(e));
                     }
                 }

--- a/ui/src/components/settings/sub_pages/general.rs
+++ b/ui/src/components/settings/sub_pages/general.rs
@@ -8,7 +8,7 @@ use warp::logging::tracing::log;
 
 use crate::{
     components::settings::SettingSection,
-    state::{Action, State},
+    state::{action::ConfigAction, Action, State},
     utils::get_available_themes,
 };
 
@@ -28,9 +28,9 @@ pub fn GeneralSettings(cx: Scope) -> Element {
                 section_label: get_local_text("settings-general.overlay"),
                 section_description: get_local_text("settings-general.overlay-description"),
                 Switch {
-                    active: state.read().configuration.config.general.enable_overlay,
+                    active: state.read().configuration.general.enable_overlay,
                     onflipped: move |e| {
-                        state.write().configuration.set_overlay(e);
+                        state.write().mutate(Action::Config(ConfigAction::OverlayEnabled(e)));
                         state.write().mutate(Action::SetOverlay(e));
                     }
                 }

--- a/ui/src/components/settings/sub_pages/notifications.rs
+++ b/ui/src/components/settings/sub_pages/notifications.rs
@@ -5,7 +5,10 @@ use kit::{
 };
 use shared::language::get_local_text;
 
-use crate::{components::settings::SettingSection, state::State};
+use crate::{
+    components::settings::SettingSection,
+    state::{action::ConfigAction, Action, State},
+};
 
 #[allow(non_snake_case)]
 pub fn NotificationSettings(cx: Scope) -> Element {
@@ -30,28 +33,28 @@ pub fn NotificationSettings(cx: Scope) -> Element {
                 section_label: get_local_text("settings-notifications.enabled"),
                 section_description: get_local_text("settings-notifications.enabled-description"),
                 Switch {
-                    active: state.read().configuration.config.notifications.enabled,
+                    active: state.read().configuration.notifications.enabled,
                     onflipped: move |e| {
-                        if state.read().configuration.config.audiovideo.interface_sounds {
+                        if state.read().configuration.audiovideo.interface_sounds {
                             crate::utils::sounds::Play(crate::utils::sounds::Sounds::Flip);
                         }
-                        state.write().configuration.set_notifications_enabled(e);
+                        state.write().mutate(Action::Config(ConfigAction::NotificationsEnabled(e)));
                     }
                 }
             },
             div {
-                class: format_args!("{}", if state.read().configuration.config.notifications.enabled { "enabled" } else { "disabled" }),
+                class: format_args!("{}", if state.read().configuration.notifications.enabled { "enabled" } else { "disabled" }),
                 SettingSection {
                     section_label: get_local_text("friends"),
                     section_description: get_local_text("settings-notifications.friends-description"),
                     Switch {
-                        active: state.read().configuration.config.notifications.enabled && state.read().configuration.config.notifications.friends_notifications,
-                        disabled: !state.read().configuration.config.notifications.enabled,
+                        active: state.read().configuration.notifications.enabled && state.read().configuration.notifications.friends_notifications,
+                        disabled: !state.read().configuration.notifications.enabled,
                         onflipped: move |e| {
-                            if state.read().configuration.config.audiovideo.interface_sounds {
+                            if state.read().configuration.audiovideo.interface_sounds {
                                 crate::utils::sounds::Play(crate::utils::sounds::Sounds::Flip);
                             }
-                            state.write().configuration.set_friends_notifications(e);
+                            state.write().mutate(Action::Config(ConfigAction::FriendsNotificationsEnabled(e)));
                         }
                     }
                 },
@@ -59,13 +62,13 @@ pub fn NotificationSettings(cx: Scope) -> Element {
                     section_label: get_local_text("messages"),
                     section_description: get_local_text("settings-notifications.messages-description"),
                     Switch {
-                        active: state.read().configuration.config.notifications.enabled && state.read().configuration.config.notifications.messages_notifications,
-                        disabled: !state.read().configuration.config.notifications.enabled,
+                        active: state.read().configuration.notifications.enabled && state.read().configuration.notifications.messages_notifications,
+                        disabled: !state.read().configuration.notifications.enabled,
                         onflipped: move |e| {
-                            if state.read().configuration.config.audiovideo.interface_sounds {
+                            if state.read().configuration.audiovideo.interface_sounds {
                                 crate::utils::sounds::Play(crate::utils::sounds::Sounds::Flip);
                             }
-                            state.write().configuration.set_messages_notifications(e);
+                            state.write().mutate(Action::Config(ConfigAction::MessagesNotificationsEnabled(e)));
                         }
                     }
                 },
@@ -73,13 +76,13 @@ pub fn NotificationSettings(cx: Scope) -> Element {
                     section_label: get_local_text("settings"),
                     section_description: get_local_text("settings-notifications.settings-description"),
                     Switch {
-                        active: state.read().configuration.config.notifications.enabled && state.read().configuration.config.notifications.settings_notifications,
-                        disabled: !state.read().configuration.config.notifications.enabled,
+                        active: state.read().configuration.notifications.enabled && state.read().configuration.notifications.settings_notifications,
+                        disabled: !state.read().configuration.notifications.enabled,
                         onflipped: move |e| {
-                            if state.read().configuration.config.audiovideo.interface_sounds {
+                            if state.read().configuration.audiovideo.interface_sounds {
                                 crate::utils::sounds::Play(crate::utils::sounds::Sounds::Flip);
                             }
-                            state.write().configuration.set_settings_notifications(e);
+                            state.write().mutate(Action::Config(ConfigAction::SettingsNotificationsEnabled(e)));
                         }
                     }
                 },

--- a/ui/src/components/settings/sub_pages/notifications.rs
+++ b/ui/src/components/settings/sub_pages/notifications.rs
@@ -38,7 +38,7 @@ pub fn NotificationSettings(cx: Scope) -> Element {
                         if state.read().configuration.audiovideo.interface_sounds {
                             crate::utils::sounds::Play(crate::utils::sounds::Sounds::Flip);
                         }
-                        state.write().mutate(Action::Config(ConfigAction::NotificationsEnabled(e)));
+                        state.write().mutate(Action::Config(ConfigAction::SetNotificationsEnabled(e)));
                     }
                 }
             },
@@ -54,7 +54,7 @@ pub fn NotificationSettings(cx: Scope) -> Element {
                             if state.read().configuration.audiovideo.interface_sounds {
                                 crate::utils::sounds::Play(crate::utils::sounds::Sounds::Flip);
                             }
-                            state.write().mutate(Action::Config(ConfigAction::FriendsNotificationsEnabled(e)));
+                            state.write().mutate(Action::Config(ConfigAction::SetFriendsNotificationsEnabled(e)));
                         }
                     }
                 },
@@ -68,7 +68,7 @@ pub fn NotificationSettings(cx: Scope) -> Element {
                             if state.read().configuration.audiovideo.interface_sounds {
                                 crate::utils::sounds::Play(crate::utils::sounds::Sounds::Flip);
                             }
-                            state.write().mutate(Action::Config(ConfigAction::MessagesNotificationsEnabled(e)));
+                            state.write().mutate(Action::Config(ConfigAction::SetMessagesNotificationsEnabled(e)));
                         }
                     }
                 },
@@ -82,7 +82,7 @@ pub fn NotificationSettings(cx: Scope) -> Element {
                             if state.read().configuration.audiovideo.interface_sounds {
                                 crate::utils::sounds::Play(crate::utils::sounds::Sounds::Flip);
                             }
-                            state.write().mutate(Action::Config(ConfigAction::SettingsNotificationsEnabled(e)));
+                            state.write().mutate(Action::Config(ConfigAction::SetSettingsNotificationsEnabled(e)));
                         }
                     }
                 },

--- a/ui/src/config.rs
+++ b/ui/src/config.rs
@@ -1,9 +1,5 @@
 use serde::{Deserialize, Serialize};
 
-use std::fs;
-
-use crate::STATIC_ARGS;
-
 /// A struct that represents the configuration of the application.
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 pub struct Configuration {
@@ -95,51 +91,4 @@ pub struct Notifications {
     // By default we leave this one off.
     #[serde(default)]
     pub settings_notifications: bool,
-}
-
-impl Configuration {
-    pub fn new() -> Self {
-        // Create a default configuration here
-        // For example:
-        Self {
-            developer: Developer {
-                ..Developer::default()
-            },
-            ..Self::default()
-        }
-    }
-
-    pub fn load() -> Self {
-        // Load the config from the specified path
-        match fs::read_to_string(&STATIC_ARGS.config_path) {
-            Ok(contents) => {
-                // Parse the config from the file contents using serde
-                match serde_json::from_str(&contents) {
-                    Ok(config) => config,
-                    Err(_) => Self::new(),
-                }
-            }
-            Err(_) => Self::new(),
-        }
-    }
-
-    pub fn load_or_default() -> Self {
-        // Try to load the config from the specified path
-        match fs::read_to_string(&STATIC_ARGS.config_path) {
-            Ok(contents) => {
-                // Parse the config from the file contents using serde
-                match serde_json::from_str(&contents) {
-                    Ok(config) => config,
-                    Err(_) => Self::new(),
-                }
-            }
-            Err(_) => Self::new(),
-        }
-    }
-
-    pub fn save(&self) -> Result<(), std::io::Error> {
-        let config_json = serde_json::to_string_pretty(self)?;
-        fs::write(&STATIC_ARGS.config_path, config_json)?;
-        Ok(())
-    }
 }

--- a/ui/src/layouts/create_account.rs
+++ b/ui/src/layouts/create_account.rs
@@ -12,6 +12,7 @@ use shared::language::get_local_text;
 use warp::logging::tracing::log;
 
 use crate::{
+    state::configuration::AudioVideo,
     warp_runner::{MultiPassCmd, WarpCmd},
     AuthPages, WARP_CMD_CH,
 };
@@ -43,6 +44,7 @@ pub fn CreateAccountLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<Str
     let ch = use_coroutine(cx, |mut rx: UnboundedReceiver<(String, String)>| {
         to_owned![page];
         async move {
+            let config = AudioVideo::load_async().await;
             let warp_cmd_tx = WARP_CMD_CH.tx.clone();
             while let Some((username, passphrase)) = rx.next().await {
                 //println!("auth got input");
@@ -62,8 +64,9 @@ pub fn CreateAccountLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<Str
                 //println!("got response from warp");
                 match res {
                     Ok(_) => {
-                        // todo: shadow this in a file other than state.json
-                        crate::utils::sounds::Play(crate::utils::sounds::Sounds::On);
+                        if config.interface_sounds {
+                            crate::utils::sounds::Play(crate::utils::sounds::Sounds::On);
+                        }
 
                         page.set(AuthPages::Success);
                     }

--- a/ui/src/layouts/create_account.rs
+++ b/ui/src/layouts/create_account.rs
@@ -12,7 +12,6 @@ use shared::language::get_local_text;
 use warp::logging::tracing::log;
 
 use crate::{
-    config::Configuration,
     warp_runner::{MultiPassCmd, WarpCmd},
     AuthPages, WARP_CMD_CH,
 };
@@ -63,9 +62,9 @@ pub fn CreateAccountLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<Str
                 //println!("got response from warp");
                 match res {
                     Ok(_) => {
-                        if Configuration::load_or_default().audiovideo.interface_sounds {
-                            crate::utils::sounds::Play(crate::utils::sounds::Sounds::On);
-                        }
+                        // todo: shadow this in a file other than state.json
+                        crate::utils::sounds::Play(crate::utils::sounds::Sounds::On);
+
                         page.set(AuthPages::Success);
                     }
                     // todo: notify user

--- a/ui/src/layouts/unlock.rs
+++ b/ui/src/layouts/unlock.rs
@@ -12,6 +12,7 @@ use shared::language::get_local_text;
 use warp::logging::tracing::log;
 
 use crate::{
+    state::configuration::AudioVideo,
     warp_runner::{MultiPassCmd, WarpCmd},
     AuthPages, WARP_CMD_CH,
 };
@@ -45,6 +46,7 @@ pub fn UnlockLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -
     let ch = use_coroutine(cx, |mut rx| {
         to_owned![password_failed, page, can_create_new_account];
         async move {
+            let config = AudioVideo::load_async().await;
             let warp_cmd_tx = WARP_CMD_CH.tx.clone();
             while let Some(password) = rx.next().await {
                 let (tx, rx) = oneshot::channel::<Result<(), warp::error::Error>>();
@@ -61,8 +63,9 @@ pub fn UnlockLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -
 
                 match res {
                     Ok(_) => {
-                        // todo: shadow this in a file other than state.json
-                        crate::utils::sounds::Play(crate::utils::sounds::Sounds::On);
+                        if config.interface_sounds {
+                            crate::utils::sounds::Play(crate::utils::sounds::Sounds::On);
+                        }
                         page.set(AuthPages::Success)
                     }
                     Err(err) => {

--- a/ui/src/layouts/unlock.rs
+++ b/ui/src/layouts/unlock.rs
@@ -12,7 +12,6 @@ use shared::language::get_local_text;
 use warp::logging::tracing::log;
 
 use crate::{
-    config::Configuration,
     warp_runner::{MultiPassCmd, WarpCmd},
     AuthPages, WARP_CMD_CH,
 };
@@ -62,9 +61,8 @@ pub fn UnlockLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -
 
                 match res {
                     Ok(_) => {
-                        if Configuration::load_or_default().audiovideo.interface_sounds {
-                            crate::utils::sounds::Play(crate::utils::sounds::Sounds::On);
-                        }
+                        // todo: shadow this in a file other than state.json
+                        crate::utils::sounds::Play(crate::utils::sounds::Sounds::On);
                         page.set(AuthPages::Success)
                     }
                     Err(err) => {

--- a/ui/src/logger/mod.rs
+++ b/ui/src/logger/mod.rs
@@ -67,6 +67,11 @@ impl LogGlue {
     }
 }
 
+/// used only for debugging
+pub fn print() {
+    println!("{:#?}", LOGGER.read());
+}
+
 impl crate::log::Log for LogGlue {
     fn enabled(&self, metadata: &log::Metadata) -> bool {
         metadata.level() <= self.max_level
@@ -102,13 +107,6 @@ impl Logger {
             .create(true)
             .append(true)
             .open(&logger_path);
-
-        let warp_path = STATIC_ARGS
-            .warp_path
-            .join("warp.log")
-            .to_string_lossy()
-            .to_string();
-        let _ = OpenOptions::new().create(true).append(true).open(warp_path);
 
         Self {
             save_to_file: false,
@@ -204,9 +202,6 @@ impl Logger {
 pub fn init_with_level(level: LevelFilter) -> Result<(), SetLoggerError> {
     log::set_max_level(level);
     log::set_boxed_logger(Box::new(LogGlue::new(level)))?;
-    if level == LevelFilter::Trace {
-        set_display_warp(true);
-    }
     Ok(())
 }
 

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -52,7 +52,6 @@ use dioxus_router::*;
 use kit::STYLE as UIKIT_STYLES;
 pub const APP_STYLE: &str = include_str!("./compiled_styles.css");
 pub mod components;
-pub mod config;
 pub mod layouts;
 pub mod logger;
 pub mod overlay;
@@ -68,7 +67,6 @@ pub struct StaticArgs {
     pub themes_path: PathBuf,
     pub cache_path: PathBuf,
     pub mock_cache_path: PathBuf,
-    pub config_path: PathBuf,
     pub warp_path: PathBuf,
     pub logger_path: PathBuf,
     pub tesseract_path: PathBuf,
@@ -91,7 +89,6 @@ pub static STATIC_ARGS: Lazy<StaticArgs> = Lazy::new(|| {
         themes_path: uplink_container.join("themes"),
         cache_path: uplink_path.join("state.json"),
         mock_cache_path: uplink_path.join("mock-state.json"),
-        config_path: uplink_path.join("Config.json"),
         warp_path: warp_path.clone(),
         logger_path: uplink_path.join("debug.log"),
         typing_indicator_refresh: 5,
@@ -393,7 +390,7 @@ pub fn app_bootstrap(cx: Scope) -> Element {
     desktop.set_inner_size(LogicalSize::new(950.0, 600.0));
 
     // todo: delete this. it is just an example
-    if state.configuration.config.general.enable_overlay {
+    if state.configuration.general.enable_overlay {
         let overlay_test = VirtualDom::new(OverlayDom);
         let window = desktop.new_window(overlay_test, make_config());
         state.ui.overlays.push(window);
@@ -824,7 +821,6 @@ fn get_logger(cx: Scope) -> Element {
     cx.render(rsx!(state
         .read()
         .configuration
-        .config
         .developer
         .developer_mode
         .then(|| rsx!(DebugLogger {}))))
@@ -848,7 +844,7 @@ fn get_toasts(cx: Scope) -> Element {
 fn get_titlebar(cx: Scope) -> Element {
     let desktop = use_window(cx);
     let state = use_shared_state::<State>(cx)?;
-    let config = state.read().configuration.config.clone();
+    let config = state.read().configuration.clone();
 
     cx.render(rsx!(
         div {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -80,7 +80,7 @@ pub struct StaticArgs {
     /// contains the keypair used for IPFS
     pub tesseract_path: PathBuf,
     /// the unlock and auth pages don't have access to State but need to know if they should play a notification.
-    /// state::configuration::Notifications is serialized and saved here
+    /// part of state is serialized and saved here
     pub login_config_path: PathBuf,
     /// seconds
     pub typing_indicator_refresh: u64,

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -63,17 +63,30 @@ mod window_manager;
 
 #[derive(Debug)]
 pub struct StaticArgs {
+    /// Uplink stores its data with the following layout, starting at whatever the root folder is:
+    /// ./uplink ./uplink/warp ./themes
+    /// uplink_path is used for deleting all uplink data when a new account is created
     pub uplink_path: PathBuf,
+    /// does nothing until themes are properly bundled with the app. maybe one day we will have an installer that does this
     pub themes_path: PathBuf,
+    /// state.json: a serialized version of State which gets saved every time state is modified
     pub cache_path: PathBuf,
+    /// a fake tesseract_path to prevent anything from mutating the tesseract keypair after it has been created (probably not necessary)
     pub mock_cache_path: PathBuf,
+    /// houses warp specific data
     pub warp_path: PathBuf,
+    /// a debug log which is only written to when the settings are enabled. otherwise logs are only sent to stdout
     pub logger_path: PathBuf,
+    /// contains the keypair used for IPFS
     pub tesseract_path: PathBuf,
-    // seconds
+    /// the unlock and auth pages don't have access to State but need to know if they should play a notification.
+    /// state::configuration::Notifications is serialized and saved here
+    pub login_config_path: PathBuf,
+    /// seconds
     pub typing_indicator_refresh: u64,
-    // seconds
+    /// seconds
     pub typing_indicator_timeout: u64,
+    /// used only for testing the UI. generates fake friends, conversations, and messages
     pub use_mock: bool,
 }
 pub static STATIC_ARGS: Lazy<StaticArgs> = Lazy::new(|| {
@@ -94,6 +107,7 @@ pub static STATIC_ARGS: Lazy<StaticArgs> = Lazy::new(|| {
         typing_indicator_refresh: 5,
         typing_indicator_timeout: 6,
         tesseract_path: warp_path.join("tesseract.json"),
+        login_config_path: uplink_path.join("login_config.json"),
         use_mock: args.with_mock,
     }
 });
@@ -148,6 +162,8 @@ pub enum AuthPages {
     Success,
 }
 
+// note that Trace and Trace2 are both LevelFilter::Trace. higher trace levels like Trace2
+// enable tracing from modules besides Uplink
 #[derive(clap::Subcommand, Debug)]
 enum LogProfile {
     /// normal operation

--- a/ui/src/state/action.rs
+++ b/ui/src/state/action.rs
@@ -165,26 +165,26 @@ pub enum Action {
 
 #[derive(Display)]
 pub enum ConfigAction {
-    #[display(fmt = "NotificationsEnabled {_0}")]
-    NotificationsEnabled(bool),
-    #[display(fmt = "Theme {_0}")]
-    Theme(String),
-    #[display(fmt = "OverlayEnabled {_0}")]
-    OverlayEnabled(bool),
-    #[display(fmt = "DevModeEnabled {_0}")]
-    DevModeEnabled(bool),
-    #[display(fmt = "InterfaceSoundsEnabled {_0}")]
-    InterfaceSoundsEnabled(bool),
-    #[display(fmt = "MediaSoundsEnabled {_0}")]
-    MediaSoundsEnabled(bool),
-    #[display(fmt = "MessageSoundsEnabled {_0}")]
-    MessageSoundsEnabled(bool),
-    #[display(fmt = "FriendsNotificationsEnabled {_0}")]
-    FriendsNotificationsEnabled(bool),
-    #[display(fmt = "MessagesNotificationsEnabled {_0}")]
-    MessagesNotificationsEnabled(bool),
-    #[display(fmt = "SettingsNotificationsEnabled {_0}")]
-    SettingsNotificationsEnabled(bool),
+    #[display(fmt = "SetNotificationsEnabled {_0}")]
+    SetNotificationsEnabled(bool),
+    #[display(fmt = "SetTheme {_0}")]
+    SetTheme(String),
+    #[display(fmt = "SetOverlayEnabled {_0}")]
+    SetOverlayEnabled(bool),
+    #[display(fmt = "SetDevModeEnabled {_0}")]
+    SetDevModeEnabled(bool),
+    #[display(fmt = "SetInterfaceSoundsEnabled {_0}")]
+    SetInterfaceSoundsEnabled(bool),
+    #[display(fmt = "SetMediaSoundsEnabled {_0}")]
+    SetMediaSoundsEnabled(bool),
+    #[display(fmt = "SetMessageSoundsEnabled {_0}")]
+    SetMessageSoundsEnabled(bool),
+    #[display(fmt = "SetFriendsNotificationsEnabled {_0}")]
+    SetFriendsNotificationsEnabled(bool),
+    #[display(fmt = "SetMessagesNotificationsEnabled {_0}")]
+    SetMessagesNotificationsEnabled(bool),
+    #[display(fmt = "SetSettingsNotificationsEnabled {_0}")]
+    SetSettingsNotificationsEnabled(bool),
 }
 
 impl Action {

--- a/ui/src/state/action.rs
+++ b/ui/src/state/action.rs
@@ -159,6 +159,32 @@ pub enum Action {
     MockSend(Uuid, Vec<String>),
     #[display(fmt = "ClearUnreads")]
     ClearUnreads(Chat),
+    #[display(fmt = "Config {_0}")]
+    Config(ConfigAction),
+}
+
+#[derive(Display)]
+pub enum ConfigAction {
+    #[display(fmt = "NotificationsEnabled {_0}")]
+    NotificationsEnabled(bool),
+    #[display(fmt = "Theme {_0}")]
+    Theme(String),
+    #[display(fmt = "OverlayEnabled {_0}")]
+    OverlayEnabled(bool),
+    #[display(fmt = "DevModeEnabled {_0}")]
+    DevModeEnabled(bool),
+    #[display(fmt = "InterfaceSoundsEnabled {_0}")]
+    InterfaceSoundsEnabled(bool),
+    #[display(fmt = "MediaSoundsEnabled {_0}")]
+    MediaSoundsEnabled(bool),
+    #[display(fmt = "MessageSoundsEnabled {_0}")]
+    MessageSoundsEnabled(bool),
+    #[display(fmt = "FriendsNotificationsEnabled {_0}")]
+    FriendsNotificationsEnabled(bool),
+    #[display(fmt = "MessagesNotificationsEnabled {_0}")]
+    MessagesNotificationsEnabled(bool),
+    #[display(fmt = "SettingsNotificationsEnabled {_0}")]
+    SettingsNotificationsEnabled(bool),
 }
 
 impl Action {

--- a/ui/src/state/configuration.rs
+++ b/ui/src/state/configuration.rs
@@ -143,23 +143,25 @@ impl Configuration {
 }
 
 impl Configuration {
-    pub fn handle_action(&mut self, action: ConfigAction) {
+    pub fn mutate(&mut self, action: ConfigAction) {
         let old_audiovideo = self.audiovideo;
         match action {
-            ConfigAction::NotificationsEnabled(enabled) => self.notifications.enabled = enabled,
-            ConfigAction::Theme(theme_name) => self.general.theme = theme_name,
-            ConfigAction::OverlayEnabled(overlay) => self.general.enable_overlay = overlay,
-            ConfigAction::DevModeEnabled(flag) => self.developer.developer_mode = flag,
-            ConfigAction::InterfaceSoundsEnabled(flag) => self.audiovideo.interface_sounds = flag,
-            ConfigAction::MediaSoundsEnabled(flag) => self.audiovideo.media_sounds = flag,
-            ConfigAction::MessageSoundsEnabled(flag) => self.audiovideo.message_sounds = flag,
-            ConfigAction::FriendsNotificationsEnabled(flag) => {
+            ConfigAction::SetNotificationsEnabled(enabled) => self.notifications.enabled = enabled,
+            ConfigAction::SetTheme(theme_name) => self.general.theme = theme_name,
+            ConfigAction::SetOverlayEnabled(overlay) => self.general.enable_overlay = overlay,
+            ConfigAction::SetDevModeEnabled(flag) => self.developer.developer_mode = flag,
+            ConfigAction::SetInterfaceSoundsEnabled(flag) => {
+                self.audiovideo.interface_sounds = flag
+            }
+            ConfigAction::SetMediaSoundsEnabled(flag) => self.audiovideo.media_sounds = flag,
+            ConfigAction::SetMessageSoundsEnabled(flag) => self.audiovideo.message_sounds = flag,
+            ConfigAction::SetFriendsNotificationsEnabled(flag) => {
                 self.notifications.friends_notifications = flag
             }
-            ConfigAction::MessagesNotificationsEnabled(flag) => {
+            ConfigAction::SetMessagesNotificationsEnabled(flag) => {
                 self.notifications.messages_notifications = flag
             }
-            ConfigAction::SettingsNotificationsEnabled(flag) => {
+            ConfigAction::SetSettingsNotificationsEnabled(flag) => {
                 self.notifications.settings_notifications = flag
             }
         }

--- a/ui/src/state/configuration.rs
+++ b/ui/src/state/configuration.rs
@@ -1,68 +1,119 @@
 use serde::{Deserialize, Serialize};
 
-use crate::config::Configuration as Config;
+use super::action::ConfigAction;
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+/// A struct that represents the configuration of the application.
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
 pub struct Configuration {
+    /// General configuration options.
     #[serde(default)]
-    pub config: Config,
-    // We should allow for custom config options here in the future to support extension developers.
+    pub general: General,
+
+    /// Privacy-related configuration options.
+    #[serde(default)]
+    pub privacy: Privacy,
+
+    /// Audio and video-related configuration options.
+    #[serde(default)]
+    pub audiovideo: AudioVideo,
+
+    /// Extension-related configuration options.
+    #[serde(default)]
+    pub extensions: Extensions,
+
+    /// Developer-related configuration options.
+    #[serde(default)]
+    pub developer: Developer,
+
+    /// Notification-related configuration options.
+    #[serde(default)]
+    pub notifications: Notifications,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+pub struct General {
+    #[serde(default)]
+    pub theme: String,
+    #[serde(default)]
+    pub show_splash: bool,
+    #[serde(default)]
+    pub enable_overlay: bool,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, Copy, Clone)]
+pub struct Privacy {
+    #[serde(default)]
+    pub satellite_sync_nodes: bool,
+    #[serde(default)]
+    pub safer_file_scanning: bool,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, Copy, Clone)]
+pub struct AudioVideo {
+    #[serde(default)]
+    pub noise_suppression: bool,
+    #[serde(default)]
+    pub call_timer: bool,
+    #[serde(default)]
+    pub interface_sounds: bool,
+    #[serde(default = "bool_true")]
+    pub message_sounds: bool,
+    #[serde(default = "bool_true")]
+    pub media_sounds: bool,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, Copy, Clone)]
+pub struct Extensions {
+    #[serde(default)]
+    pub enable: bool,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, Copy, Clone)]
+pub struct Developer {
+    #[serde(default)]
+    pub developer_mode: bool,
+}
+
+fn bool_true() -> bool {
+    true
+}
+
+// We may want to give the user the ability to pick and choose which notifications they want to see.
+// This is a good place to start.
+#[derive(Debug, Default, Deserialize, Serialize, Copy, Clone)]
+pub struct Notifications {
+    #[serde(default = "bool_true")]
+    pub enabled: bool,
+    #[serde(default)]
+    pub show_app_icon: bool,
+    #[serde(default = "bool_true")]
+    pub friends_notifications: bool,
+    #[serde(default = "bool_true")]
+    pub messages_notifications: bool,
+    // By default we leave this one off.
+    #[serde(default)]
+    pub settings_notifications: bool,
 }
 
 impl Configuration {
-    pub fn new() -> Self {
-        Self {
-            config: Config::load_or_default(),
+    pub fn handle_action(&mut self, action: ConfigAction) {
+        match action {
+            ConfigAction::NotificationsEnabled(enabled) => self.notifications.enabled = enabled,
+            ConfigAction::Theme(theme_name) => self.general.theme = theme_name,
+            ConfigAction::OverlayEnabled(overlay) => self.general.enable_overlay = overlay,
+            ConfigAction::DevModeEnabled(flag) => self.developer.developer_mode = flag,
+            ConfigAction::InterfaceSoundsEnabled(flag) => self.audiovideo.interface_sounds = flag,
+            ConfigAction::MediaSoundsEnabled(flag) => self.audiovideo.media_sounds = flag,
+            ConfigAction::MessageSoundsEnabled(flag) => self.audiovideo.message_sounds = flag,
+            ConfigAction::FriendsNotificationsEnabled(flag) => {
+                self.notifications.friends_notifications = flag
+            }
+            ConfigAction::MessagesNotificationsEnabled(flag) => {
+                self.notifications.messages_notifications = flag
+            }
+            ConfigAction::SettingsNotificationsEnabled(flag) => {
+                self.notifications.settings_notifications = flag
+            }
         }
-    }
-
-    pub fn set_notifications_enabled(&mut self, enabled: bool) {
-        self.config.notifications.enabled = enabled;
-        let _ = self.config.save();
-    }
-
-    pub fn set_theme(&mut self, theme_name: String) {
-        self.config.general.theme = theme_name;
-        let _ = self.config.save();
-    }
-
-    pub fn set_overlay(&mut self, overlay: bool) {
-        self.config.general.enable_overlay = overlay;
-        let _ = self.config.save();
-    }
-
-    pub fn set_developer_mode(&mut self, developer_mode: bool) {
-        self.config.developer.developer_mode = developer_mode;
-        let _ = self.config.save();
-    }
-
-    pub fn set_interface_sounds(&mut self, status: bool) {
-        self.config.audiovideo.interface_sounds = status;
-        let _ = self.config.save();
-    }
-
-    pub fn set_media_sounds(&mut self, status: bool) {
-        self.config.audiovideo.media_sounds = status;
-        let _ = self.config.save();
-    }
-
-    pub fn set_message_sounds(&mut self, status: bool) {
-        self.config.audiovideo.message_sounds = status;
-        let _ = self.config.save();
-    }
-
-    pub fn set_friends_notifications(&mut self, friends_notifications: bool) {
-        self.config.notifications.friends_notifications = friends_notifications;
-        let _ = self.config.save();
-    }
-
-    pub fn set_messages_notifications(&mut self, messages_notifications: bool) {
-        self.config.notifications.messages_notifications = messages_notifications;
-        let _ = self.config.save();
-    }
-
-    pub fn set_settings_notifications(&mut self, settings_notifications: bool) {
-        self.config.notifications.settings_notifications = settings_notifications;
-        let _ = self.config.save();
     }
 }

--- a/ui/src/state/configuration.rs
+++ b/ui/src/state/configuration.rs
@@ -96,6 +96,30 @@ pub struct Notifications {
 }
 
 impl Configuration {
+    pub fn new() -> Self {
+        // Create a default configuration here
+        // For example:
+        Self {
+            developer: Developer {
+                ..Developer::default()
+            },
+            audiovideo: AudioVideo {
+                message_sounds: true,
+                media_sounds: true,
+                ..AudioVideo::default()
+            },
+            notifications: Notifications {
+                enabled: true,
+                friends_notifications: true,
+                messages_notifications: true,
+                ..Notifications::default()
+            },
+            ..Self::default()
+        }
+    }
+}
+
+impl Configuration {
     pub fn handle_action(&mut self, action: ConfigAction) {
         match action {
             ConfigAction::NotificationsEnabled(enabled) => self.notifications.enabled = enabled,

--- a/ui/src/state/mod.rs
+++ b/ui/src/state/mod.rs
@@ -45,7 +45,7 @@ use warp::{
     raygun::{self, Message, Reaction},
 };
 
-use self::{action::ActionHook, chats::Direction, ui::Call};
+use self::{action::ActionHook, chats::Direction, configuration::Configuration, ui::Call};
 
 #[derive(Default, Deserialize, Serialize)]
 pub struct State {
@@ -755,7 +755,10 @@ impl State {
         let contents = match fs::read_to_string(&STATIC_ARGS.cache_path) {
             Ok(r) => r,
             Err(_) => {
-                return State::default();
+                return State {
+                    configuration: Configuration::new(),
+                    ..State::default()
+                };
             }
         };
         serde_json::from_str(&contents).unwrap_or_default()

--- a/ui/src/state/mod.rs
+++ b/ui/src/state/mod.rs
@@ -81,6 +81,7 @@ impl fmt::Debug for State {
     }
 }
 
+// todo: why is there clone impl which returns a mutated value?
 impl Clone for State {
     fn clone(&self) -> Self {
         State {

--- a/ui/src/state/mod.rs
+++ b/ui/src/state/mod.rs
@@ -211,7 +211,7 @@ impl State {
             Action::DisableMedia => self.disable_media(),
 
             // ===== Configuration =====
-            Action::Config(action) => self.configuration.handle_action(action),
+            Action::Config(action) => self.configuration.mutate(action),
         }
 
         let _ = self.save();

--- a/ui/src/state/notifications.rs
+++ b/ui/src/state/notifications.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{config::Configuration, utils::notifications::set_badge};
+use crate::utils::notifications::set_badge;
+
+use super::configuration::Configuration;
 
 // This kind is used to determine which notification kind to add to. It can also be used for querying specific notification counts.
 pub enum NotificationKind {
@@ -30,10 +32,7 @@ impl Notifications {
     }
 
     // This method is used for calculating the badge count for the app tray icon.
-    pub fn total(&self) -> u32 {
-        // Since this is read only, we can just load the config here.
-        let config = Configuration::load_or_default();
-
+    pub fn total(&self, config: &Configuration) -> u32 {
         let mut total = 0;
 
         // Only count notifications that are enabled in the config.
@@ -51,7 +50,7 @@ impl Notifications {
     }
 
     // Adds notification(s) to the specified kind.
-    pub fn increment(&mut self, kind: NotificationKind, count: u32) {
+    pub fn increment(&mut self, config: &Configuration, kind: NotificationKind, count: u32) {
         match kind {
             NotificationKind::FriendRequest => self.friends += count,
             NotificationKind::Message => self.messages += count,
@@ -59,12 +58,12 @@ impl Notifications {
         };
 
         // Update the badge any time notifications are added.
-        let _ = set_badge(self.total());
+        let _ = set_badge(self.total(config));
     }
 
     // Removes notification(s) from the specified kind.
     // Prevent underflow using saturating_sub()
-    pub fn decrement(&mut self, kind: NotificationKind, count: u32) {
+    pub fn decrement(&mut self, config: &Configuration, kind: NotificationKind, count: u32) {
         match kind {
             NotificationKind::FriendRequest => {
                 self.friends = self.friends.saturating_sub(count);
@@ -78,11 +77,11 @@ impl Notifications {
         };
 
         // Update the badge any time notifications are removed.
-        let _ = set_badge(self.total());
+        let _ = set_badge(self.total(config));
     }
 
     // Sets a notification count for the specified kind.
-    pub fn set(&mut self, kind: NotificationKind, count: u32) {
+    pub fn set(&mut self, config: &Configuration, kind: NotificationKind, count: u32) {
         match kind {
             NotificationKind::FriendRequest => self.friends = count,
             NotificationKind::Message => self.messages = count,
@@ -90,7 +89,7 @@ impl Notifications {
         };
 
         // Update the badge with new possible totals.
-        let _ = set_badge(self.total());
+        let _ = set_badge(self.total(config));
     }
 
     // Returns the total count for a given notification kind.
@@ -103,23 +102,23 @@ impl Notifications {
     }
 
     // Clears all notifications for the specified kind.
-    pub fn clear_kind(&mut self, kind: NotificationKind) {
+    pub fn clear_kind(&mut self, config: &Configuration, kind: NotificationKind) {
         match kind {
             NotificationKind::FriendRequest => self.friends = 0,
             NotificationKind::Message => self.messages = 0,
             NotificationKind::Settings => self.settings = 0,
         };
         // Upadte the badge with new possible totals.
-        let _ = set_badge(self.total());
+        let _ = set_badge(self.total(config));
     }
 
     // Clears all notifications.
-    pub fn clear_all(&mut self) {
+    pub fn clear_all(&mut self, config: &Configuration) {
         self.friends = 0;
         self.messages = 0;
         self.settings = 0;
 
         // Clear the badge.
-        let _ = set_badge(self.total());
+        let _ = set_badge(self.total(config));
     }
 }

--- a/ui/src/warp_runner/manager/commands/constellation_commands.rs
+++ b/ui/src/warp_runner/manager/commands/constellation_commands.rs
@@ -362,7 +362,7 @@ fn set_thumbnail_if_file_is_video(
     let output = Command::new("ffmpeg")
         .args([
             "-i",
-            &file_path.to_string_lossy().to_string(),
+            &file_path.to_string_lossy(),
             "-vf",
             "select=eq(pict_type\\,I)",
             "-q:v",
@@ -371,7 +371,7 @@ fn set_thumbnail_if_file_is_video(
             "image2",
             "-update",
             "1",
-            &temp_path.to_string_lossy().to_string(),
+            &temp_path.to_string_lossy(),
         ])
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
@@ -384,8 +384,8 @@ fn set_thumbnail_if_file_is_video(
 
         let image = std::fs::read(temp_path)?;
 
-        let prefix = format!("data:{};base64,", IMAGE_JPEG.to_string());
-        let base64_image = base64::encode(&image);
+        let prefix = format!("data:{};base64,", IMAGE_JPEG);
+        let base64_image = base64::encode(image);
         let img = prefix + base64_image.as_str();
         item.set_thumbnail(&img);
         Ok(())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- addresses the following problems:
1. changing settings within state didn't trigger a re-render or cause state to be saved
2. State was expected to have a default configuration that matched what Serde would generate from this: "{}" 
3. when the configuration was saved, `Config.json` didn't match the `configuration` entry in `State.json` 

- moves `config.rs` into `state/configuration.rs` and forces configuration to be changed via `state::mutate()`, same as everything else in state. 
- shadows changes to `AudioVideo` config so that the unlock and create_account pages can play the sound (to maintain previous behavior). 

- fixes some misc clippy warnings and a minor bug in logger

### Tests: 
a. A way to test it, is creating new account, going to .uplink folder, and verify if state.json file was created with correct default values, some of them true, some of them false 
b. Other way, is testing if sound in app is working if you receive new message, without need to go to settings page and verify if the option is true 
c. Other test would be see state.json file, go to settings on Uplink, change one of the options there, and observe if values has been changed in state.json 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

