### PR TITLE
chore(Windows/Unix): Remove toolbar on systems other than osx

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ cargo run --bin ui --profile=rapid
 **Windows 10+**
 | Dep  | Install Command                                                  |
 |------|------------------------------------------------------------------|
-| Chocolatey | [Installation Guide](https://chocolatey.org/install) |
-| Rust | choco install rust |
+| Rust | [Installation Guide](https://www.rust-lang.org/tools/install) |
+| Protoc | [Download](https://github.com/protocolbuffers/protobuf/releases/download/v22.0/protoc-22.0-win64.zip) |
 
 **Ubuntu WSL (Maybe also Ubuntu + Debian)**
 | Dep  | Install Command                                                  |

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -12,6 +12,7 @@ dioxus-router = { git = "https://github.com/DioxusLabs/dioxus", rev = "d521da199
 dioxus-desktop = { git = "https://github.com/DioxusLabs/dioxus", rev = "d521da1991719760e271457dfe4f9ddf281afbb3", features = [
     "transparent",
 ] }
+raw-window-handle = "0.5.0"
 dioxus-core = { git = "https://github.com/DioxusLabs/dioxus", rev = "d521da1991719760e271457dfe4f9ddf281afbb3" }
 fermi = { git = "https://github.com/DioxusLabs/dioxus", rev = "22e71a71bdcdc03c3ae83ae1c3b3fb5417ebaa80" }
 kit = { path = "../kit" }
@@ -20,6 +21,7 @@ extensions = { path = "../extensions" }
 tokio-util = { version = "0.7", features = ["full"] }
 arboard = "3.1.0"
 humansize = "2.1.3"
+window-vibrancy = "0.3.2"
 uuid = { version = "1.0", features = ["serde", "v4"] }
 libloading = "0.7.4"
 warp = { git = "https://github.com/Satellite-im/Warp", rev = "a7e075238ee926919894cb27d743284ed3724dc2" }

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -117,7 +117,6 @@ fn main() {
     // Attempts to increase the file desc limit on unix-like systems
     // Note: Will be changed out in the future
     if fdlimit::raise_fd_limit().is_none() {}
-
     // configure logging
     let args = common::Args::parse();
     let max_log_level = if let Some(profile) = args.profile {
@@ -248,6 +247,14 @@ fn bootstrap(cx: Scope) -> Element {
         width: 500.0,
         height: 300.0,
     });
+
+    #[cfg(target_os = "windows")]
+    {
+        #[allow(unused_imports)]
+        use raw_window_handle::HasRawWindowHandle;
+        window_vibrancy::apply_acrylic(&**desktop, None)
+            .expect("Unsupported platform! 'apply_blur' is only supported on Windows");
+    }
     cx.render(rsx!(crate::auth_page_manager {}))
 }
 

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -199,12 +199,16 @@ fn main() {
 
         window = window
             .with_has_shadow(true)
-            .with_title_hidden(true)
             .with_transparent(true)
             .with_fullsize_content_view(true)
             .with_menu(main_menu)
             .with_titlebar_transparent(true);
         // .with_movable_by_window_background(true)
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        window = window.with_decorations(false);
     }
 
     let config = Config::default();
@@ -843,6 +847,41 @@ fn get_titlebar(cx: Scope) -> Element {
     let state = use_shared_state::<State>(cx)?;
     let config = state.read().configuration.clone();
 
+    let mut controls = None;
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        controls = cx.render(rsx!(
+            div {
+                class: "controls",
+                Button {
+                    aria_label: "minimize-button".into(),
+                    icon: Icon::Minus,
+                    appearance: Appearance::Transparent,
+                    onpress: move |_| {
+                        desktop.set_minimized(true);
+                    }
+                },
+                Button {
+                    aria_label: "square-button".into(),
+                    icon: Icon::Square2Stack,
+                    appearance: Appearance::Transparent,
+                    onpress: move |_| {
+                        desktop.close();
+                    }
+                },
+                Button {
+                    aria_label: "close-button".into(),
+                    icon: Icon::XMark,
+                    appearance: Appearance::Transparent,
+                    onpress: move |_| {
+                        desktop.close();
+                    }
+                },
+            }
+        ))
+    }
+
     cx.render(rsx!(
         div {
             id: "titlebar",
@@ -906,6 +945,9 @@ fn get_titlebar(cx: Scope) -> Element {
                     }
                 }
             )),
+
+            controls,
+
         },
     ))
 }

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -561,12 +561,12 @@ fn app(cx: Scope) -> Element {
                         let new_metadata = WindowMeta {
                             height: size.height,
                             width: size.width,
-                            minimal_view: size.width < 1200,
+                            minimal_view: size.width < 600,
                             ..metadata
                         };
                         if metadata != new_metadata {
+                            state.write().ui.sidebar_hidden = new_metadata.minimal_view;
                             state.write().ui.metadata = new_metadata;
-                            state.write().ui.sidebar_hidden = size.width < 1200;
                             needs_update.set(true);
                         }
                     }

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -202,6 +202,7 @@ fn main() {
             .with_title_hidden(true)
             .with_transparent(true)
             .with_fullsize_content_view(true)
+            .with_menu(main_menu)
             .with_titlebar_transparent(true);
         // .with_movable_by_window_background(true)
     }
