### PR TITLE
feat(chats): wire up UI for replies, typing indicator, and attachments

### DIFF
--- a/common/src/warp_runner/manager/commands/raygun_commands.rs
+++ b/common/src/warp_runner/manager/commands/raygun_commands.rs
@@ -44,7 +44,7 @@ pub enum RayGunCmd {
         conv_id: Uuid,
         msg_id: Uuid,
         file_name: String,
-        directory: String,
+        directory: PathBuf,
         rsp: oneshot::Sender<Result<ConstellationProgressStream, warp::error::Error>>,
     },
     #[display(fmt = "DeleteMessage {{ conv_id: {conv_id}, msg_id: {msg_id} }} ")]
@@ -137,7 +137,7 @@ pub async fn handle_raygun_cmd(
             directory,
             rsp,
         } => {
-            let pb = PathBuf::from(directory).join(&file_name);
+            let pb = directory.join(&file_name);
             let r = messaging.download(conv_id, msg_id, file_name, pb).await;
             let _ = rsp.send(r);
         }

--- a/kit/src/components/file_embed/mod.rs
+++ b/kit/src/components/file_embed/mod.rs
@@ -8,27 +8,25 @@ use dioxus::prelude::*;
 use humansize::format_size;
 use humansize::DECIMAL;
 
-#[derive(PartialEq, Props)]
-pub struct Props {
+#[derive(Props)]
+pub struct Props<'a> {
     // The filename of the file
-    #[props(optional)]
-    filename: Option<String>,
+    filename: String,
 
     // The size of the file in bytes
-    #[props(optional)]
-    filesize: Option<u32>,
+    filesize: usize,
 
     // The type of the file (e.g. "PDF", "JPEG")
-    #[props(optional)]
     kind: Option<String>,
 
     // Whether the file is coming from a remote user, or we sent it.
-    #[props(optional)]
     remote: Option<bool>,
 
     // The icon to use to represent the file
-    #[props(optional)]
     icon: Option<Icon>,
+
+    // called shen the icon is clicked
+    on_press: EventHandler<'a, ()>,
 }
 
 pub fn get_icon(cx: &Scope<Props>) -> Icon {
@@ -38,10 +36,11 @@ pub fn get_icon(cx: &Scope<Props>) -> Icon {
 }
 
 #[allow(non_snake_case)]
-pub fn FileEmbed(cx: Scope<Props>) -> Element {
-    let filename = cx.props.filename.clone().unwrap_or_default();
-    let kind = cx.props.kind.clone().unwrap_or_default();
-    let filesize = cx.props.filesize.unwrap_or_default();
+pub fn FileEmbed<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
+    let filename = &cx.props.filename;
+    // if kind is omitted, don't want the file size to appear negative
+    let kind = format!("{} -", cx.props.kind.clone().unwrap_or_default());
+    let filesize = cx.props.filesize;
     let filesize_str = format_size(filesize, DECIMAL);
     let remote = cx.props.remote.unwrap_or_default();
 
@@ -69,12 +68,13 @@ pub fn FileEmbed(cx: Scope<Props>) -> Element {
                 },
                 p {
                     class: "meta",
-                    "{kind} - {filesize_str}"
+                    "{kind} {filesize_str}"
                 }
             },
             Button {
                 icon: Icon::ArrowDown,
                 appearance: Appearance::Primary,
+                onpress: move |_| cx.props.on_press.call(()),
             }
         }
     ))

--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -1,5 +1,10 @@
+use common::icons::outline::Shape as Icon;
 use derive_more::Display;
 use dioxus::prelude::*;
+use humansize::{format_size, DECIMAL};
+use warp::constellation::file::File;
+
+use crate::elements::button;
 
 #[derive(Eq, PartialEq, Clone, Copy, Display)]
 pub enum Order {
@@ -45,7 +50,7 @@ pub struct Props<'a> {
     // todo: remove this
     #[allow(unused)]
     #[props(optional)]
-    attachments: Option<Vec<String>>,
+    attachments: Option<Vec<File>>,
 }
 
 #[allow(non_snake_case)]
@@ -57,6 +62,16 @@ pub fn Message<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let loading = cx.props.loading.unwrap_or_default();
     let remote = cx.props.remote.unwrap_or_default();
     let order = cx.props.order.unwrap_or(Order::Last);
+
+    let attachment_list = cx.props.attachments.iter().map(|vec| {
+        vec.iter().map(|file| {
+            let key = file.id();
+            rsx!(Attachment {
+                key: "{key}",
+                file: file.clone(),
+            })
+        })
+    });
 
     cx.render(rsx! (
         div {
@@ -87,6 +102,44 @@ pub fn Message<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     "{text}"
                 }
             ))
+            attachment_list.map(|list| {
+                rsx!(div { list })
+            })
         }
     ))
