### PR TITLE
add(ui): add aria labels needed to for appium tests

### DIFF
--- a/kit/src/elements/switch/mod.rs
+++ b/kit/src/elements/switch/mod.rs
@@ -39,8 +39,9 @@ pub fn Switch<'a>(cx: Scope<'a, Props>) -> Element<'a> {
             class: {
                 format_args!("switch {}", if disabled { "disabled" } else { "" })
             },
-            aria_label: "Switch Slider",
+            aria_label: "switch-slider",
             input {
+                aria_label: "switch-slider-value",
                 disabled: "{disabled}",
                 "type": "checkbox",
                 checked: "{checked_state}",

--- a/kit/src/elements/switch/mod.rs
+++ b/kit/src/elements/switch/mod.rs
@@ -39,7 +39,7 @@ pub fn Switch<'a>(cx: Scope<'a, Props>) -> Element<'a> {
             class: {
                 format_args!("switch {}", if disabled { "disabled" } else { "" })
             },
-            aria_label: "switch-slider",
+            aria_label: "Switch Slider",
             input {
                 aria_label: "switch-slider-value",
                 disabled: "{disabled}",

--- a/kit/src/elements/tooltip/mod.rs
+++ b/kit/src/elements/tooltip/mod.rs
@@ -57,10 +57,11 @@ pub fn Tooltip(cx: Scope<Props>) -> Element {
 
     cx.render(rsx! {
         div {
+            aria_label: "tooltip",
             class: {
                 format_args!("tooltip hidden tooltip-{} tooltip-{}", &UUID, arrow_position)
             },
-            span { class: "tooltip-text", "{text}" }
+            span { aria_label: "tooltip-text", class: "tooltip-text", "{text}" }
         }
     })
 }

--- a/kit/src/layout/topbar/mod.rs
+++ b/kit/src/layout/topbar/mod.rs
@@ -40,6 +40,7 @@ pub fn Topbar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             aria_label: "Topbar",
             (show_back_button(&cx)).then(|| rsx!(
                 Button {
+                    aria_label: "hamburger-button".into(),
                     icon: if currently_back { icons::outline::Shape::ChevronLeft } else { icons::outline::Shape::SidebarArrowLeft },
                     onpress: move |_| emit(&cx),
                     appearance: Appearance::Secondary

--- a/ui/src/components/debug_logger/mod.rs
+++ b/ui/src/components/debug_logger/mod.rs
@@ -26,14 +26,17 @@ pub fn DebugLogger(cx: Scope) -> Element {
         style { STYLE }
         div {
             id: "debug_logger",
+            aria_label: "debug-logger",
             class: "debug-logger resize-vert-top",
             div {
                 class: "header",
+                aria_label: "debug-logger-header",
                 Label {
                     text: "Logger".into()
                 }
             },
             div {
+                aria_label: "debug-logger-body",
                 class: "body",
                 div {
                     logs_to_show.iter().map(|log| {
@@ -45,11 +48,14 @@ pub fn DebugLogger(cx: Scope) -> Element {
                         rsx!(
                             p {
                                 class: "item",
+                                aria_label: "debug-logger-item",
                                 span {
+                                    aria_label: "debug-logger-item-timestamp",
                                     class: "log-text muted",
                                     "〇 {log_datetime}"
                                 },
                                 span {
+                                    aria_label: "debug-logger-item-level",
                                     class: "log-text bold {log_level_string}",
                                     "{log_level}"
                                 },
@@ -58,6 +64,7 @@ pub fn DebugLogger(cx: Scope) -> Element {
                                     "»"
                                 }
                                 span {
+                                    aria_label: "debug-logger-item-text",
                                     id: "log_text",
                                     class: "log-text",
                                     " {log_message}"

--- a/ui/src/components/friends/add.rs
+++ b/ui/src/components/friends/add.rs
@@ -171,6 +171,7 @@ pub fn AddFriend(cx: Scope) -> Element {
                     aria_label: "Add Someone Button".into()
                 },
                 Button {
+                    aria_label: "Copy ID".into()
                     icon: Icon::ClipboardDocument,
                     onpress: move |_| {
                         id_ch.send(());

--- a/ui/src/components/settings/sub_pages/developer.rs
+++ b/ui/src/components/settings/sub_pages/developer.rs
@@ -58,7 +58,7 @@ pub fn DeveloperSettings(cx: Scope) -> Element {
                 section_description: "Sends a test notification.".into(),
                 Button {
                     text: "Test Notifications".into(),
-                    aria_label: "open-codebase-button".into(),
+                    aria_label: "test-notification-button".into(),
                     appearance: Appearance::Secondary,
                     icon: Icon::BellAlert,
                     onpress: move |_| {

--- a/ui/src/components/settings/sub_pages/notifications.rs
+++ b/ui/src/components/settings/sub_pages/notifications.rs
@@ -20,6 +20,7 @@ pub fn NotificationSettings(cx: Scope) -> Element {
                 section_label: get_local_text("settings-notifications.grant-permissions"),
                 section_description: get_local_text("settings-notifications.grant-permissions-description"),
                 Button {
+                    aria_label: "grant-permissions-button".into(),
                     text: get_local_text("settings-notifications.grant-permissions"),
                     icon: Icon::Shield,
                     onpress: move |_| {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -796,6 +796,7 @@ fn get_titlebar(cx: Scope) -> Element {
             // Only display this if developer mode is enabled.
             (config.developer.developer_mode).then(|| rsx!(
                 Button {
+                    aria_label: "device-phone-mobile-button".into(),
                     icon: Icon::DevicePhoneMobile,
                     appearance: Appearance::Transparent,
                     onpress: move |_| {
@@ -811,6 +812,7 @@ fn get_titlebar(cx: Scope) -> Element {
                     }
                 },
                 Button {
+                    aria_label: "device-tablet-button".into(),
                     icon: Icon::DeviceTablet,
                     appearance: Appearance::Transparent,
                     onpress: move |_| {
@@ -826,6 +828,7 @@ fn get_titlebar(cx: Scope) -> Element {
                     }
                 },
                 Button {
+                    aria_label: "computer-desktop-button".into(),
                     icon: Icon::ComputerDesktop,
                     appearance: Appearance::Transparent,
                     onpress: move |_| {
@@ -841,6 +844,7 @@ fn get_titlebar(cx: Scope) -> Element {
                     }
                 },
                 Button {
+                    aria_label: "command-line-button".into(),
                     icon: Icon::CommandLine,
                     appearance: Appearance::Transparent,
                     onpress: |_| {


### PR DESCRIPTION
### What this PR does 📖

- Add aria labels required for UI locators on appium tests for the following items: switch checkboxes, tooltips, hamburger button, debug logger, copy did button, mobile/tablet/desktop/CL view buttons, grant permissions button from settings notifications
- Fixed a wrong aria label from settings developer (test notification had incorrect text)

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️
- Solves issue #68 added on Appium Repo

### Additional comments 🎤