@@ -211,7 +212,7 @@ fn main() {
     dioxus_desktop::launch_cfg(
         bootstrap,
         config
-            .with_window(window.with_menu(main_menu))
+            .with_window(window)
             .with_custom_index(
                 r#"
     <!doctype html>

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -267,13 +267,13 @@ fn auth_page_manager(cx: Scope) -> Element {
     }))
 }
 
+#[allow(unused_assignments)]
 #[inline_props]
 fn auth_wrapper(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -> Element {
     log::trace!("rendering auth wrapper");
     let desktop = use_window(cx);
     let theme = "";
-    let pre_release_text = get_local_text("uplink.pre-release");
-    let mut controls = None;
+    let mut controls: Option<VNode> = None;
 
     #[cfg(not(target_os = "macos"))]
     {
@@ -871,12 +871,13 @@ fn get_toasts(cx: Scope) -> Element {
     )))
 }
 
+#[allow(unused_assignments)]
 fn get_titlebar(cx: Scope) -> Element {
     let desktop = use_window(cx);
     let state = use_shared_state::<State>(cx)?;
     let config = state.read().configuration.clone();
 
-    let mut controls = None;
+    let mut controls: Option<VNode> = None;
 
     #[cfg(not(target_os = "macos"))]
     {

--- a/ui/src/style.scss
+++ b/ui/src/style.scss
@@ -1,12 +1,12 @@
 
 
 html, body {
-    background-color: var(--background);
     height: 100%;
     margin: 0;
     overscroll-behavior-y: none;
     overscroll-behavior-x: none;
-    overflow: hidden;;
+    overflow: hidden;
+    border-radius: var(--border-radius);
 }
 #main, #app-wrap {
     height: 100%;
@@ -14,8 +14,13 @@ html, body {
     margin: 0;
     overscroll-behavior-x: none;
     overscroll-behavior-y: none;
+    overflow: hidden;
     display: inline-flex;
     flex-direction: column;
+}
+
+#app-wrap {
+    border: 1px solid var(--border-color);
 }
 
 :root {

--- a/ui/src/style.scss
+++ b/ui/src/style.scss
@@ -23,7 +23,7 @@ html, body {
 }
 
 #titlebar {
-    height: var(--titlebar-height);
+    height: fit-content;
     width: 100%;
     background-color: var(--background);
     border-bottom: 1px solid var(--border-color);
@@ -33,9 +33,9 @@ html, body {
     cursor: pointer;
 
     .btn-wrap {
-        height: 100%;
+        height: var(--titlebar-height);
+        width: var(--titlebar-height);
         padding: unset;
-
         .btn {
             font-size: var(--text-size-less);
             height: 100%;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

On OSX we NEED to provide a menu bar (for edit->copy paste) etc otherwise the keyboard commands will not work, this is not required in windows or linux so this PR disables it.

