### PR TITLE
chore(appium): update to GH workflow for MacOS tests

### DIFF
--- a/.github/workflows/ui-test-execution.yml
+++ b/.github/workflows/ui-test-execution.yml
@@ -111,16 +111,14 @@ jobs:
 
       - name: Install and Run Appium Server 💻
         run: |
-          chmod +x ./appium-tests/scripts/run_appium_macos_server.sh
-          ./appium-tests/scripts/run_appium_macos_server.sh
+          npm install -g appium@next
+          appium -v
+          appium driver install mac2
+          appium driver list
+          appium &>/dev/null &
 
       - name: Validations before starting appium ✅
-        run: |
-          cd appium-tests/apps
-          ls -la
-          cd /Applications/
-          ls -la
-          rm -rf ~/.uplink
+        run: rm -rf ~/.uplink
 
       - name: Run WebdriverIO tests on MacOS 🧪
         working-directory: ./appium-tests


### PR DESCRIPTION
### What this PR does 📖

- I am going to remove the run_appium_macos_server.sh file on testing-uplink repo since the steps contained on this file can be manually added into the github workflow file.
- This PR is adding these steps and avoiding the use of run_appium_macos_server.sh file, that will be removed later from appium repo. These steps install the latest version of appium, the driver for macos and start the server, so the tests can be executed in a later step.
- Removed unnecessary steps from Github workflow (ls -la that were used to debug when I was implementing this workflow)

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