+}
+
+#[derive(PartialEq, Eq, Props)]
+pub struct AttachmentProps {
+    file: File,
+}
+
+#[allow(non_snake_case)]
+pub fn Attachment(cx: Scope<AttachmentProps>) -> Element {
+    let size = format_size(cx.props.file.size(), DECIMAL);
+    let name = cx.props.file.name();
+    cx.render(rsx! {
+        div {
+            class: "attachment-embed",
+            div {
+                class: "embed-icon",
+                common::icons::Icon {
+                    icon: Icon::Document,
+                },
+                h2 {
+                    "{name}"
+                }
+            }
+            div {
+                class: "embed-details",
+                p {
+                    "{size}"
+                },
+                button::Button {
+                    icon: Icon::DocumentArrowDown,
+                    text: String::new(),
+                }
+            }
+        }
+    })
 }

--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -47,6 +47,11 @@ pub struct Props<'a> {
     // If not set, the default value of Order::Last will be used.
     #[props(optional)]
     order: Option<Order>,
+
+    // todo: remove this
+    #[allow(unused)]
+    #[props(optional)]
+    attachments: Option<Vec<String>>,
 }
 
 #[allow(non_snake_case)]

--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -28,12 +28,6 @@ pub struct Props<'a> {
     with_text: Option<String>,
 
     // todo: remove unused attribute
-    // if Some, will contain part of the message being replied to
-    #[allow(unused)]
-    #[props(!optional)]
-    in_reply_to: Option<String>,
-
-    // todo: remove unused attribute
     // todo: does this need to be an option like the rest of 'em?
     #[allow(unused)]
     reactions: Vec<warp::raygun::Reaction>,

--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -1,10 +1,9 @@
 use common::icons::outline::Shape as Icon;
 use derive_more::Display;
 use dioxus::prelude::*;
-use humansize::{format_size, DECIMAL};
 use warp::constellation::file::File;
 
