### PR TITLE
Fix blank language dropdown on new accounts

### DIFF
--- a/common/src/language/mod.rs
+++ b/common/src/language/mod.rs
@@ -6,7 +6,7 @@ use warp::sync::RwLock;
 
 use crate::LOCALES;
 
-const US_ENGLISH: (LanguageIdentifier, &str) = (langid!("en-US"), "English (USA)");
+pub const US_ENGLISH: (LanguageIdentifier, &str) = (langid!("en-US"), "English (USA)");
 const BR_PORTUGUESE: (LanguageIdentifier, &str) = (langid!("pt-BR"), "Português (Brasil)");
 const PT_PORTUGUESE: (LanguageIdentifier, &str) = (langid!("pt-PT"), "Português (Portugal)");
 const MX_SPANISH: (LanguageIdentifier, &str) = (langid!("es-MX"), "Español (México)");

--- a/common/src/state/settings.rs
+++ b/common/src/state/settings.rs
@@ -1,8 +1,21 @@
+use crate::language::US_ENGLISH;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Settings {
     // Selected Language
-    #[serde(default)]
+    #[serde(default = "default_lang")]
     pub language: String,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Settings {
+            language: default_lang(),
+        }
+    }
+}
+
+fn default_lang() -> String {
+    US_ENGLISH.1.to_string()
 }


### PR DESCRIPTION
### What this PR does 📖

- Fixes the language dropdown on a new account being empty

### Which issue(s) this PR fixes 🔨

- Resolves #249

