### PR TITLE
add(config): add launch.json for VSC

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+    // Debug runs using breakpoints.
+    // Needs the CodeLLDB plugin for vsc
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "UI Debug",
+            "type": "lldb",
+            "request": "launch",
+            "program": "${workspaceRoot}/target/debug/ui",
+            "cwd": "${workspaceRoot}"
+        },
+        {
+            "name": "UI Debug With Mock",
+            "type": "lldb",
+            "request": "launch",
+            "program": "${workspaceRoot}/target/debug/ui",
+            "args": [
+                "--with-mock"
+            ],
+            "cwd": "${workspaceRoot}"
+        }
+    ]
+}


### PR DESCRIPTION
### What this PR does 📖

- Adds a launch.json for vsc for debug runs using breakpoints. Might be useful for those who use breakpoints in vsc.


![Screenshot from 2023-03-03 13-17-50](https://user-images.githubusercontent.com/34157027/222718244-0de86599-8817-41fc-b517-a549eb9bced2.png)
