### PR TITLE
fix(extensions): remove panics

### DIFF
--- a/extensions/src/lib.rs
+++ b/extensions/src/lib.rs
@@ -1,5 +1,5 @@
 use dioxus::prelude::*;
-use ipc_channel::ipc::IpcReceiver;
+
 use libloading::Library;
 use std::{fmt, rc::Rc};
 

--- a/kit/src/components/user/mod.rs
+++ b/kit/src/components/user/mod.rs
@@ -30,8 +30,7 @@ pub struct Props<'a> {
 pub fn get_time_ago(cx: &Scope<Props>) -> String {
     let f = timeago::Formatter::new();
     let current_time = Utc::now();
-    let c: chrono::Duration =
-        current_time - cx.props.timestamp.unwrap_or(current_time);
+    let c: chrono::Duration = current_time - cx.props.timestamp.unwrap_or(current_time);
     let duration: std::time::Duration = match c.to_std() {
         // for the sidebar, don't want the timestamp to increment a few seconds every time the typing indicator comes over.
         // prevent this by rounding down and giving a duration in minutes only.

--- a/kit/src/elements/file/mod.rs
+++ b/kit/src/elements/file/mod.rs
@@ -238,35 +238,35 @@ mod test {
     #[test]
     fn test_get_file_extension1() {
         let input = String::from("image.jpeg");
-        let file_extension = get_file_extension(input.clone());
+        let file_extension = get_file_extension(input);
         assert_eq!(file_extension, ".jpeg");
     }
 
     #[test]
     fn test_get_file_extension2() {
         let input = String::from("image.png");
-        let file_extension = get_file_extension(input.clone());
+        let file_extension = get_file_extension(input);
         assert_eq!(file_extension, ".png");
     }
 
     #[test]
     fn test_get_file_extension3() {
         let input = String::from("file.txt");
-        let file_extension = get_file_extension(input.clone());
+        let file_extension = get_file_extension(input);
         assert_eq!(file_extension, ".txt");
     }
 
     #[test]
     fn test_get_file_extension4() {
         let input = String::from("file.txt.exe");
-        let file_extension = get_file_extension(input.clone());
+        let file_extension = get_file_extension(input);
         assert_eq!(file_extension, ".exe");
     }
 
     #[test]
     fn test_get_file_extension5() {
         let input = String::from("file");
-        let file_extension = get_file_extension(input.clone());
+        let file_extension = get_file_extension(input);
         assert_eq!(file_extension, "");
     }
 }

--- a/native_extensions/emoji_selector/src/lib.rs
+++ b/native_extensions/emoji_selector/src/lib.rs
@@ -117,7 +117,7 @@ impl EmojiSelector {
                         )
                     })
                 }
-                self.build_nav(&cx),
+                self.build_nav(cx),
             }
         ))
     }
@@ -149,7 +149,7 @@ impl Extension for EmojiSelector {
         cx.render(rsx! (
             style { "{styles}" },
             // If enabled, render the selector popup.
-            display_selector.then(|| self.render_selector(&cx)),
+            display_selector.then(|| self.render_selector(cx)),
             // Render standard (required) button to toggle.
             Button {
                 icon: Icon::FaceSmile,

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -573,7 +573,7 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
 
     let extensions = &state.read().ui.extensions;
 
-    let ext_renders = {
+    let _ext_renders = {
         let mut list = vec![];
         let extensions = extensions.iter();
         for (_, proxy) in extensions {
@@ -617,9 +617,9 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
         },
         controls: cx.render(rsx!(
             // Load extensions
-//            for node in ext_renders {
-//                rsx!(node)
-//            },
+            //            for node in ext_renders {
+            //                rsx!(node)
+            //            },
             Button {
                 icon: Icon::ChevronDoubleRight,
                 disabled: is_loading,

--- a/ui/src/components/settings/sub_pages/extensions.rs
+++ b/ui/src/components/settings/sub_pages/extensions.rs
@@ -24,7 +24,7 @@ pub fn ExtensionSettings(cx: Scope) -> Element {
                 text: open_folder,
                 aria_label: "open-extensions-folder-button".into(),
                 onpress: move |_| {
-                    let _ = opener::open(STATIC_ARGS.extensions_path.to_owned());
+                    let _ = opener::open(&STATIC_ARGS.extensions_path);
                 }
             },
             SettingSection {

--- a/ui/src/extensions/mod.rs
+++ b/ui/src/extensions/mod.rs
@@ -2,7 +2,7 @@ use common::state::configuration::Configuration;
 use extensions::*;
 use libloading::Library;
 use std::{collections::HashMap, ffi::OsStr, io, rc::Rc};
-use warp::logging::tracing::log;
+
 
 struct ExtensionRegistrar {
     extensions: HashMap<String, ExtensionProxy>,

--- a/ui/src/layouts/storage.rs
+++ b/ui/src/layouts/storage.rs
@@ -488,7 +488,7 @@ pub fn FilesLayout(cx: Scope<Props>) -> Element {
                                                 let file_extension = std::path::Path::new(&file_name2)
                                                     .extension()
                                                     .and_then(OsStr::to_str)
-                                                    .map(|s| format!("{s}"))
+                                                    .map(|s| s.to_string())
                                                     .unwrap_or_default();
 
                                                 let file_stem = PathBuf::from(&file_name2)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- PR #274 had some requests to remove `unwrap` and `expect`, which are implemented here. the change is to use `?`  and  `map_err` a few times. 
- also used clippy to automatically fix some warnings. 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

