### PR TITLE
chore(appium): remove step to run appium server in background

### DIFF
--- a/.github/workflows/ui-test-execution.yml
+++ b/.github/workflows/ui-test-execution.yml
@@ -115,7 +115,6 @@ jobs:
           appium -v
           appium driver install mac2
           appium driver list
-          appium &>/dev/null &
 
       - name: Validations before starting appium ✅
         run: rm -rf ~/.uplink

--- a/.github/workflows/ui-test-windows.yml
+++ b/.github/workflows/ui-test-windows.yml
@@ -97,7 +97,6 @@ jobs:
           appium -v
           appium driver install --source=npm appium-windows-driver
           appium driver list
-          appium &>/dev/null &
 
       - name: Delete cache folder before starting
         run: If (Test-Path $home/.uplink) {Remove-Item -Recurse -Force $home/.uplink} Else { Break }

--- a/.github/workflows/ui-test-windows.yml
+++ b/.github/workflows/ui-test-windows.yml
@@ -35,12 +35,6 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      - name: Setup cmake 🛠️
-        uses: jwlawson/actions-setup-cmake@v1.13
-
-      - name: Use cmake 💿
-        run: cmake --version
-
       - name: Install Protobuf 💿
         uses: arduino/setup-protoc@v1
         with:


### PR DESCRIPTION
### What this PR does 📖

- I did some updates on the appium repository to start the appium server using wdio/appium service instead of manually running the server, so I need to remove this step: "appium &>/dev/null &" on the appium GH actions.
- This should help to avoid the random ECONNREFUSED issues presented in CI
- Sending as draft to see if CI passes first. I will remove the draft label once that I see both Gh actions are green

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

