### PR TITLE
feat(settings): Clear button user settings

### DIFF
--- a/kit/src/elements/input/mod.rs
+++ b/kit/src/elements/input/mod.rs
@@ -78,6 +78,7 @@ pub struct Options {
     pub replace_spaces_underscore: bool,
     pub disabled: bool,
     pub with_clear_btn: bool,
+    pub clear_btn_icon: Icon,
     pub clear_on_submit: bool,
     pub with_label: Option<&'static str>,
     pub react_to_esc_key: bool,
@@ -90,6 +91,7 @@ impl Default for Options {
             replace_spaces_underscore: false,
             disabled: false,
             with_clear_btn: false,
+            clear_btn_icon: Icon::Backspace,
             clear_on_submit: true,
             with_label: None,
             react_to_esc_key: false,
@@ -396,7 +398,7 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                             }
                         },
                         IconElement {
-                            icon: Icon::Backspace
+                            icon: options.clear_btn_icon
                         }
                     }
                 )),

--- a/ui/src/components/settings/sub_pages/profile/mod.rs
+++ b/ui/src/components/settings/sub_pages/profile/mod.rs
@@ -208,7 +208,10 @@ pub fn ProfileSettings(cx: Scope) -> Element {
                         placeholder:  get_local_text("uplink.username"),
                         default_text: username,
                         aria_label: "username-input".into(),
-                        options: get_input_options(username_validation_options),
+                        options: Options {
+                            with_clear_btn: true,
+                            ..get_input_options(username_validation_options)
+                        },
                         onreturn: move |(v, is_valid, _): (String, bool, _)| {
                             if !is_valid {
                                 return;


### PR DESCRIPTION
### What this PR does 📖

- Adds a clear button to the username input
- Also adds option to specify the clear button icon (though all atm use the default one)
- Made it so if the clear button is pressed the text field gets focused

### Which issue(s) this PR fixes 🔨

- Resolve #413

