### PR TITLE
feat(chat): Default sidebar message for new chat

### DIFF
--- a/common/locales/en-US/main.ftl
+++ b/common/locales/en-US/main.ftl
@@ -193,3 +193,4 @@ auth = Create Account
 
 sidebar = Sidebar 
     .subtext = sent multiple attachments
+    .chat-new = No messages sent yet, send one!

--- a/ui/src/components/chat/sidebar.rs
+++ b/ui/src/components/chat/sidebar.rs
@@ -215,13 +215,14 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
                     let subtext_val = match unwrapped_message.value().iter().map(|x| x.trim()).find(|x| !x.is_empty()) {
                         Some(v) => v.into(),
                         _ => match &unwrapped_message.attachments()[..] {
-                            [] => String::new(),
+                            [] => get_local_text("sidebar.chat-new"),
                             [ file ] => file.name(),
                             _ => match chat.participants.iter().find(|p| p.did_key() == unwrapped_message.sender()).map(|x| x.username()) {
                                 Some(name) => format!("{name} {}", get_local_text("sidebar.subtext")),
                                 None => {
                                     log::error!("error calculating subtext for sidebar chat");
-                                    String::new()
+                                    // Still return default message
+                                    get_local_text("sidebar.chat-new")
                                 }
                             }
                         }


### PR DESCRIPTION
### What this PR does 📖

- Adds a default message in the sidebar when user has an empty chat with someone

### Which issue(s) this PR fixes 🔨

- Resolve #232

### Special notes for reviewers 🗒️

- Translation key only added for en