### PR TITLE
chore(appium): update GH action for UI Tests on MacOS

### DIFF
--- a/.github/workflows/ui-test-execution.yml
+++ b/.github/workflows/ui-test-execution.yml
@@ -126,6 +126,13 @@ jobs:
         working-directory: ./appium-tests
         run: npm run mac.ci
 
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        if: always()
+        with:
+          junit_files: "./appium-tests/test-report/*.xml"
+          check_name: "UI Automated Test Results on MacOS"
+
       - name: Upload Screenshots if tests failed 📷
         uses: actions/upload-artifact@v3
         if: failure()
@@ -145,31 +152,3 @@ jobs:
         if: failure()
         with:
           file-name: "desktop.jpg"
-
-      - name: Publish JUnit reports ⬆️
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: junit-results
-          path: ./appium-tests/test-report/*.xml
-
-  publish:
-    needs: test
-    if: always()
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout directory 🔖
-        uses: actions/checkout@v3
-
-      - name: Download JUnit results 🗳️
-        uses: actions/download-artifact@v3
-        with:
-          name: junit-results
-          path: ./junit-results
-
-      - name: Publish Test Results 📢
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        with:
-          junit_files: "junit-results/*.xml"
-          check_name: "UI Automated Test Results on MacOS"


### PR DESCRIPTION
### What this PR does 📖

- The GH action executing UI tests for MacOS was doing an unnecessary third job to publish the test results, and then somehow if tests were failing the publish result appeared as green and was looking weird in my opinion. I found a way to move it inside the same test job so I am sending a PR with this small change

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

