### PR TITLE
chore(state): unify data model concerning identities

### DIFF
--- a/common/src/state/action.rs
+++ b/common/src/state/action.rs
@@ -103,8 +103,8 @@ pub enum Action {
     CancelRequest(Identity),
 
     /// Handle a new incoming friend request
-    #[display(fmt = "IncomingRequest")]
-    IncomingRequest(Identity),
+    // #[display(fmt = "IncomingRequest")]
+    // IncomingRequest(Identity),
     /// Accept an incoming friend request
     #[display(fmt = "AcceptRequest")]
     AcceptRequest(Identity),

--- a/common/src/state/chats.rs
+++ b/common/src/state/chats.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     time::Instant,
 };
 
@@ -8,8 +8,6 @@ use uuid::Uuid;
 use warp::{crypto::DID, raygun::Message};
 
 use crate::{warp_runner::ui_adapter, STATIC_ARGS};
-
-use super::identity::Identity;
 
 // warning: Chat implements Serialize
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
@@ -21,7 +19,7 @@ pub struct Chat {
     // Includes the list of participants within a given chat.
     // these don't need to be stored in state either
     #[serde(default)]
-    pub participants: Vec<Identity>,
+    pub participants: HashSet<DID>,
     // Messages should only contain messages we want to render. Do not include the entire message history.
     // don't store the actual message in state
     #[serde(default)]

--- a/common/src/state/chats.rs
+++ b/common/src/state/chats.rs
@@ -39,7 +39,7 @@ pub struct Chat {
 // warning: Chats implements Serialize
 #[derive(Clone, Debug, Default, Deserialize)]
 pub struct Chats {
-    #[serde(default)]
+    #[serde(skip)]
     pub initialized: bool,
     // All active chats from warp.
     #[serde(skip)]

--- a/common/src/state/chats.rs
+++ b/common/src/state/chats.rs
@@ -42,7 +42,7 @@ pub struct Chats {
     #[serde(default)]
     pub initialized: bool,
     // All active chats from warp.
-    #[serde(default)]
+    #[serde(skip)]
     pub all: HashMap<Uuid, Chat>,
     // Chat to display / interact with currently.
     #[serde(default)]
@@ -57,10 +57,6 @@ pub struct Chats {
     // Favorite Chats
     #[serde(default)]
     pub favorites: Vec<Uuid>,
-}
-pub enum Direction {
-    Incoming,
-    Outgoing,
 }
 
 impl Chats {

--- a/common/src/state/friends.rs
+++ b/common/src/state/friends.rs
@@ -1,10 +1,9 @@
 use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use warp::crypto::DID;
 
 use crate::STATIC_ARGS;
 
-use super::identity::Identity;
 // warning: Friends implements Serialize
 #[derive(Clone, Debug, Default, Deserialize)]
 pub struct Friends {
@@ -13,15 +12,15 @@ pub struct Friends {
     pub initialized: bool,
     // All active friends.
     #[serde(default)]
-    pub all: HashMap<DID, Identity>,
+    pub all: HashSet<DID>,
     // List of friends the user has blocked
     #[serde(default)]
-    pub blocked: HashSet<Identity>,
+    pub blocked: HashSet<DID>,
     // Friend requests, incoming and outgoing.
     #[serde(default)]
-    pub incoming_requests: HashSet<Identity>,
+    pub incoming_requests: HashSet<DID>,
     #[serde(default)]
-    pub outgoing_requests: HashSet<Identity>,
+    pub outgoing_requests: HashSet<DID>,
 }
 
 // don't skip friends data when using mock data

--- a/common/src/state/friends.rs
+++ b/common/src/state/friends.rs
@@ -8,7 +8,7 @@ use crate::STATIC_ARGS;
 #[derive(Clone, Debug, Default, Deserialize)]
 pub struct Friends {
     // becomes true when the friends fields have been retrieved from Warp
-    #[serde(default)]
+    #[serde(skip)]
     pub initialized: bool,
     // All active friends.
     #[serde(default)]

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -73,7 +73,9 @@ pub struct State {
     pub configuration: configuration::Configuration,
     #[serde(skip_serializing, skip_deserializing)]
     pub(crate) hooks: Vec<action::ActionHook>,
-    #[serde(skip)]
+
+    // let's persist these for now.
+    #[serde(default)]
     identities: HashMap<DID, identity::Identity>,
 }
 
@@ -196,6 +198,10 @@ impl State {
             .filter_map(|did| self.identities.get(did))
             .cloned()
             .collect()
+    }
+
+    pub fn account(&self) -> &account::Account {
+        &self.account
     }
 
     pub fn set_account(&mut self, account: account::Account) {
@@ -557,7 +563,9 @@ impl State {
         // Remove the identity from the outgoing requests list if they are present
         self.friends.outgoing_requests.remove(&identity.did_key());
         self.friends.incoming_requests.remove(&identity.did_key());
-        self.identities.remove(&identity.did_key());
+
+        // still want the username to appear in the blocked list
+        //self.identities.remove(&identity.did_key());
 
         // Remove the identity from the friends list if they are present
         self.remove_friend(&identity.did_key());
@@ -660,14 +668,6 @@ impl State {
                 chat.participants.len() == 2 && chat.participants.contains(&friend.did_key())
             })
             .cloned()
-    }
-
-    pub fn get_without_me(&self, identities: &[DID]) -> Vec<DID> {
-        identities
-            .iter()
-            .filter(|identity| **identity != self.account.identity.did_key())
-            .cloned()
-            .collect()
     }
 
     pub fn has_friend_with_did(&self, did: &DID) -> bool {

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -109,163 +109,6 @@ impl Clone for State {
     }
 }
 
-impl State {
-    pub fn mock(
-        my_id: Identity,
-        identities: HashMap<DID, Identity>,
-        chats: chats::Chats,
-        friends: friends::Friends,
-        storage: Storage,
-    ) -> Self {
-        Self {
-            account: Account { identity: my_id },
-            settings: Settings {
-                language: "English (USA)".into(),
-            },
-            route: Route { active: "/".into() },
-            storage,
-            chats,
-            friends,
-            identities,
-            ..Default::default()
-        }
-    }
-    pub fn friends(&self) -> &friends::Friends {
-        &self.friends
-    }
-
-    pub fn friend_identities(&self) -> Vec<Identity> {
-        self.friends
-            .all
-            .iter()
-            .filter_map(|did| self.identities.get(did))
-            .cloned()
-            .collect()
-    }
-
-    pub fn incoming_fr_identities(&self) -> Vec<Identity> {
-        self.friends
-            .incoming_requests
-            .iter()
-            .filter_map(|did| self.identities.get(did))
-            .cloned()
-            .collect()
-    }
-
-    pub fn outgoing_fr_identities(&self) -> Vec<Identity> {
-        self.friends
-            .outgoing_requests
-            .iter()
-            .filter_map(|did| self.identities.get(did))
-            .cloned()
-            .collect()
-    }
-
-    pub fn blocked_fr_identities(&self) -> Vec<Identity> {
-        self.friends
-            .blocked
-            .iter()
-            .filter_map(|did| self.identities.get(did))
-            .cloned()
-            .collect()
-    }
-
-    pub fn chats(&self) -> &chats::Chats {
-        &self.chats
-    }
-
-    pub fn chats_favorites(&self) -> Vec<Chat> {
-        self.chats
-            .favorites
-            .iter()
-            .filter_map(|did| self.chats.all.get(did))
-            .cloned()
-            .collect()
-    }
-
-    pub fn chats_sidebar(&self) -> Vec<Chat> {
-        self.chats
-            .in_sidebar
-            .iter()
-            .filter_map(|did| self.chats.all.get(did))
-            .cloned()
-            .collect()
-    }
-
-    pub fn chat_participants(&self, chat: &Chat) -> Vec<Identity> {
-        chat.participants
-            .iter()
-            .filter_map(|did| self.identities.get(did))
-            .cloned()
-            .collect()
-    }
-
-    pub fn account(&self) -> &account::Account {
-        &self.account
-    }
-
-    pub fn set_account(&mut self, account: account::Account) {
-        self.account = account;
-    }
-
-    pub fn set_warp_identity(&mut self, identity: warp::multipass::identity::Identity) {
-        self.account.identity.set_warp_identity(identity);
-    }
-
-    pub fn set_friends(&mut self, friends: friends::Friends, identities: HashSet<Identity>) {
-        self.friends = friends;
-        self.friends.initialized = true;
-        self.identities
-            .extend(identities.iter().map(|x| (x.did_key(), x.clone())));
-    }
-    pub fn set_chats(&mut self, chats: HashMap<Uuid, Chat>, identities: HashSet<Identity>) {
-        self.chats.all = chats;
-        self.chats.initialized = true;
-        self.identities
-            .extend(identities.iter().map(|x| (x.did_key(), x.clone())));
-    }
-
-    pub fn update_identity(&mut self, id: DID, ident: identity::Identity) {
-        if let Some(friend) = self.identities.get_mut(&id) {
-            *friend = ident;
-        } else {
-            log::warn!("failed up update identity: {}", ident.username());
-        }
-    }
-
-    pub fn did_key(&self) -> DID {
-        self.account.identity.did_key()
-    }
-
-    pub fn status_message(&self) -> Option<String> {
-        self.account.identity.status_message()
-    }
-
-    pub fn username(&self) -> String {
-        self.account.identity.username()
-    }
-
-    pub fn graphics(&self) -> warp::multipass::identity::Graphics {
-        self.account.identity.graphics()
-    }
-
-    pub fn remove_self(&self, identities: &[Identity]) -> Vec<Identity> {
-        identities
-            .iter()
-            .filter(|x| x.did_key() != self.account.identity.did_key())
-            .cloned()
-            .collect()
-    }
-
-    pub fn join_usernames(identities: &[Identity]) -> String {
-        identities
-            .iter()
-            .map(|x| x.username())
-            .collect::<Vec<String>>()
-            .join(", ")
-    }
-}
-
 // This code defines a number of methods for the State struct, which are used to mutate the state in a controlled manner.
 // For example, the set_active_chat method sets the active chat in the State struct, and the toggle_favorite method adds or removes a chat from the user's favorites.
 //  These methods are used to update the relevant fields within the State struct in response to user actions or other events within the application.
@@ -1134,6 +977,163 @@ impl State {
                 }
             }
         }
+    }
+}
+
+impl State {
+    pub fn mock(
+        my_id: Identity,
+        identities: HashMap<DID, Identity>,
+        chats: chats::Chats,
+        friends: friends::Friends,
+        storage: Storage,
+    ) -> Self {
+        Self {
+            account: Account { identity: my_id },
+            settings: Settings {
+                language: "English (USA)".into(),
+            },
+            route: Route { active: "/".into() },
+            storage,
+            chats,
+            friends,
+            identities,
+            ..Default::default()
+        }
+    }
+    pub fn friends(&self) -> &friends::Friends {
+        &self.friends
+    }
+
+    pub fn friend_identities(&self) -> Vec<Identity> {
+        self.friends
+            .all
+            .iter()
+            .filter_map(|did| self.identities.get(did))
+            .cloned()
+            .collect()
+    }
+
+    pub fn incoming_fr_identities(&self) -> Vec<Identity> {
+        self.friends
+            .incoming_requests
+            .iter()
+            .filter_map(|did| self.identities.get(did))
+            .cloned()
+            .collect()
+    }
+
+    pub fn outgoing_fr_identities(&self) -> Vec<Identity> {
+        self.friends
+            .outgoing_requests
+            .iter()
+            .filter_map(|did| self.identities.get(did))
+            .cloned()
+            .collect()
+    }
+
+    pub fn blocked_fr_identities(&self) -> Vec<Identity> {
+        self.friends
+            .blocked
+            .iter()
+            .filter_map(|did| self.identities.get(did))
+            .cloned()
+            .collect()
+    }
+
+    pub fn chats(&self) -> &chats::Chats {
+        &self.chats
+    }
+
+    pub fn chats_favorites(&self) -> Vec<Chat> {
+        self.chats
+            .favorites
+            .iter()
+            .filter_map(|did| self.chats.all.get(did))
+            .cloned()
+            .collect()
+    }
+
+    pub fn chats_sidebar(&self) -> Vec<Chat> {
+        self.chats
+            .in_sidebar
+            .iter()
+            .filter_map(|did| self.chats.all.get(did))
+            .cloned()
+            .collect()
+    }
+
+    pub fn chat_participants(&self, chat: &Chat) -> Vec<Identity> {
+        chat.participants
+            .iter()
+            .filter_map(|did| self.identities.get(did))
+            .cloned()
+            .collect()
+    }
+
+    pub fn account(&self) -> &account::Account {
+        &self.account
+    }
+
+    pub fn set_account(&mut self, account: account::Account) {
+        self.account = account;
+    }
+
+    pub fn set_warp_identity(&mut self, identity: warp::multipass::identity::Identity) {
+        self.account.identity.set_warp_identity(identity);
+    }
+
+    pub fn set_friends(&mut self, friends: friends::Friends, identities: HashSet<Identity>) {
+        self.friends = friends;
+        self.friends.initialized = true;
+        self.identities
+            .extend(identities.iter().map(|x| (x.did_key(), x.clone())));
+    }
+    pub fn set_chats(&mut self, chats: HashMap<Uuid, Chat>, identities: HashSet<Identity>) {
+        self.chats.all = chats;
+        self.chats.initialized = true;
+        self.identities
+            .extend(identities.iter().map(|x| (x.did_key(), x.clone())));
+    }
+
+    pub fn update_identity(&mut self, id: DID, ident: identity::Identity) {
+        if let Some(friend) = self.identities.get_mut(&id) {
+            *friend = ident;
+        } else {
+            log::warn!("failed up update identity: {}", ident.username());
+        }
+    }
+
+    pub fn did_key(&self) -> DID {
+        self.account.identity.did_key()
+    }
+
+    pub fn status_message(&self) -> Option<String> {
+        self.account.identity.status_message()
+    }
+
+    pub fn username(&self) -> String {
+        self.account.identity.username()
+    }
+
+    pub fn graphics(&self) -> warp::multipass::identity::Graphics {
+        self.account.identity.graphics()
+    }
+
+    pub fn remove_self(&self, identities: &[Identity]) -> Vec<Identity> {
+        identities
+            .iter()
+            .filter(|x| x.did_key() != self.account.identity.did_key())
+            .cloned()
+            .collect()
+    }
+
+    pub fn join_usernames(identities: &[Identity]) -> String {
+        identities
+            .iter()
+            .map(|x| x.username())
+            .collect::<Vec<String>>()
+            .join(", ")
     }
 }
 

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -922,7 +922,12 @@ impl State {
                 };
             }
         };
-        serde_json::from_str(&contents).unwrap_or_default()
+        let mut state: Self = serde_json::from_str(&contents).unwrap_or_default();
+        // not sure how these defaulted to true, but this should serve as additional
+        // protection in the future
+        state.friends.initialized = false;
+        state.chats.initialized = false;
+        state
     }
 
     fn load_mock() -> Self {

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -136,8 +136,7 @@ impl State {
         self.friends
             .all
             .iter()
-            .map(|did| self.identities.get(&did))
-            .flatten()
+            .filter_map(|did| self.identities.get(did))
             .cloned()
             .collect()
     }
@@ -146,8 +145,7 @@ impl State {
         self.friends
             .incoming_requests
             .iter()
-            .map(|did| self.identities.get(&did))
-            .flatten()
+            .filter_map(|did| self.identities.get(did))
             .cloned()
             .collect()
     }
@@ -156,8 +154,7 @@ impl State {
         self.friends
             .outgoing_requests
             .iter()
-            .map(|did| self.identities.get(&did))
-            .flatten()
+            .filter_map(|did| self.identities.get(did))
             .cloned()
             .collect()
     }
@@ -166,8 +163,7 @@ impl State {
         self.friends
             .blocked
             .iter()
-            .map(|did| self.identities.get(&did))
-            .flatten()
+            .filter_map(|did| self.identities.get(did))
             .cloned()
             .collect()
     }
@@ -180,8 +176,7 @@ impl State {
         self.chats
             .favorites
             .iter()
-            .map(|did| self.chats.all.get(&did))
-            .flatten()
+            .filter_map(|did| self.chats.all.get(did))
             .cloned()
             .collect()
     }
@@ -190,8 +185,7 @@ impl State {
         self.chats
             .in_sidebar
             .iter()
-            .map(|did| self.chats.all.get(&did))
-            .flatten()
+            .filter_map(|did| self.chats.all.get(did))
             .cloned()
             .collect()
     }
@@ -199,8 +193,7 @@ impl State {
     pub fn chat_participants(&self, chat: &Chat) -> Vec<Identity> {
         chat.participants
             .iter()
-            .map(|did| self.identities.get(did))
-            .flatten()
+            .filter_map(|did| self.identities.get(did))
             .cloned()
             .collect()
     }

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -56,7 +56,7 @@ use self::{action::ActionHook, configuration::Configuration, ui::Call};
 #[derive(Default, Deserialize, Serialize)]
 pub struct State {
     #[serde(skip)]
-    pub account: account::Account,
+    account: account::Account,
     #[serde(default)]
     pub route: route::Route,
     #[serde(default)]
@@ -205,6 +205,14 @@ impl State {
             .collect()
     }
 
+    pub fn set_account(&mut self, account: account::Account) {
+        self.account = account;
+    }
+
+    pub fn set_warp_identity(&mut self, identity: warp::multipass::identity::Identity) {
+        self.account.identity.set_warp_identity(identity);
+    }
+
     pub fn set_friends(&mut self, friends: friends::Friends, identities: HashSet<Identity>) {
         self.friends = friends;
         self.friends.initialized = true;
@@ -230,6 +238,18 @@ impl State {
         self.account.identity.did_key()
     }
 
+    pub fn status_message(&self) -> Option<String> {
+        self.account.identity.status_message()
+    }
+
+    pub fn username(&self) -> String {
+        self.account.identity.username()
+    }
+
+    pub fn graphics(&self) -> warp::multipass::identity::Graphics {
+        self.account.identity.graphics()
+    }
+
     pub fn remove_self(&self, identities: &[Identity]) -> Vec<Identity> {
         identities
             .iter()
@@ -244,7 +264,6 @@ impl State {
             .map(|x| x.username())
             .collect::<Vec<String>>()
             .join(", ")
-            .to_string()
     }
 }
 

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -225,6 +225,27 @@ impl State {
             log::warn!("failed up update identity: {}", ident.username());
         }
     }
+
+    pub fn did_key(&self) -> DID {
+        self.account.identity.did_key()
+    }
+
+    pub fn remove_self(&self, identities: &[Identity]) -> Vec<Identity> {
+        identities
+            .iter()
+            .filter(|x| x.did_key() != self.account.identity.did_key())
+            .cloned()
+            .collect()
+    }
+
+    pub fn join_usernames(identities: &[Identity]) -> String {
+        identities
+            .iter()
+            .map(|x| x.username())
+            .collect::<Vec<String>>()
+            .join(", ")
+            .to_string()
+    }
 }
 
 // This code defines a number of methods for the State struct, which are used to mutate the state in a controlled manner.

--- a/common/src/testing/mock.rs
+++ b/common/src/testing/mock.rs
@@ -14,14 +14,12 @@ use titlecase::titlecase;
 use uuid::Uuid;
 use warp::{
     constellation::{directory::Directory, file::File},
+    crypto::DID,
     multipass::identity::{Graphics, IdentityStatus, Platform},
     raygun::Message,
 };
 
-use crate::state::{
-    storage::Storage, Account, Chat, Chats, Friends, Identity, Route, Settings, State,
-    ToastNotification,
-};
+use crate::state::{storage::Storage, Chat, Chats, Friends, Identity, State, ToastNotification};
 
 use crate::warp_runner::ui_adapter;
 
@@ -61,47 +59,37 @@ pub fn generate_mock() -> State {
     toast_notifications.clear();
 
     let storage = generate_fake_storage();
-    let mut id_map = HashMap::new();
-    for ident in identities {
+    let mut id_map: HashMap<DID, Identity> = HashMap::new();
+    for ident in identities.iter().cloned() {
         id_map.insert(ident.did_key(), ident);
     }
-    for ident in blocked_identities {
+    for ident in blocked_identities.iter().cloned() {
         id_map.insert(ident.did_key(), ident);
     }
-    for ident in incoming_requests {
+    for ident in incoming_requests.iter().cloned() {
         id_map.insert(ident.did_key(), ident);
     }
-    for ident in outgoing_requests {
+    for ident in outgoing_requests.iter().cloned() {
         id_map.insert(ident.did_key(), ident);
     }
 
-    State {
-        account: Account {
-            identity: me.clone(),
-        },
-        settings: Settings {
-            language: "English (USA)".into(),
-        },
-        route: Route { active: "/".into() },
-        chats: Chats {
-            initialized: true,
-            all: all_chats.clone(),
-            active: None,
-            active_media: None,
-            in_sidebar,
-            favorites: vec![],
-        },
-        storage,
-        friends: Friends {
-            initialized: true,
-            all: HashSet::from_iter(identities.iter().map(|x| x.did_key())),
-            blocked: HashSet::from_iter(blocked_identities.iter().map(|x| x.did_key())),
-            incoming_requests: HashSet::from_iter(incoming_requests.iter().map(|x| x.did_key())),
-            outgoing_requests: HashSet::from_iter(outgoing_requests.iter().map(|x| x.did_key())),
-        },
-        identities: id_map,
-        ..Default::default()
-    }
+    let chats = Chats {
+        initialized: true,
+        all: all_chats.clone(),
+        active: None,
+        active_media: None,
+        in_sidebar,
+        favorites: vec![],
+    };
+    let friends = Friends {
+        initialized: true,
+        all: HashSet::from_iter(identities.iter().map(|x| x.did_key())),
+        blocked: HashSet::from_iter(blocked_identities.iter().map(|x| x.did_key())),
+        incoming_requests: HashSet::from_iter(incoming_requests.iter().map(|x| x.did_key())),
+        outgoing_requests: HashSet::from_iter(outgoing_requests.iter().map(|x| x.did_key())),
+    };
+
+    State::mock(me.clone(), id_map, chats, friends, storage)
 }
 
 fn generate_fake_chat(participants: Vec<Identity>, conversation: Uuid) -> Chat {

--- a/common/src/testing/mock.rs
+++ b/common/src/testing/mock.rs
@@ -61,6 +61,19 @@ pub fn generate_mock() -> State {
     toast_notifications.clear();
 
     let storage = generate_fake_storage();
+    let mut id_map = HashMap::new();
+    for ident in identities {
+        id_map.insert(ident.did_key(), ident);
+    }
+    for ident in blocked_identities {
+        id_map.insert(ident.did_key(), ident);
+    }
+    for ident in incoming_requests {
+        id_map.insert(ident.did_key(), ident);
+    }
+    for ident in outgoing_requests {
+        id_map.insert(ident.did_key(), ident);
+    }
 
     State {
         account: Account {
@@ -81,14 +94,12 @@ pub fn generate_mock() -> State {
         storage,
         friends: Friends {
             initialized: true,
-            all: identities
-                .into_iter()
-                .map(|id| (id.did_key(), id))
-                .collect(),
-            blocked: HashSet::from_iter(blocked_identities.iter().cloned()),
-            incoming_requests: HashSet::from_iter(incoming_requests.iter().cloned()),
-            outgoing_requests: HashSet::from_iter(outgoing_requests.iter().cloned()),
+            all: HashSet::from_iter(identities.iter().map(|x| x.did_key())),
+            blocked: HashSet::from_iter(blocked_identities.iter().map(|x| x.did_key())),
+            incoming_requests: HashSet::from_iter(incoming_requests.iter().map(|x| x.did_key())),
+            outgoing_requests: HashSet::from_iter(outgoing_requests.iter().map(|x| x.did_key())),
         },
+        identities: id_map,
         ..Default::default()
     }
 }
@@ -117,7 +128,7 @@ fn generate_fake_chat(participants: Vec<Identity>, conversation: Uuid) -> Chat {
 
     Chat {
         id: conversation,
-        participants,
+        participants: HashSet::from_iter(participants.iter().map(|x| x.did_key())),
         messages,
         unreads: rng.gen_range(0..2),
         replying_to: None,

--- a/common/src/warp_runner/manager/commands/multipass_commands.rs
+++ b/common/src/warp_runner/manager/commands/multipass_commands.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use derive_more::Display;
 use futures::channel::oneshot;
@@ -14,10 +14,7 @@ use warp::{
 
 use crate::{
     state::{self, friends},
-    warp_runner::{
-        ui_adapter::{did_to_identity, dids_to_identity},
-        Account,
-    },
+    warp_runner::{ui_adapter::dids_to_identity, Account},
 };
 
 #[derive(Display)]
@@ -40,7 +37,9 @@ pub enum MultiPassCmd {
     },
     #[display(fmt = "InitializeFriends")]
     InitializeFriends {
-        rsp: oneshot::Sender<Result<friends::Friends, warp::error::Error>>,
+        rsp: oneshot::Sender<
+            Result<(friends::Friends, HashSet<state::Identity>), warp::error::Error>,
+        >,
     },
     #[display(fmt = "RefreshFriends")]
     RefreshFriends {
@@ -249,26 +248,28 @@ async fn multipass_refresh_friends(
 
 async fn multipass_initialize_friends(
     account: &mut Account,
-) -> Result<state::friends::Friends, Error> {
+) -> Result<(state::friends::Friends, HashSet<state::Identity>), Error> {
     let reqs = account.list_incoming_request().await?;
     log::trace!("init friends with {} total", reqs.len());
-    let idents = dids_to_identity(&reqs, account).await?;
-    let incoming_requests = HashSet::from_iter(idents.iter().cloned());
+    let incoming_requests = HashSet::from_iter(reqs.iter().cloned());
 
     let outgoing = account.list_outgoing_request().await?;
-    let idents = dids_to_identity(&outgoing, account).await?;
-    let outgoing_requests = HashSet::from_iter(idents.iter().cloned());
+    let outgoing_requests = HashSet::from_iter(outgoing.iter().cloned());
 
     let ids = account.block_list().await?;
-    let idents = dids_to_identity(&ids, account).await?;
-    let blocked = HashSet::from_iter(idents.iter().cloned());
+    let blocked = HashSet::from_iter(ids.iter().cloned());
 
     let ids = account.list_friends().await?;
-    let mut friends = HashMap::new();
-    for id in ids {
-        let ident = did_to_identity(&id, account).await?;
-        friends.insert(id, ident);
-    }
+    let friends = HashSet::from_iter(ids.iter().cloned());
+
+    let mut all_ids = Vec::new();
+    all_ids.extend(friends.clone());
+    all_ids.extend(blocked.clone());
+    all_ids.extend(incoming_requests.clone());
+    all_ids.extend(outgoing_requests.clone());
+
+    let identities = dids_to_identity(&all_ids, account).await?;
+    let ids = HashSet::from_iter(identities.iter().cloned());
 
     let ret = friends::Friends {
         initialized: true,
@@ -277,5 +278,5 @@ async fn multipass_initialize_friends(
         incoming_requests,
         outgoing_requests,
     };
-    Ok(ret)
+    Ok((ret, ids))
 }

--- a/common/src/warp_runner/manager/commands/multipass_commands.rs
+++ b/common/src/warp_runner/manager/commands/multipass_commands.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use derive_more::Display;
 use futures::channel::oneshot;

--- a/common/src/warp_runner/manager/commands/raygun_commands.rs
+++ b/common/src/warp_runner/manager/commands/raygun_commands.rs
@@ -31,14 +31,7 @@ pub enum RayGunCmd {
         // need to send over own identity because 'State' sets it to default
         #[allow(clippy::type_complexity)]
         rsp: oneshot::Sender<
-            Result<
-                (
-                    state::Identity,
-                    HashMap<Uuid, chats::Chat>,
-                    HashSet<state::Identity>,
-                ),
-                warp::error::Error,
-            >,
+            Result<(HashMap<Uuid, chats::Chat>, HashSet<state::Identity>), warp::error::Error>,
         >,
     },
     #[display(fmt = "CreateConversation {{ did: {recipient} }} ")]
@@ -220,16 +213,8 @@ async fn raygun_initialize_conversations(
     stream_manager: &mut conv_stream::Manager,
     account: &Account,
     messaging: &mut Messaging,
-) -> Result<
-    (
-        state::Identity,
-        HashMap<Uuid, chats::Chat>,
-        HashSet<state::Identity>,
-    ),
-    Error,
-> {
+) -> Result<(HashMap<Uuid, chats::Chat>, HashSet<state::Identity>), Error> {
     log::trace!("init convs with {} total", convs.len());
-    let own_identity = account.get_own_identity().await?;
     let mut all_chats = HashMap::new();
     let mut identities = HashSet::new();
     for conv in convs {
@@ -250,7 +235,7 @@ async fn raygun_initialize_conversations(
             }
         };
     }
-    Ok((state::Identity::from(own_identity), all_chats, identities))
+    Ok((all_chats, identities))
 }
 
 async fn raygun_remove_direct_convs(

--- a/common/src/warp_runner/manager/commands/raygun_commands.rs
+++ b/common/src/warp_runner/manager/commands/raygun_commands.rs
@@ -1,6 +1,9 @@
 use derive_more::Display;
 use futures::channel::oneshot;
-use std::{collections::HashMap, path::PathBuf};
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+};
 use uuid::Uuid;
 use warp::{
     constellation::ConstellationProgressStream,
@@ -12,7 +15,11 @@ use warp::{
 
 use crate::{
     state::{self, chats},
-    warp_runner::{conv_stream, ui_adapter::conversation_to_chat, Account, Messaging},
+    warp_runner::{
+        conv_stream,
+        ui_adapter::{conversation_to_chat, ChatAdapter},
+        Account, Messaging,
+    },
 };
 
 #[allow(clippy::large_enum_variant)]
@@ -24,13 +31,20 @@ pub enum RayGunCmd {
         // need to send over own identity because 'State' sets it to default
         #[allow(clippy::type_complexity)]
         rsp: oneshot::Sender<
-            Result<(state::Identity, HashMap<Uuid, chats::Chat>), warp::error::Error>,
+            Result<
+                (
+                    state::Identity,
+                    HashMap<Uuid, chats::Chat>,
+                    HashSet<state::Identity>,
+                ),
+                warp::error::Error,
+            >,
         >,
     },
     #[display(fmt = "CreateConversation {{ did: {recipient} }} ")]
     CreateConversation {
         recipient: DID,
-        rsp: oneshot::Sender<Result<chats::Chat, warp::error::Error>>,
+        rsp: oneshot::Sender<Result<ChatAdapter, warp::error::Error>>,
     },
     #[display(fmt = "SendMessage {{ conv_id: {conv_id} }} ")]
     SendMessage {
@@ -190,28 +204,37 @@ async fn raygun_initialize_conversations(
     stream_manager: &mut conv_stream::Manager,
     account: &Account,
     messaging: &mut Messaging,
-) -> Result<(state::Identity, HashMap<Uuid, chats::Chat>), Error> {
+) -> Result<
+    (
+        state::Identity,
+        HashMap<Uuid, chats::Chat>,
+        HashSet<state::Identity>,
+    ),
+    Error,
+> {
     log::trace!("init convs with {} total", convs.len());
     let own_identity = account.get_own_identity().await?;
     let mut all_chats = HashMap::new();
+    let mut identities = HashSet::new();
     for conv in convs {
         match conversation_to_chat(conv, account, messaging).await {
             Ok(chat) => {
-                if let Err(e) = stream_manager.add_stream(chat.id, messaging).await {
+                if let Err(e) = stream_manager.add_stream(chat.inner.id, messaging).await {
                     log::error!(
                         "failed to open conversation stream for conv {}: {}",
-                        chat.id,
+                        chat.inner.id,
                         e
                     );
                 }
-                let _ = all_chats.insert(chat.id, chat);
+                let _ = all_chats.insert(chat.inner.id, chat.inner);
+                identities.extend(chat.identities);
             }
             Err(e) => {
                 log::error!("failed to convert conversation to chat: {}", e);
             }
         };
     }
-    Ok((state::Identity::from(own_identity), all_chats))
+    Ok((state::Identity::from(own_identity), all_chats, identities))
 }
 
 async fn raygun_remove_direct_convs(

--- a/common/src/warp_runner/ui_adapter/mod.rs
+++ b/common/src/warp_runner/ui_adapter/mod.rs
@@ -13,7 +13,7 @@ pub use raygun_event::{convert_raygun_event, RayGunEvent};
 use crate::state::{self, chats};
 use futures::{stream::FuturesOrdered, FutureExt, StreamExt};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use warp::{
     crypto::DID,
     error::Error,
@@ -28,6 +28,11 @@ use warp::{
 pub struct Message {
     pub inner: warp::raygun::Message,
     pub in_reply_to: Option<String>,
+}
+
+pub struct ChatAdapter {
+    pub inner: chats::Chat,
+    pub identities: HashSet<state::identity::Identity>,
 }
 
 /// if a raygun::Message is in reply to another message, attempt to fetch part of the message text
@@ -98,12 +103,12 @@ pub async fn conversation_to_chat(
     conv: &Conversation,
     account: &super::Account,
     messaging: &mut super::Messaging,
-) -> Result<chats::Chat, Error> {
+) -> Result<ChatAdapter, Error> {
     // todo: should Chat::participants include self?
-    let mut participants = Vec::new();
+    let mut identities = HashSet::new();
     for id in conv.recipients() {
         let identity = did_to_identity(&id, account).await?;
-        participants.push(identity);
+        identities.insert(identity);
     }
 
     // todo: warp doesn't support paging yet. it also doesn't check the range bounds
@@ -120,12 +125,17 @@ pub async fn conversation_to_chat(
     .collect()
     .await;
 
-    Ok(chats::Chat {
-        id: conv.id(),
-        participants,
-        messages,
-        unreads: unreads as u32,
-        replying_to: None,
-        typing_indicator: HashMap::new(),
-    })
+    let adapter = ChatAdapter {
+        inner: chats::Chat {
+            id: conv.id(),
+            participants: HashSet::from_iter(conv.recipients()),
+            messages,
+            unreads: unreads as u32,
+            replying_to: None,
+            typing_indicator: HashMap::new(),
+        },
+        identities,
+    };
+
+    Ok(adapter)
 }

--- a/common/src/warp_runner/ui_adapter/raygun_event.rs
+++ b/common/src/warp_runner/ui_adapter/raygun_event.rs
@@ -1,13 +1,11 @@
 use uuid::Uuid;
 use warp::{error::Error, logging::tracing::log, raygun::RayGunEventKind};
 
-use crate::state::{self};
-
-use super::{super::conv_stream, conversation_to_chat};
+use super::{super::conv_stream, conversation_to_chat, ChatAdapter};
 
 #[allow(clippy::large_enum_variant)]
 pub enum RayGunEvent {
-    ConversationCreated(state::Chat),
+    ConversationCreated(ChatAdapter),
     ConversationDeleted(Uuid),
 }
 
@@ -22,7 +20,7 @@ pub async fn convert_raygun_event(
         RayGunEventKind::ConversationCreated { conversation_id } => {
             let conv = messaging.get_conversation(conversation_id).await?;
             let chat = conversation_to_chat(&conv, account, messaging).await?;
-            stream_manager.add_stream(chat.id, messaging).await?;
+            stream_manager.add_stream(chat.inner.id, messaging).await?;
             RayGunEvent::ConversationCreated(chat)
         }
         RayGunEventKind::ConversationDeleted { conversation_id } => {

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -58,6 +58,7 @@ use crate::{
 struct ComposeData {
     active_chat: Chat,
     message_groups: Vec<state::MessageGroup>,
+    my_id: Identity,
     other_participants: Vec<Identity>,
     active_participant: Identity,
     subtext: String,
@@ -164,6 +165,7 @@ fn get_compose_data(s: State) -> Option<Rc<ComposeData>> {
         active_chat,
         message_groups,
         other_participants,
+        my_id: s.account().identity.clone(),
         active_participant,
         subtext,
         is_favorite,
@@ -845,7 +847,14 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
                 let active_chat = data.active_chat.clone();
                 cx.render(rsx!(active_chat.clone().replying_to.map(|msg| {
                     let our_did = state.read().did_key();
-                    let msg_owner = data.other_participants.first();
+                    let msg_owner = if data.my_id.did_key() == msg.sender() {
+                        Some(&data.my_id)
+                    } else {
+                        data.other_participants
+                            .iter()
+                            .filter(|x| x.did_key() == msg.sender())
+                            .next()
+                    };
                     let (platform, status) = get_platform_and_status(msg_owner);
 
                     rsx!(

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -150,12 +150,7 @@ fn get_compose_data(s: State) -> Option<Rc<ComposeData>> {
     let is_favorite = s.is_favorite(&active_chat);
 
     let first_image = active_participant.graphics().profile_picture();
-    let other_participants_names = other_participants
-        .iter()
-        .map(|x| x.username())
-        .collect::<Vec<String>>()
-        .join(", ")
-        .to_string();
+    let other_participants_names = State::join_usernames(&other_participants);
     let active_media = Some(active_chat.id) == s.chats().active_media;
 
     // TODO: Pending new message divider implementation

--- a/ui/src/components/friends/add.rs
+++ b/ui/src/components/friends/add.rs
@@ -99,18 +99,14 @@ pub fn AddFriend(cx: Scope) -> Element {
                     Err(e) => match e {
                         Error::CannotSendSelfFriendRequest => {
                             log::warn!("cannot add self: {}", e);
-                            error_toast.set(Some(get_local_text(
-                                "friends.cannot-add-self",
-                            )));
+                            error_toast.set(Some(get_local_text("friends.cannot-add-self")));
                         }
                         Error::PublicKeyIsBlocked => {
                             log::warn!("add friend failed: {}", e);
-                            error_toast
-                                .set(Some(get_local_text("friends.key-blocked")));
+                            error_toast.set(Some(get_local_text("friends.key-blocked")));
                         }
                         _ => {
-                            error_toast
-                                .set(Some(get_local_text("friends.add-failed")));
+                            error_toast.set(Some(get_local_text("friends.add-failed")));
                             log::error!("add friend failed: {}", e);
                         }
                     },

--- a/ui/src/components/friends/blocked/mod.rs
+++ b/ui/src/components/friends/blocked/mod.rs
@@ -21,7 +21,7 @@ use warp::{crypto::DID, error::Error, logging::tracing::log, multipass::identity
 #[allow(non_snake_case)]
 pub fn BlockedUsers(cx: Scope) -> Element {
     let state = use_shared_state::<State>(cx).unwrap();
-    let block_list = state.read().friends.blocked.clone();
+    let block_list = state.read().blocked_fr_identities();
 
     let ch = use_coroutine(cx, |mut rx: UnboundedReceiver<DID>| {
         //to_owned![];

--- a/ui/src/components/friends/friends_list/mod.rs
+++ b/ui/src/components/friends/friends_list/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use dioxus::prelude::*;
 use dioxus_router::use_router;
 use futures::{channel::oneshot, StreamExt};
@@ -10,8 +12,8 @@ use kit::{
     elements::label::Label,
 };
 
-use common::icons::outline::Shape as Icon;
 use common::language::get_local_text;
+use common::{icons::outline::Shape as Icon, warp_runner::ui_adapter::ChatAdapter};
 use common::{
     state::{Action, Chat, State},
     warp_runner::{MultiPassCmd, RayGunCmd, WarpCmd},
@@ -37,7 +39,13 @@ enum ChanCmd {
 #[allow(non_snake_case)]
 pub fn Friends(cx: Scope) -> Element {
     let state: UseSharedState<State> = use_shared_state::<State>(cx).unwrap();
-    let friends_list = state.read().friends.all.clone();
+    let friends_list = HashMap::from_iter(
+        state
+            .read()
+            .friend_identities()
+            .iter()
+            .map(|id| (id.did_key(), id.clone())),
+    );
     let friends = State::get_friends_by_first_letter(friends_list);
     let router = use_router(cx);
 
@@ -65,7 +73,7 @@ pub fn Friends(cx: Scope) -> Element {
                             None => {
                                 // if not, create the chat
                                 let (tx, rx) =
-                                    oneshot::channel::<Result<Chat, warp::error::Error>>();
+                                    oneshot::channel::<Result<ChatAdapter, warp::error::Error>>();
                                 if let Err(e) = warp_cmd_tx.send(WarpCmd::RayGun(
                                     RayGunCmd::CreateConversation { recipient, rsp: tx },
                                 )) {
@@ -76,7 +84,7 @@ pub fn Friends(cx: Scope) -> Element {
                                 let rsp = rx.await.expect("command canceled");
 
                                 match rsp {
-                                    Ok(c) => c,
+                                    Ok(c) => c.inner,
                                     Err(e) => {
                                         log::error!("failed to create conversation: {}", e);
                                         continue;

--- a/ui/src/components/friends/incoming_requests/mod.rs
+++ b/ui/src/components/friends/incoming_requests/mod.rs
@@ -28,7 +28,7 @@ enum ChanCmd {
 #[allow(non_snake_case)]
 pub fn PendingFriends(cx: Scope) -> Element {
     let state: UseSharedState<State> = use_shared_state::<State>(cx).unwrap();
-    let friends_list = state.read().friends.incoming_requests.clone();
+    let friends_list = state.read().incoming_fr_identities();
 
     let ch = use_coroutine(cx, |mut rx: UnboundedReceiver<ChanCmd>| {
         //to_owned![];

--- a/ui/src/components/friends/outgoing_requests/mod.rs
+++ b/ui/src/components/friends/outgoing_requests/mod.rs
@@ -23,7 +23,7 @@ use warp::{crypto::DID, logging::tracing::log, multipass::identity::Relationship
 #[allow(non_snake_case)]
 pub fn OutgoingRequests(cx: Scope) -> Element {
     let state: UseSharedState<State> = use_shared_state::<State>(cx).unwrap();
-    let friends_list = state.read().friends.outgoing_requests.clone();
+    let friends_list = state.read().outgoing_fr_identities();
 
     let ch = use_coroutine(cx, |mut rx: UnboundedReceiver<DID>| {
         //to_owned![];

--- a/ui/src/components/settings/sub_pages/profile/mod.rs
+++ b/ui/src/components/settings/sub_pages/profile/mod.rs
@@ -28,26 +28,17 @@ pub fn ProfileSettings(cx: Scope) -> Element {
     log::trace!("rendering ProfileSettings");
 
     let state = use_shared_state::<State>(cx)?;
-    let user_status = state
-        .read()
-        .account
-        .identity
-        .status_message()
-        .unwrap_or_default();
-    let username = state.read().account.identity.username();
+    let user_status = state.read().status_message().unwrap_or_default();
+    let username = state.read().username();
     let should_update: &UseState<Option<multipass::identity::Identity>> = use_state(cx, || None);
     // TODO: This needs to persist across restarts but a config option seems overkill. Should we have another kind of file to cache flags?
     let welcome_dismissed = use_state(cx, || false);
-    let image = state.read().account.identity.graphics().profile_picture();
-    let banner = state.read().account.identity.graphics().profile_banner();
+    let image = state.read().graphics().profile_picture();
+    let banner = state.read().graphics().profile_banner();
 
     if let Some(ident) = should_update.get() {
         log::trace!("Updating ProfileSettings");
-        state
-            .write()
-            .account
-            .identity
-            .set_warp_identity(ident.clone());
+        state.write().set_warp_identity(ident.clone());
         should_update.set(None);
     }
 

--- a/ui/src/layouts/chat.rs
+++ b/ui/src/layouts/chat.rs
@@ -19,7 +19,7 @@ pub fn ChatLayout(cx: Scope<Props>) -> Element {
 
     let is_minimal_view = state.read().ui.is_minimal_view();
     let sidebar_hidden = state.read().ui.sidebar_hidden;
-    let show_welcome = state.read().chats.active.is_none();
+    let show_welcome = state.read().chats().active.is_none();
 
     if *first_render.get() && is_minimal_view {
         state.write().mutate(Action::SidebarHidden(true));

--- a/ui/src/layouts/friends.rs
+++ b/ui/src/layouts/friends.rs
@@ -116,7 +116,7 @@ fn render_route(cx: Scope<Props>, route: FriendRoute) -> Element {
 
 fn get_topbar<'a>(cx: Scope<'a, Props>, route: &'a UseState<FriendRoute>) -> Element<'a> {
     let state = use_shared_state::<State>(cx)?;
-    let pending_friends = state.read().friends.incoming_requests.len();
+    let pending_friends = state.read().friends().incoming_requests.len();
 
     cx.render(rsx!(Topbar {
         with_back_button: state.read().ui.is_minimal_view() || state.read().ui.sidebar_hidden,

--- a/ui/src/layouts/storage.rs
+++ b/ui/src/layouts/storage.rs
@@ -214,7 +214,7 @@ pub fn FilesLayout(cx: Scope<Props>) -> Element {
                     }
                     ChanCmd::UploadFiles(files_path) => {
                         let mut script = main_script.replace("$IS_DRAGGING", "true");
-                        script.push_str(&ANIMATION_DASH_SCRIPT);
+                        script.push_str(ANIMATION_DASH_SCRIPT);
                         window.eval(&script);
 
                         let (tx, mut rx) =
@@ -813,7 +813,7 @@ async fn drag_and_drop_function(
                 window.eval(&script);
             }
             FileDropEvent::Dropped(files_local_path) => {
-                ch.send(ChanCmd::UploadFiles(files_local_path.clone()));
+                ch.send(ChanCmd::UploadFiles(files_local_path));
                 break;
             }
             _ => {

--- a/ui/src/layouts/storage.rs
+++ b/ui/src/layouts/storage.rs
@@ -530,13 +530,11 @@ pub fn FilesLayout(cx: Scope<Props>) -> Element {
                                                         .and_then(OsStr::to_str)
                                                         .map(|s| s.to_string())
                                                         .unwrap_or_default();
-    
                                                     let file_stem = PathBuf::from(&file_name2)
                                                             .file_stem()
                                                             .and_then(OsStr::to_str)
                                                             .map(str::to_string)
                                                             .unwrap_or_default();
-    
                                                     let file_path_buf = match FileDialog::new().set_directory(".").set_file_name(&file_stem).add_filter("", &[&file_extension]).save_file() {
                                                         Some(path) => path,
                                                         None => return,

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -5,7 +5,6 @@ use clap::Parser;
 use common::icons::outline::Shape as Icon;
 use common::icons::Icon as IconElement;
 use common::language::{change_language, get_local_text};
-use common::state::identity;
 use common::{state, warp_runner, LogProfile, STATIC_ARGS, WARP_CMD_CH, WARP_EVENT_CH};
 use dioxus::prelude::*;
 use dioxus_desktop::tao::dpi::LogicalSize;

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -373,7 +373,7 @@ pub fn app_bootstrap(cx: Scope, identity: multipass::identity::Identity) -> Elem
         assert!(state.friends().initialized);
         assert!(state.chats().initialized);
     } else {
-        state.account.identity = identity.clone().into();
+        state.set_warp_identity(identity.clone());
     }
 
     // set the window to the normal size.
@@ -769,11 +769,7 @@ fn app(cx: Scope) -> Element {
             let res = loop {
                 let (tx, rx) = oneshot::channel::<
                     Result<
-                        (
-                            state::Identity,
-                            HashMap<Uuid, state::Chat>,
-                            HashSet<state::Identity>,
-                        ),
+                        (HashMap<Uuid, state::Chat>, HashSet<state::Identity>),
                         warp::error::Error,
                     >,
                 >();
@@ -807,8 +803,7 @@ fn app(cx: Scope) -> Element {
 
             match inner.try_borrow_mut() {
                 Ok(state) => {
-                    state.write().account.identity = chats.0;
-                    state.write().set_chats(chats.1, chats.2);
+                    state.write().set_chats(chats.0, chats.1);
                     needs_update.set(true);
                 }
                 Err(e) => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Identities need to be updated with the user's username, status, profile picture, banner, and whether or not they are online. Identities were previously stored in both the friends list and with every chat, and the two lists didn't necessarily overlap. Obviously this is bad. 
- A `HashMap<DID, Identity>` was added to state. everywhere else in state, `Identity` was replaced with `DID`. 
- A few fields in state were made private because altering them may (either now or in the future) require updating `state.identities`. 
- Lots of utility functions were added to state in response to these fields becoming private. 
- If you read this far, good job! 
- There are also miscellaneous changes due to `cargo fmt` and `cargo clippy`

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