-use crate::elements::button;
+use crate::components::file_embed::FileEmbed;
 
 #[derive(Eq, PartialEq, Clone, Copy, Display)]
 pub enum Order {
@@ -21,15 +20,12 @@ pub enum Order {
 #[derive(Props)]
 pub struct Props<'a> {
     // An optional field that, if set to true, will add a CSS class of "loading" to the div element.
-    #[props(optional)]
     loading: Option<bool>,
 
     // An optional field that, if set, will be used as the content of a nested div element with a class of "content".
-    #[props(optional)]
     with_content: Option<Element<'a>>,
 
     // An optional field that, if set, will be used as the text content of a nested p element with a class of "text".
-    #[props(optional)]
     with_text: Option<String>,
 
     // todo: remove unused attribute
@@ -38,18 +34,14 @@ pub struct Props<'a> {
     reactions: Vec<warp::raygun::Reaction>,
 
     // An optional field that, if set to true, will add a CSS class of "remote" to the div element.
-    #[props(optional)]
     remote: Option<bool>,
 
     // An optional field that, if set, will be used to determine the ordering of the div element relative to other Message elements.
     // The value will be converted to a string using the Order enum's fmt::Display implementation and used as a CSS class of the div element.
     // If not set, the default value of Order::Last will be used.
-    #[props(optional)]
     order: Option<Order>,
 
-    // todo: remove this
-    #[allow(unused)]
-    #[props(optional)]
+    // available for download
     attachments: Option<Vec<File>>,
 
     /// called when an attachment is downloaded
@@ -60,19 +52,29 @@ pub struct Props<'a> {
 pub fn Message<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let text = cx.props.with_text.clone().unwrap_or_default();
     // todo: render reactions
-    // todo: render part of message being replied to
 
     let loading = cx.props.loading.unwrap_or_default();
-    let remote = cx.props.remote.unwrap_or_default();
+    let is_remote = cx.props.remote.unwrap_or_default();
     let order = cx.props.order.unwrap_or(Order::Last);
 
-    let attachment_list = cx.props.attachments.iter().map(|vec| {
+    let has_attachments = cx
+        .props
+        .attachments
+        .as_ref()
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
+
+    // there's some weirdness here to avoid more nesting. this should make the code easier to read overall
+    let attachment_list = cx.props.attachments.as_ref().map(|vec| {
         vec.iter().map(|file| {
             let key = file.id();
             let name = file.name();
-            rsx!(Attachment {
+            rsx!(FileEmbed {
                 key: "{key}",
-                file: file.clone(),
+                filename: file.name(),
+                filesize: file.size(),
+                remote: is_remote.clone(),
+                icon: Icon::Document,
                 on_press: move |_| cx.props.on_download.call(name.clone()),
             })
         })
@@ -86,7 +88,7 @@ pub fn Message<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     if loading {
                         "loading"
                     } else { "" },
-                    if remote {
+                    if is_remote {
                         "remote"
                     } else { "" },
                     if cx.props.order.is_some() {
@@ -106,48 +108,18 @@ pub fn Message<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     class: "text",
                     "{text}"
                 }
-            ))
-            attachment_list.map(|list| {
-                rsx!(div { list })
+            )),
+            has_attachments.then(|| {
+                rsx!(
+                    div {
+                        class: "attachment-list",
+                        attachment_list.map(|list| {
+                            rsx!( list )
+                        })
+                    }
+                )
             })
+
         }
     ))
-}
-
-#[derive(Props)]
-pub struct AttachmentProps<'a> {
-    file: File,
-    on_press: EventHandler<'a, ()>,
-}
-
-#[allow(non_snake_case)]
-fn Attachment<'a>(cx: Scope<'a, AttachmentProps<'a>>) -> Element<'a> {
-    let size = format_size(cx.props.file.size(), DECIMAL);
-    let name = cx.props.file.name();
-
-    cx.render(rsx! {
-        div {
-            class: "attachment-embed",
-            div {
-                class: "embed-icon",
-                common::icons::Icon {
-                    icon: Icon::Document,
-                },
-                h2 {
-                    "{name}"
-                }
-            }
-            div {
-                class: "embed-details",
-                p {
-                    "{size}"
-                },
-                button::Button {
-                    icon: Icon::DocumentArrowDown,
-                    text: String::new(),
-                    onpress: move |_| cx.props.on_press.call(()),
-                }
-            }
-        }
-    })
 }

--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -1,4 +1,4 @@
-use common::icons::outline::Shape as Icon;
+//use common::icons::outline::Shape as Icon;
 use derive_more::Display;
 use dioxus::prelude::*;
 use warp::constellation::file::File;
@@ -64,6 +64,7 @@ pub fn Message<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
         .map(|v| !v.is_empty())
         .unwrap_or(false);
 
+    // todo: pick an icon based on the file extension
     // there's some weirdness here to avoid more nesting. this should make the code easier to read overall
     let attachment_list = cx.props.attachments.as_ref().map(|vec| {
         vec.iter().map(|file| {
@@ -73,8 +74,7 @@ pub fn Message<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 key: "{key}",
                 filename: file.name(),
                 filesize: file.size(),
-                remote: is_remote.clone(),
-                icon: Icon::Document,
+                remote: is_remote,
                 on_press: move |_| cx.props.on_download.call(name.clone()),
             })
         })

--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -51,6 +51,9 @@ pub struct Props<'a> {
     #[allow(unused)]
     #[props(optional)]
     attachments: Option<Vec<File>>,
+
+    /// called when an attachment is downloaded
+    on_download: EventHandler<'a, String>,
 }
 
 #[allow(non_snake_case)]
@@ -66,9 +69,11 @@ pub fn Message<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let attachment_list = cx.props.attachments.iter().map(|vec| {
         vec.iter().map(|file| {
             let key = file.id();
+            let name = file.name();
             rsx!(Attachment {
                 key: "{key}",
                 file: file.clone(),
+                on_press: move |_| cx.props.on_download.call(name.clone()),
             })
         })
     });
@@ -109,15 +114,17 @@ pub fn Message<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     ))
 }
 
-#[derive(PartialEq, Eq, Props)]
-pub struct AttachmentProps {
+#[derive(Props)]
+pub struct AttachmentProps<'a> {
     file: File,
+    on_press: EventHandler<'a, ()>,
 }
 
 #[allow(non_snake_case)]
