### PR TITLE
fix(windows): remove transparency support . . . known issue on windows

### DIFF
--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -21,7 +21,6 @@ extensions = { path = "../extensions" }
 tokio-util = { version = "0.7", features = ["full"] }
 arboard = "3.1.0"
 humansize = "2.1.3"
-window-vibrancy = "0.3.2"
 uuid = { version = "1.0", features = ["serde", "v4"] }
 libloading = "0.7.4"
 warp = { git = "https://github.com/Satellite-im/Warp", rev = "a7e075238ee926919894cb27d743284ed3724dc2" }

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -21,6 +21,7 @@ extensions = { path = "../extensions" }
 tokio-util = { version = "0.7", features = ["full"] }
 arboard = "3.1.0"
 humansize = "2.1.3"
+window-vibrancy = "0.3.2"
 uuid = { version = "1.0", features = ["serde", "v4"] }
 libloading = "0.7.4"
 warp = { git = "https://github.com/Satellite-im/Warp", rev = "a7e075238ee926919894cb27d743284ed3724dc2" }

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -248,13 +248,6 @@ fn bootstrap(cx: Scope) -> Element {
         height: 300.0,
     });
 
-    #[cfg(target_os = "windows")]
-    {
-        #[allow(unused_imports)]
-        use raw_window_handle::HasRawWindowHandle;
-        window_vibrancy::apply_acrylic(&**desktop, None)
-            .expect("Unsupported platform! 'apply_blur' is only supported on Windows");
-    }
     cx.render(rsx!(crate::auth_page_manager {}))
 }
 


### PR DESCRIPTION
### What this PR does 📖

Removes OS based transparency which we were not using anyway and was causing unbearable slowness for Windows 10 even on powerful computers.  It's also an issue on certain builds of Windows 11.

### Which issue(s) this PR fixes 🔨

- none! Fixed it too fast! :)

### Special notes for reviewers 🗒️

I was the only one seeing the bug, likely because I'm the only one on Windows 10. According to the docs it's a known issue on Windows 10 and 11.  [Here is a link for more.](https://github.com/tauri-apps/window-vibrancy)



