### PR TITLE
chore(directories): rename uplink directory

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -91,7 +91,7 @@ pub static STATIC_ARGS: Lazy<StaticArgs> = Lazy::new(|| {
         Some(path) => path,
         _ => dirs::home_dir().unwrap_or_default().join(".uplink"),
     };
-    let uplink_path = uplink_container.join("uplink");
+    let uplink_path = uplink_container.join(".user");
     let warp_path = uplink_path.join("warp");
     StaticArgs {
         uplink_path: uplink_path.clone(),

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -96,7 +96,7 @@ pub enum AuthPages {
 }
 
 fn copy_assets() {
-    let themes_dest = &STATIC_ARGS.uplink_path;
+    let themes_dest = &STATIC_ARGS.themes_path;
     let themes_src = Path::new("ui").join("extra").join("themes");
 
     match create_all(themes_dest.clone(), false) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- uplink has an application directory called `.uplink`. this PR renames a folder within that directory. 
- tested on Linux and Mac, and  couldn't replicate #320
- the rational behind renaming `.uplink/uplink` to `.uplink/.user` (at least adding the leading `.` to hide the file) is that this directory, which contains `state.json` and the `warp` folder, isn't meant to be modified by the user, while `.uplink/extensions` and `.uplink/themes` expect user interaction. 

### Which issue(s) this PR fixes 🔨

- Resolve #320

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

