### PR TITLE
feat(logger): add button to view state

### DIFF
--- a/common/locales/en-US/main.ftl
+++ b/common/locales/en-US/main.ftl
@@ -156,6 +156,8 @@ settings-developer = Developer Settings
     .open-debug-logger = Open debug logger
     .save-logs-to-file = Save logs in a file
     .save-logs-to-file-description = Enabling this option, logs will be saved in a file and will be persistent.
+    .print-state = Print State 
+    .print-state-description = Display State in the debug logger 
 
 media-player = Media Player 
     .enable-camera = Enable Camera 

--- a/ui/src/components/settings/sub_pages/developer.rs
+++ b/ui/src/components/settings/sub_pages/developer.rs
@@ -83,7 +83,6 @@ pub fn DeveloperSettings(cx: Scope) -> Element {
                     }
                 }
             },
-
             SettingSection {
                 section_label: get_local_text("settings-developer.compress-download-cache"),
                 section_description: get_local_text("settings-developer.compress-download-cache-description"),
@@ -93,6 +92,19 @@ pub fn DeveloperSettings(cx: Scope) -> Element {
                     appearance: Appearance::Secondary,
                     icon: Icon::ArchiveBoxArrowDown,
                     onpress: |_| {
+                    }
+                }
+            },
+            SettingSection {
+                section_label: get_local_text("settings-developer.print-state"),
+                section_description: get_local_text("settings-developer.print-state-description"),
+                Button {
+                    text: get_local_text("settings-developer.print-state"),
+                    aria_label: "print-state-button".into(),
+                    appearance: Appearance::Secondary,
+                    icon: Icon::DocumentChartBar,
+                    onpress: move |_| {
+                        log::debug!("{:#?}", state.read());
                     }
                 }
             },

--- a/ui/src/logger/mod.rs
+++ b/ui/src/logger/mod.rs
@@ -141,6 +141,7 @@ impl Logger {
         if self.save_to_file {
             let mut file = OpenOptions::new()
                 .append(true)
+                .create(true)
                 .open(&self.log_file)
                 .unwrap();
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- adds a button under developer settings and fixes a crash

### Which issue(s) this PR fixes 🔨

- Resolve #327 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
`debug_logger` was written with single line logs in mind. pretty-printing state doesn't fit in this model. however, the logs get printed to the terminal just fine. however, the display in the debug_logger will be wrong due to this:
![image](https://user-images.githubusercontent.com/8636602/220760311-efb6b65c-2a96-4bfb-86ac-5fa3c12d1ed7.png)

fortunately, the log file will be unharmed by this. i can also use `log::trace` to bypass the `debug_logger`
