### PR TITLE
feat(friends): Add "accept" option to pending friend context menu

### DIFF
--- a/ui/src/components/friends/incoming_requests/mod.rs
+++ b/ui/src/components/friends/incoming_requests/mod.rs
@@ -86,9 +86,10 @@ pub fn PendingFriends(cx: Scope) -> Element {
                 let mut rng = rand::thread_rng();
                 let did = friend.did_key();
                 let did_suffix: String = did.to_string().chars().rev().take(6).collect();
-                let friend_clone = friend.clone();
-                let friend_clone_clone = friend.clone();
-                let friend_clone_clone_clone = friend.clone();
+                let friend_clone_accept = friend.clone();
+                let friend_clone_remove = friend.clone();
+                let friend_clone_ctx_accept = friend.clone();
+                let friend_clone_ctx_deny = friend.clone();
                 let platform = match friend.platform() {
                     warp::multipass::identity::Platform::Desktop => Platform::Desktop,
                     warp::multipass::identity::Platform::Mobile => Platform::Mobile,
@@ -101,16 +102,28 @@ pub fn PendingFriends(cx: Scope) -> Element {
                         items: cx.render(rsx!(
                             ContextItem {
                                 danger: true,
+                                icon: Icon::Check,
+                                text: get_local_text("friends.accept"),
+                                onpress: move |_| {
+                                    if STATIC_ARGS.use_mock {
+                                        state.write().mutate(Action::AcceptRequest(friend_clone_ctx_accept.clone()));
+                                    } else {
+                                       ch.send(ChanCmd::AcceptRequest(friend_clone_ctx_accept.clone()));
+                                    }
+                                }
+                            },
+                            ContextItem {
+                                danger: true,
                                 icon: Icon::XMark,
                                 text: get_local_text("friends.deny"),
                                 onpress: move |_| {
                                     if STATIC_ARGS.use_mock {
-                                        state.write().mutate(Action::DenyRequest(friend_clone_clone_clone.clone()));
+                                        state.write().mutate(Action::DenyRequest(friend_clone_ctx_deny.clone()));
                                     } else {
-                                       ch.send(ChanCmd::DenyRequest(friend_clone_clone_clone.clone()));
+                                       ch.send(ChanCmd::DenyRequest(friend_clone_ctx_deny.clone()));
                                     }
                                 }
-                            },
+                            }
                         )),
                         Friend {
                             username: friend.username(),
@@ -131,17 +144,17 @@ pub fn PendingFriends(cx: Scope) -> Element {
                             )),
                             onaccept: move |_| {
                                 if STATIC_ARGS.use_mock {
-                                    state.write().mutate(Action::AcceptRequest(friend_clone.clone()));
+                                    state.write().mutate(Action::AcceptRequest(friend_clone_accept.clone()));
                                 } else {
-                                     ch.send(ChanCmd::AcceptRequest(friend_clone.clone()));
+                                     ch.send(ChanCmd::AcceptRequest(friend_clone_accept.clone()));
                                 }
 
                             },
                             onremove: move |_| {
                                 if STATIC_ARGS.use_mock {
-                                    state.write().mutate(Action::AcceptRequest(friend_clone_clone.clone()));
+                                    state.write().mutate(Action::AcceptRequest(friend_clone_remove.clone()));
                                 } else {
-                                    ch.send(ChanCmd::DenyRequest(friend_clone_clone.clone()));
+                                    ch.send(ChanCmd::DenyRequest(friend_clone_remove.clone()));
                                 }
                             }
                         }


### PR DESCRIPTION
### What this PR does 📖

- Adds the option to accept/deny friend requests via context menu

### Which issue(s) this PR fixes 🔨

- Resolve #180 

### Additional comments 🎤

IMO the issue seems to add a redundant feature as you are already able to accept/deny via button right next to it.

![Screenshot from 2023-03-06 17-25-19](https://user-images.githubusercontent.com/34157027/223171478-c01ecb4e-1d90-4b05-9d24-4c5a9b5beafb.png)
