### PR TITLE
fix(friends): remove Favorite/Unfavorite option for not initialized chat

### DIFF
--- a/ui/src/components/friends/friends_list/mod.rs
+++ b/ui/src/components/friends/friends_list/mod.rs
@@ -164,7 +164,7 @@ pub fn Friends(cx: Scope) -> Element {
                             let chat = state.read().get_chat_with_friend(&friend);
                             let chat2 = chat.clone();
                             let chat3 = chat.clone();
-                            let favorite = chat.clone().map(|c| state.read().is_favorite(&c)).unwrap_or_default();
+                            let favorite = chat.clone().map(|c| state.read().is_favorite(&c));
                             let did_suffix: String = did.to_string().chars().rev().take(6).collect();
                             let remove_friend = friend.clone();
                             let remove_friend_2 = friend.clone();
@@ -196,16 +196,18 @@ pub fn Friends(cx: Scope) -> Element {
                                             text: get_local_text("uplink.call"),
                                             // TODO: Wire this up to state
                                         },
-                                        ContextItem {
-                                            icon: if favorite {Icon::HeartSlash} else {Icon::Heart},
-                                            text: get_local_text(if favorite {"favorites.remove"} else {"favorites.favorites"}),
-                                            onpress: move |_| {
-                                                // can't favorite a non-existent conversation
-                                                // todo: don't even allow favoriting from the friends page unless there's a conversation
-                                                if let Some(c) = &chat {
-                                                    state.write().mutate(Action::ToggleFavorite(c.clone()));
+                                        if let Some(f) = favorite {
+                                            rsx!(ContextItem {
+                                                icon: if f {Icon::HeartSlash} else {Icon::Heart},
+                                                text: get_local_text(if f {"favorites.remove"} else {"favorites.favorites"}),
+                                                onpress: move |_| {
+                                                    // can't favorite a non-existent conversation
+                                                    // todo: don't even allow favoriting from the friends page unless there's a conversation
+                                                    if let Some(c) = &chat {
+                                                        state.write().mutate(Action::ToggleFavorite(c.clone()));
+                                                    }
                                                 }
-                                            }
+                                            })
                                         },
                                         hr{}
                                         ContextItem {


### PR DESCRIPTION
### What this PR does 📖

- Removes the favorite/unfavorite menu when there is not a chat created for the given friend yet

### Which issue(s) this PR fixes 🔨

- Resolve #368 

