### PR TITLE
feat(language): Make adding languages easier

### DIFF
--- a/common/src/language/mod.rs
+++ b/common/src/language/mod.rs
@@ -1,8 +1,6 @@
 use std::collections::HashMap;
 
-use fluent_templates::{
-    lazy_static::lazy_static, once_cell::sync::Lazy, LanguageIdentifier, Loader,
-};
+use fluent_templates::{once_cell::sync::Lazy, LanguageIdentifier, Loader};
 use unic_langid::langid;
 use warp::sync::RwLock;
 
@@ -10,22 +8,20 @@ use crate::LOCALES;
 
 pub const US_ENGLISH: (LanguageIdentifier, &str) = (langid!("en-US"), "English (USA)");
 
-lazy_static! {
-    static ref LANGUAGES: HashMap<String, (LanguageIdentifier, &'static str)> = {
-        let mut map = HashMap::new();
+static LANGUAGES: Lazy<HashMap<String, (LanguageIdentifier, &'static str)>> = Lazy::new(|| {
+    let mut map = HashMap::new();
 
-        let add = |map: &mut HashMap<String, (LanguageIdentifier, &'static str)>,
-                   lang: &(LanguageIdentifier, &'static str)| {
-            map.insert(lang.1.to_string(), lang.to_owned());
-        };
-
-        add(&mut map, &US_ENGLISH);
-        add(&mut map, &(langid!("pt-BR"), "Português (Brasil)"));
-        add(&mut map, &(langid!("pt-PT"), "Português (Portugal)"));
-        add(&mut map, &(langid!("es-MX"), "Español (México)"));
-        map
+    let add = |map: &mut HashMap<String, (LanguageIdentifier, &'static str)>,
+               lang: &(LanguageIdentifier, &'static str)| {
+        map.insert(lang.1.to_string(), lang.to_owned());
     };
-}
+
+    add(&mut map, &US_ENGLISH);
+    add(&mut map, &(langid!("pt-BR"), "Português (Brasil)"));
+    add(&mut map, &(langid!("pt-PT"), "Português (Portugal)"));
+    add(&mut map, &(langid!("es-MX"), "Español (México)"));
+    map
+});
 
 static APP_LANG: Lazy<RwLock<(LanguageIdentifier, &str)>> = Lazy::new(|| RwLock::new(US_ENGLISH));
 


### PR DESCRIPTION
### What this PR does 📖

The goal of this PR is to make adding more language easier. For the previous version to add another language one had to change things at 3 location:
1. Create a const
2. Add the const to the Hashmap of `change_language::change_language`
3. Add the const to `change_language::get_available_languages` 

With this new version the only thing thats needed is to add the new language to the map of `LANGUAGES`. One could still define the language as a constant in addition to that (if e.g. a reference of it is needed elsewhere like the default english lang) but that is not needed.

Something to note is that the LANGUAGES is now a static map so it looses advantages of constant lang fields (like compiler inlining) but i dont think this will be much an issue.