### PR TITLE
refactor(Unlock): Apply theme on login

### DIFF
--- a/ui/src/layouts/unlock.rs
+++ b/ui/src/layouts/unlock.rs
@@ -1,5 +1,7 @@
 use common::{
-    language::get_local_text, state::configuration::Configuration, warp_runner::TesseractCmd,
+    language::get_local_text,
+    state::{configuration::Configuration, State},
+    warp_runner::TesseractCmd,
     STATIC_ARGS,
 };
 use dioxus::prelude::*;
@@ -142,7 +144,9 @@ pub fn UnlockLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -
     let loading = !loaded.get();
 
     cx.render(rsx!(
+        style {update_theme_colors()},
         div {
+            class: "unlock-screen",
             id: "unlock-layout",
             aria_label: "unlock-layout",
             if loading {
@@ -213,26 +217,34 @@ pub fn UnlockLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -
                         }
                     }
                     Button {
-                        text: match account_exists_bool {
-                            true => get_local_text("unlock.unlock-account"),
-                            false => get_local_text("unlock.create-account"),
-                        },
-                        aria_label: "create-account-button".into(),
-                        appearance: kit::elements::Appearance::Primary,
-                        icon: Icon::Check,
-                        disabled: validation_failure.get().is_some(),
-                        onpress: move |_| {
-                            if let Some(validation_error) = validation_failure.get() {
-                                shown_error.set(validation_error.as_str());
-                            } else if let Some(e) = error.get() {
-                                shown_error.set(e.as_str());
-                            } else {
-                                page.set(AuthPages::CreateAccount);
+                            text: match account_exists_bool {
+                                true => get_local_text("unlock.unlock-account"),
+                                false => get_local_text("unlock.create-account"),
+                            },
+                            aria_label: "create-account-button".into(),
+                            appearance: kit::elements::Appearance::Primary,
+                            icon: Icon::Check,
+                            disabled: validation_failure.get().is_some(),
+                            onpress: move |_| {
+                                if let Some(validation_error) = validation_failure.get() {
+                                    shown_error.set(validation_error.as_str());
+                                } else if let Some(e) = error.get() {
+                                    shown_error.set(e.as_str());
+                                } else {
+                                    page.set(AuthPages::CreateAccount);
+                                }
                             }
                         }
-                    }
                 )
             }
         }
     ))
+}
+
+fn update_theme_colors() -> String {
+    let state = State::load();
+    match state.ui.theme.clone() {
+        Some(theme) => theme.styles,
+        None => String::new(),
+    }
 }

--- a/ui/src/layouts/unlock.rs
+++ b/ui/src/layouts/unlock.rs
@@ -146,7 +146,6 @@ pub fn UnlockLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -
     cx.render(rsx!(
         style {update_theme_colors()},
         div {
-            class: "unlock-screen",
             id: "unlock-layout",
             aria_label: "unlock-layout",
             if loading {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
### 1. Theme colors applied when user has an account 
![image](https://user-images.githubusercontent.com/63157656/224365657-1206eda0-d613-4bbb-90f5-862c6d46d1ea.png)
![image](https://user-images.githubusercontent.com/63157656/224365745-86777f32-e63d-4991-ba07-ce193f50ac8a.png)
![image](https://user-images.githubusercontent.com/63157656/224365818-5c3c7771-1ee9-462a-8602-f97a32342adf.png)



### 2. When user does not have an account, default colors are used 
![image](https://user-images.githubusercontent.com/63157656/224365561-65e9dd53-320c-47a6-b0d4-5cc2e3eaae42.png)

- 

### Which issue(s) this PR fixes 🔨

- Resolve #428

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