-pub fn Attachment(cx: Scope<AttachmentProps>) -> Element {
+pub fn Attachment<'a>(cx: Scope<'a, AttachmentProps<'a>>) -> Element<'a> {
     let size = format_size(cx.props.file.size(), DECIMAL);
     let name = cx.props.file.name();
+
     cx.render(rsx! {
         div {
             class: "attachment-embed",
@@ -138,6 +145,7 @@ pub fn Attachment(cx: Scope<AttachmentProps>) -> Element {
                 button::Button {
                     icon: Icon::DocumentArrowDown,
                     text: String::new(),
+                    onpress: move |_| cx.props.on_press.call(()),
                 }
             }
         }

--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -121,7 +121,7 @@ pub struct AttachmentProps<'a> {
 }
 
 #[allow(non_snake_case)]
-pub fn Attachment<'a>(cx: Scope<'a, AttachmentProps<'a>>) -> Element<'a> {
+fn Attachment<'a>(cx: Scope<'a, AttachmentProps<'a>>) -> Element<'a> {
     let size = format_size(cx.props.file.size(), DECIMAL);
     let name = cx.props.file.name();
 

--- a/kit/src/components/message_reply/style.scss
+++ b/kit/src/components/message_reply/style.scss
@@ -1,12 +1,11 @@
 .message-reply {
 	border-radius: var(--border-radius-more);
 	border-bottom-right-radius: var(--border-radius);
-	min-height: var(--height-input);
+	min-height: calc(var(--height-input) / 1.25);
 	display: inline-flex;
 	align-items: center;
 	width: fit-content;
 	align-self: flex-end;
-	margin-top: calc(var(--gap) * 2);
 	position: relative;
 	.user-image {
 		transform: scale(0.75);

--- a/kit/src/components/message_typing/style.scss
+++ b/kit/src/components/message_typing/style.scss
@@ -1,6 +1,7 @@
 .message-typing-wrap {
 	display: inline-flex;
 	gap: var(--gap);
+	padding: var(--padding-less);
 }
 .message-typing {
 	min-height: var(--height-input);

--- a/launch_docker.sh
+++ b/launch_docker.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# arguments: 
+# $1: the docker container to run. ex: uplink-runner
+# $2: the docker volume to mount. ex: warp2
+
+# example docker file
+
+# description
+# bind the local X11 port to the docker container, allowing the docker container to execute GUI applications on Linux. 
+
+# from ubuntu:22.04
+# 
+# RUN apt-get update && apt-get install -y \
+# 	x11-apps \
+# 	xauth
+# 
+# RUN apt-get install -y \
+# 	libwebkit2gtk-4.0-37
+# 
+# RUN mkdir  /root/.uplink
+# WORKDIR /root/bin
+# 
+# CMD ["bash"]
+
+docker run -ti --rm --net=host -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix -v `pwd`/target:/root/bin -v $2:/root/.uplink $1 /bin/bash

--- a/quick_build.sh
+++ b/quick_build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh 
+
+# for most development, this cuts the rebuild time in half
+
+cargo build --package ui

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -461,7 +461,6 @@ fn get_messages(cx: Scope<ComposeProps>) -> Element {
                                                     key: "{message_key}",
                                                     remote: group.remote,
                                                     with_text: message.inner.value().join("\n"),
-                                                    in_reply_to: message.in_reply_to,
                                                     reactions: message.inner.reactions(),
                                                     order: if grouped_message.is_first { Order::First } else if grouped_message.is_last { Order::Last } else { Order::Middle },
                                                 }

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -7,7 +7,7 @@ use std::{
 use dioxus::prelude::*;
 
 use futures::{channel::oneshot, StreamExt};
-use humansize::{format_size, DECIMAL};
+
 use kit::{
     components::{
         context_menu::{ContextItem, ContextMenu},
@@ -42,7 +42,6 @@ use dioxus_desktop::{use_eval, use_window};
 use rfd::FileDialog;
 use uuid::Uuid;
 use warp::{
-    constellation::file::File,
     logging::tracing::log,
     raygun::{self, ReactionState},
 };
@@ -838,7 +837,6 @@ fn Attachments(cx: Scope<AttachmentProps>) -> Element {
         .props
         .files
         .current()
-        .clone()
         .iter()
         .map(|x| x.to_string_lossy().to_string())
         .map(|file_name| {

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -567,16 +567,18 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
 
     let files_to_upload: &UseState<Vec<PathBuf>> = use_state(cx, Vec::new);
 
-    // todo: use this to render the typing indicator
-    let users_typing = active_chat_id
+    // used to render the typing indicator
+    // for now it doesn't quite work for group messages
+    let is_typing = active_chat_id
         .and_then(|id| state.read().chats.all.get(&id).cloned())
         .map(|chat| {
             chat.participants
                 .iter()
                 .filter(|x| chat.typing_indicator.contains_key(&x.did_key()))
-                .map(|x| x.username())
-                .collect::<Vec<_>>()
-        });
+                .next()
+                .is_some()
+        })
+        .unwrap_or_default();
 
     let msg_ch = use_coroutine(
         cx,
@@ -821,9 +823,6 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
     let platform = Platform::Headless;
     let status = Status::Online;
 
-    // todo: make this look nice
-    let users_typing = users_typing.unwrap_or_default();
-    let is_typing = !users_typing.is_empty();
     cx.render(rsx!(
         is_typing.then(|| {
             rsx!(MessageTyping {

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -502,8 +502,6 @@ fn get_messages(cx: Scope<ComposeProps>) -> Element {
                                                     with_text: other_msg,
                                                     remote: group.remote,
                                                     remote_message: group.remote,
-                                                    // todo: translate this. possibly add the username 
-                                                    with_prefix: "replying to: ".into(),
                                                 }
                                             )),
                                             Message {
@@ -812,13 +810,21 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
         }))
     }));
 
+    let platform = Platform::Headless;
+    let status = Status::Online;
+
     // todo: make this look nice
     let users_typing = users_typing.unwrap_or_default();
     let is_typing = !users_typing.is_empty();
     cx.render(rsx!(
         is_typing.then(|| {
             rsx!(MessageTyping {
-                user_image: None
+                user_image: cx.render(rsx!(
+                    UserImage {
+                        platform: platform,
+                        status: status
+                    }
+                ))
             })
         })
         chatbar,

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -545,6 +545,7 @@ struct TypingInfo {
     pub last_update: Instant,
 }
 
+// todo: display loading indicator if sending a message that takes a long time to upload attachments
 fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
     log::trace!("get_chatbar");
     let state = use_shared_state::<State>(cx)?;

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -800,8 +800,15 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
             disabled: is_loading || is_reply,
             appearance: Appearance::Primary,
             onpress: move |_| {
-                if let Some(v) = FileDialog::new().set_directory(".").pick_files() {
-                    files_to_upload.set(v);
+                if let Some(new_files) = FileDialog::new().set_directory(".").pick_files() {
+                    let mut new_files_to_upload: Vec<_> = files_to_upload
+                        .current()
+                        .iter()
+                        .filter(|file_name| !new_files.contains(file_name))
+                        .cloned()
+                        .collect();
+                    new_files_to_upload.extend(new_files);
+                    files_to_upload.set(new_files_to_upload);
                 }
             },
             tooltip: cx.render(rsx!(Tooltip {

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -446,25 +446,22 @@ fn get_messages(cx: Scope<ComposeProps>) -> Element {
                                                 }
                                             },
                                         )),
-                                        match message.in_reply_to {
-                                            Some(other_msg) => rsx!(
-                                                MessageReply {
-                                                    key: "{message_key}",
-                                                    with_text: message.inner.value().join("\n"),
-                                                    remote: group.remote,
-                                                    remote_message: group.remote,
-                                                    with_prefix: other_msg,
-                                                }
-                                            ),
-                                            None => rsx!(
-                                                Message {
-                                                    key: "{message_key}",
-                                                    remote: group.remote,
-                                                    with_text: message.inner.value().join("\n"),
-                                                    reactions: message.inner.reactions(),
-                                                    order: if grouped_message.is_first { Order::First } else if grouped_message.is_last { Order::Last } else { Order::Middle },
-                                                }
-                                            )
+                                       message.in_reply_to.map(|other_msg| rsx!(
+                                            MessageReply {
+                                                key: "reply-{message_key}",
+                                                with_text: other_msg,
+                                                remote: group.remote,
+                                                remote_message: group.remote,
+                                                // todo: translate this. possibly add the username 
+                                                with_prefix: "replying to: ".into(),
+                                            }
+                                        )),
+                                        Message {
+                                            key: "{message_key}",
+                                            remote: group.remote,
+                                            with_text: message.inner.value().join("\n"),
+                                            reactions: message.inner.reactions(),
+                                            order: if grouped_message.is_first { Order::First } else if grouped_message.is_last { Order::Last } else { Order::Middle },
                                         },
                                     }
                                 )

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -12,6 +12,7 @@ use kit::{
         indicator::{Platform, Status},
         message::{Message, Order},
         message_group::{MessageGroup, MessageGroupSkeletal},
+        message_typing::MessageTyping,
         user_image::UserImage,
         user_image_group::UserImageGroup,
     },
@@ -489,7 +490,7 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
     let active_chat_id = data.as_ref().map(|d| d.active_chat.id);
 
     // todo: use this to render the typing indicator
-    let _users_typing = active_chat_id
+    let users_typing = active_chat_id
         .and_then(|id| state.read().chats.all.get(&id).cloned())
         .map(|chat| {
             chat.participants
@@ -657,7 +658,7 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
         .map(|(_, proxy)| rsx!(proxy.extension.render(cx)))
         .collect();
 
-    cx.render(rsx!(Chatbar {
+    let chatbar = cx.render(rsx!(Chatbar {
         loading: is_loading,
         placeholder: get_local_text("messages.say-something-placeholder"),
         reset: should_clear_input.clone(),
@@ -720,7 +721,19 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
                 text: get_local_text("files.upload"),
             }))
         }))
-    }))
+    }));
+
+    // todo: make this look nice
+    let users_typing = users_typing.unwrap_or_default();
+    let is_typing = !users_typing.is_empty();
+    cx.render(rsx!(
+        is_typing.then(|| {
+            rsx!(MessageTyping {
+                user_image: None
+            })
+        })
+        chatbar,
+    ))
 }
 
 fn get_platform_and_status(msg_sender: Option<&Identity>) -> (Platform, Status) {

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -709,8 +709,10 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
         }
     });
 
-    let msg_valid =
-        |msg: &[String]| !msg.is_empty() && msg.iter().any(|line| !line.trim().is_empty());
+    let msg_valid = |msg: &[String]| {
+        (!msg.is_empty() && msg.iter().any(|line| !line.trim().is_empty()))
+            || !files_to_upload.current().is_empty()
+    };
 
     let submit_fn = move || {
         local_typing_ch.send(TypingIndicator::NotTyping);

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -434,7 +434,9 @@ fn get_messages(cx: Scope<ComposeProps>) -> Element {
                                                 text: get_local_text("messages.react"),
                                                 //TODO: let the user pick a reaction
                                                 onpress: move |_| {
-                                                      // using "like" for now
+                                                    // todo: render this by default: ["❤️", "😂", "😍", "💯", "👍", "😮", "😢", "😡", "🤔", "😎"];
+                                                    // todo: allow emoji extension instead
+                                                    // using "like" for now
                                                     ch.send(MessagesCommand::React((message2.inner.clone(), "👍".into())));
                                                 }
                                             },
@@ -464,7 +466,7 @@ fn get_messages(cx: Scope<ComposeProps>) -> Element {
                                             with_text: message.inner.value().join("\n"),
                                             reactions: message.inner.reactions(),
                                             order: if grouped_message.is_first { Order::First } else if grouped_message.is_last { Order::Last } else { Order::Middle },
-                                            attachments: message.inner.attachments().iter().map(|f| f.name()).collect(),
+                                            attachments: message.inner.attachments(),
                                         },
                                     }
                                 )

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -493,28 +493,31 @@ fn get_messages(cx: Scope<ComposeProps>) -> Element {
                                                 }
                                             },
                                         )),
-                                       message.in_reply_to.map(|other_msg| rsx!(
+                                        div {
+                                            class: "msg-wrapper",
+                                            message.in_reply_to.map(|other_msg| rsx!(
                                             MessageReply {
-                                                key: "reply-{message_key}",
-                                                with_text: other_msg,
+                                                    key: "reply-{message_key}",
+                                                    with_text: other_msg,
+                                                    remote: group.remote,
+                                                    remote_message: group.remote,
+                                                    // todo: translate this. possibly add the username 
+                                                    with_prefix: "replying to: ".into(),
+                                                }
+                                            )),
+                                            Message {
+                                                key: "{message_key}",
                                                 remote: group.remote,
-                                                remote_message: group.remote,
-                                                // todo: translate this. possibly add the username 
-                                                with_prefix: "replying to: ".into(),
-                                            }
-                                        )),
-                                        Message {
-                                            key: "{message_key}",
-                                            remote: group.remote,
-                                            with_text: message.inner.value().join("\n"),
-                                            reactions: message.inner.reactions(),
-                                            order: if grouped_message.is_first { Order::First } else if grouped_message.is_last { Order::Last } else { Order::Middle },
-                                            attachments: message.inner.attachments(),
-                                            on_download: move |file_name| {
-                                                // todo: let the user pick the directory
-                                                ch.send(MessagesCommand::DownloadAttachment {conv_id: message4.inner.conversation_id(), msg_id: message4.inner.id(), file_name, directory: STATIC_ARGS.uplink_path.to_string_lossy().to_string() })
+                                                with_text: message.inner.value().join("\n"),
+                                                reactions: message.inner.reactions(),
+                                                order: if grouped_message.is_first { Order::First } else if grouped_message.is_last { Order::Last } else { Order::Middle },
+                                                attachments: message.inner.attachments(),
+                                                on_download: move |file_name| {
+                                                    // todo: let the user pick the directory
+                                                    ch.send(MessagesCommand::DownloadAttachment {conv_id: message4.inner.conversation_id(), msg_id: message4.inner.id(), file_name, directory: STATIC_ARGS.uplink_path.to_string_lossy().to_string() })
+                                                },
                                             },
-                                        },
+                                       }
                                     }
                                 )
                             })

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -12,6 +12,7 @@ use kit::{
         indicator::{Platform, Status},
         message::{Message, Order},
         message_group::{MessageGroup, MessageGroupSkeletal},
+        message_reply::MessageReply,
         message_typing::MessageTyping,
         user_image::UserImage,
         user_image_group::UserImageGroup,
@@ -445,13 +446,26 @@ fn get_messages(cx: Scope<ComposeProps>) -> Element {
                                                 }
                                             },
                                         )),
-                                        Message {
-                                            key: "{message_key}",
-                                            remote: group.remote,
-                                            with_text: message.inner.value().join("\n"),
-                                            in_reply_to: message.in_reply_to,
-                                            reactions: message.inner.reactions(),
-                                            order: if grouped_message.is_first { Order::First } else if grouped_message.is_last { Order::Last } else { Order::Middle },
+                                        match message.in_reply_to {
+                                            Some(other_msg) => rsx!(
+                                                MessageReply {
+                                                    key: "{message_key}",
+                                                    with_text: message.inner.value().join("\n"),
+                                                    remote: group.remote,
+                                                    remote_message: group.remote,
+                                                    with_prefix: other_msg,
+                                                }
+                                            ),
+                                            None => rsx!(
+                                                Message {
+                                                    key: "{message_key}",
+                                                    remote: group.remote,
+                                                    with_text: message.inner.value().join("\n"),
+                                                    in_reply_to: message.in_reply_to,
+                                                    reactions: message.inner.reactions(),
+                                                    order: if grouped_message.is_first { Order::First } else if grouped_message.is_last { Order::Last } else { Order::Middle },
+                                                }
+                                            )
                                         },
                                     }
                                 )

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -11,6 +11,7 @@ use futures::{channel::oneshot, StreamExt};
 use kit::{
     components::{
         context_menu::{ContextItem, ContextMenu},
+        file_embed::FileEmbed,
         indicator::{Platform, Status},
         message::{Message, Order},
         message_group::{MessageGroup, MessageGroupSkeletal},
@@ -839,6 +840,7 @@ pub struct AttachmentProps {
 
 #[allow(non_snake_case)]
 fn Attachments(cx: Scope<AttachmentProps>) -> Element {
+    // todo: pick an icon based on the file extension
     let attachments = cx.render(rsx!(cx
         .props
         .files
@@ -846,33 +848,19 @@ fn Attachments(cx: Scope<AttachmentProps>) -> Element {
         .iter()
         .map(|x| x.to_string_lossy().to_string())
         .map(|file_name| {
-            rsx!(
-                div {
-                    class: "attachment-embed",
-                    div {
-                        class: "embed-icon",
-                        common::icons::Icon {
-                            icon: Icon::Document,
-                        },
-                        h2 {
-                            "{file_name}"
-                        }
-                    }
-                    div {
-                        class: "embed-details",
-                        Button {
-                            icon: Icon::DocumentMinus,
-                            text: String::new(),
-                            onpress: move |_| {
-                                cx.props.files.with_mut(|files| files.retain(|x| {
-                                     let s = x.to_string_lossy().to_string();
-                                    s != file_name
-                                }));
-                            },
-                        }
-                    }
-                }
-            )
+            rsx!(FileEmbed {
+                filename: file_name.clone(),
+                remote: false,
+                button_icon: Icon::Trash,
+                on_press: move |_| {
+                    cx.props.files.with_mut(|files| {
+                        files.retain(|x| {
+                            let s = x.to_string_lossy().to_string();
+                            s != file_name
+                        })
+                    });
+                },
+            })
         })));
 
     cx.render(rsx!(div {

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -307,7 +307,7 @@ enum MessagesCommand {
         conv_id: Uuid,
         msg_id: Uuid,
         file_name: String,
-        directory: String,
+        directory: PathBuf,
     },
 }
 
@@ -513,8 +513,15 @@ fn get_messages(cx: Scope<ComposeProps>) -> Element {
                                                 order: if grouped_message.is_first { Order::First } else if grouped_message.is_last { Order::Last } else { Order::Middle },
                                                 attachments: message.inner.attachments(),
                                                 on_download: move |file_name| {
-                                                    // todo: let the user pick the directory
-                                                    ch.send(MessagesCommand::DownloadAttachment {conv_id: message4.inner.conversation_id(), msg_id: message4.inner.id(), file_name, directory: STATIC_ARGS.uplink_path.to_string_lossy().to_string() })
+                                                    if let Some(directory) = FileDialog::new()
+                                                    .set_directory(dirs::home_dir().unwrap_or_default())
+                                                    .pick_folder() {
+                                                        ch.send(MessagesCommand::DownloadAttachment {
+                                                            conv_id: message4.inner.conversation_id(),
+                                                            msg_id: message4.inner.id(),
+                                                            file_name, directory
+                                                        })
+                                                    }
                                                 },
                                             },
                                        }

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -569,15 +569,10 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
 
     // used to render the typing indicator
     // for now it doesn't quite work for group messages
+    let my_id = state.read().account.identity.did_key();
     let is_typing = active_chat_id
         .and_then(|id| state.read().chats.all.get(&id).cloned())
-        .map(|chat| {
-            chat.participants
-                .iter()
-                .filter(|x| chat.typing_indicator.contains_key(&x.did_key()))
-                .next()
-                .is_some()
-        })
+        .map(|chat| chat.typing_indicator.iter().any(|(id, _)| id != &my_id))
         .unwrap_or_default();
 
     let msg_ch = use_coroutine(

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -1,4 +1,5 @@
 use std::{
+    path::PathBuf,
     rc::Rc,
     time::{Duration, Instant},
 };
@@ -35,6 +36,7 @@ use common::{
 
 use common::language::get_local_text;
 use dioxus_desktop::{use_eval, use_window};
+use rfd::FileDialog;
 use uuid::Uuid;
 use warp::{
     logging::tracing::log,
@@ -451,6 +453,7 @@ fn get_messages(cx: Scope<ComposeProps>) -> Element {
                                             in_reply_to: message.in_reply_to,
                                             reactions: message.inner.reactions(),
                                             order: if grouped_message.is_first { Order::First } else if grouped_message.is_last { Order::Last } else { Order::Middle },
+                                            attachments: message.inner.attachments().iter().map(|f| f.name()).collect(),
                                         },
                                     }
                                 )
@@ -488,6 +491,19 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
     let should_clear_input = use_state(cx, || false);
     let active_chat_id = data.as_ref().map(|d| d.active_chat.id);
 
+    let is_reply = active_chat_id
+        .and_then(|id| {
+            state
+                .read()
+                .chats
+                .all
+                .get(&id)
+                .map(|chat| chat.replying_to.is_some())
+        })
+        .unwrap_or(false);
+
+    let files_to_upload: &UseRef<Option<Vec<PathBuf>>> = use_ref(cx, || None);
+
     // todo: use this to render the typing indicator
     let _users_typing = active_chat_id
         .and_then(|id| state.read().chats.all.get(&id).cloned())
@@ -502,7 +518,7 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
     let msg_ch = use_coroutine(
         cx,
         |mut rx: UnboundedReceiver<(Vec<String>, Uuid, Option<Uuid>)>| {
-            //to_owned![];
+            to_owned![files_to_upload];
             async move {
                 let warp_cmd_tx = WARP_CMD_CH.tx.clone();
                 while let Some((msg, conv_id, reply)) = rx.next().await {
@@ -514,12 +530,17 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
                             msg,
                             rsp: tx,
                         },
-                        None => RayGunCmd::SendMessage {
-                            conv_id,
-                            msg,
-                            rsp: tx,
-                        },
+                        None => {
+                            let attachments = files_to_upload.read().clone().unwrap_or_default();
+                            RayGunCmd::SendMessage {
+                                conv_id,
+                                msg,
+                                attachments,
+                                rsp: tx,
+                            }
+                        }
                     };
+                    *files_to_upload.write_silent() = None;
                     if let Err(e) = warp_cmd_tx.send(WarpCmd::RayGun(cmd)) {
                         log::error!("failed to send warp command: {}", e);
                         continue;
@@ -713,8 +734,11 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
             .unwrap_or(None),
         with_file_upload: cx.render(rsx!(Button {
             icon: Icon::Plus,
-            disabled: is_loading,
+            disabled: is_loading || is_reply,
             appearance: Appearance::Primary,
+            onpress: move |_| {
+                *files_to_upload.write_silent() = FileDialog::new().set_directory(".").pick_files();
+            },
             tooltip: cx.render(rsx!(Tooltip {
                 arrow_position: ArrowPosition::Bottom,
                 text: get_local_text("files.upload"),

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -797,7 +797,10 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
             disabled: is_loading || is_reply,
             appearance: Appearance::Primary,
             onpress: move |_| {
-                if let Some(new_files) = FileDialog::new().set_directory(".").pick_files() {
+                if let Some(new_files) = FileDialog::new()
+                    .set_directory(dirs::home_dir().unwrap_or_default())
+                    .pick_files()
+                {
                     let mut new_files_to_upload: Vec<_> = files_to_upload
                         .current()
                         .iter()

--- a/ui/src/components/chat/style.scss
+++ b/ui/src/components/chat/style.scss
@@ -32,6 +32,16 @@
     flex-direction: column;
 }
 
+#compose-attachments {
+    display: inline-flex;
+    flex-direction: row;
+
+    .attachment-embed {
+        display: inline-flex;
+        flex-direction: column;
+    }
+}
+
 #compose #messages {
     flex: 1;
     width: 100%;

--- a/ui/src/components/chat/style.scss
+++ b/ui/src/components/chat/style.scss
@@ -35,11 +35,6 @@
 #compose-attachments {
     display: inline-flex;
     flex-direction: row;
-
-    .attachment-embed {
-        display: inline-flex;
-        flex-direction: column;
-    }
 }
 
 #compose #messages {

--- a/ui/src/components/chat/style.scss
+++ b/ui/src/components/chat/style.scss
@@ -57,6 +57,11 @@
                 justify-content: flex-start;
             }
         }
+
+        .msg-wrapper {
+            display: flex;
+            flex-direction: column;
+        }
     }
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- typing indicator: shows in chatbar and sidebar. displays the user's icon rather than the username. multiple typing indicators, such as for group messages, have not yet been implemented. 
- replies: see pictures 
- attachments: allow the user to attach and send multiple files. prior to sending, attachments may be removed via the trashcan icon. 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

![image](https://user-images.githubusercontent.com/8636602/221901779-92fb723a-1aa3-4ab1-a07d-8ec75557f5c5.png)
![image](https://user-images.githubusercontent.com/8636602/221902106-6b19ee28-1a3f-4cbd-b449-c5f56c13bd08.png)
![image](https://user-images.githubusercontent.com/8636602/221902144-712ef39a-e62f-4ac9-baed-7b38420d30af.png)
