### PR TITLE
fix(extensions): help emoji extension get data into the textarea

### DIFF
--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -156,7 +156,6 @@ fn EditMsg<'a>(cx: Scope<'a, EditProps<'a>>) -> Element<'a> {
     cx.render(rsx!(textarea::Input {
         focus: true,
         default_text: cx.props.text.clone(),
-        reset: None,
         onchange: move |_| {},
         onreturn: move |(s, _, _): (String, _, _)| {
             log::debug!("editing message: {s}");

--- a/kit/src/elements/textarea/mod.rs
+++ b/kit/src/elements/textarea/mod.rs
@@ -40,71 +40,139 @@ pub struct Props<'a> {
     aria_label: String,
     onchange: EventHandler<'a, (String, bool)>,
     onreturn: EventHandler<'a, (String, bool, Code)>,
-    #[props(!optional)]
-    reset: Option<UseState<bool>>,
-    #[props(optional)]
-    value: Option<String>,
 }
 
 #[allow(non_snake_case)]
 pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
-    let val = use_ref(cx, || cx.props.default_text.clone());
+    let Props {
+        id,
+        focus,
+        loading,
+        placeholder,
+        max_length,
+        size,
+        default_text,
+        aria_label,
+        onchange,
+        onreturn,
+    } = &cx.props;
+    let val = use_ref(cx, || default_text.clone());
 
-    if let Some(value) = &cx.props.value {
-        if value != &*val.read() {
-            val.set(value.clone());
-        }
-    }
-    println!("val: {:?}", val.read());
+    render_input(
+        cx,
+        id,
+        *focus,
+        *loading,
+        placeholder,
+        *max_length,
+        *size,
+        aria_label,
+        onchange,
+        onreturn,
+        val.read().as_str(),
+    )
+}
 
-    if let Some(hook) = &cx.props.reset {
-        let should_reset = hook.get();
-        if *should_reset {
-            val.write().clear();
-            hook.set(false);
-        }
-    }
+#[derive(Props)]
+pub struct ControlledInputProps<'a> {
+    #[props(default = "".to_owned())]
+    id: String,
+    #[props(default = false)]
+    focus: bool,
+    #[props(default = false)]
+    loading: bool,
+    #[props(default = "".to_owned())]
+    placeholder: String,
+    #[props(default = 1024)]
+    max_length: i32,
+    #[props(default = Size::Normal)]
+    size: Size,
+    #[props(default = "".to_owned())]
+    aria_label: String,
+    onchange: EventHandler<'a, (String, bool)>,
+    onreturn: EventHandler<'a, (String, bool, Code)>,
+    value: String,
+}
+
+#[allow(non_snake_case)]
+pub fn ControlledInput<'a>(cx: Scope<'a, ControlledInputProps<'a>>) -> Element<'a> {
+    let ControlledInputProps {
+        id,
+        focus,
+        loading,
+        placeholder,
+        max_length,
+        size,
+        aria_label,
+        onchange,
+        onreturn,
+        value,
+    } = &cx.props;
+
+    render_input(
+        cx,
+        id,
+        *focus,
+        *loading,
+        placeholder,
+        *max_length,
+        *size,
+        aria_label,
+        onchange,
+        onreturn,
+        value.as_str(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render_input<'a>(
+    cx: &'a ScopeState,
+    id: &String,
+    focus: bool,
+    loading: bool,
+    placeholder: &String,
+    max_length: i32,
+    size: Size,
+    aria_label: &String,
+    onchange: &'a EventHandler<'a, (String, bool)>,
+    onreturn: &'a EventHandler<'a, (String, bool, Code)>,
+    value: &str,
+) -> Element<'a> {
     let height_script = include_str!("./update_input_height.js");
     dioxus_desktop::use_eval(cx)(height_script.to_string());
 
-    let element_id = &cx.props.id;
-    let element_label = &cx.props.aria_label;
-    let loading = cx.props.loading;
-    let element_max_length = cx.props.max_length;
-    let element_placeholder = &cx.props.placeholder;
-
     let script = include_str!("./script.js")
-        .replace("UUID", &cx.props.id)
+        .replace("UUID", id)
         .replace("$MULTI_LINE", &format!("{}", true));
+    let current_val = value.to_string();
 
     cx.render(rsx! (
         div {
-            class: format_args!("input-group {}", if cx.props.loading { "disabled" } else { " " }),
+            class: format_args!("input-group {}", if loading { "disabled" } else { " " }),
             div {
                 class: "input",
-                height: cx.props.size.get_height(),
+                height: "{size.get_height()}",
                 script { "{script}" },
                 textarea {
                     class: "input_textarea",
-                    id: "{element_id}",
+                    id: "{id}",
                     // todo: troubleshoot this. it isn't working
-                    autofocus: cx.props.focus,
-                    aria_label: "{element_label}",
+                    autofocus: focus,
+                    aria_label: "{aria_label}",
                     disabled: "{loading}",
-                    value: format_args!("{}", val.read()),
-                    maxlength: "{element_max_length}",
-                    placeholder: "{element_placeholder}",
+                    value: "{value}",
+                    maxlength: "{max_length}",
+                    placeholder: "{placeholder}",
                     oninput: move |evt| {
                         let current_val = evt.value.clone();
-                        *val.write_silent() = current_val;
-                        if !val.read().trim().is_empty() {
-                            cx.props.onchange.call((val.read().to_string(), true));
+                        if !current_val.trim().is_empty() {
+                            onchange.call((current_val, true));
                         }
                     },
                     onkeyup: move |evt| {
-                        let is_valid = !val.read().trim().is_empty();
+                        let is_valid = !current_val.trim().is_empty();
                         if evt.code() == Code::Enter && !evt.data.modifiers().contains(Modifiers::SHIFT) {
-                            cx.props.onreturn.call((val.read().to_string(), is_valid, evt.code()));
+                            onreturn.call((current_val.clone(), is_valid, evt.code()));
                         }
                     }
                 }

--- a/kit/src/elements/textarea/mod.rs
+++ b/kit/src/elements/textarea/mod.rs
@@ -20,10 +20,6 @@ impl Size {
     }
 }
 
-pub fn get_value(cx: &Scope<Props>) -> String {
-    cx.props.value.clone().unwrap_or_default()
-}
-
 #[derive(Props)]
 pub struct Props<'a> {
     #[props(default = "".to_owned())]
@@ -54,9 +50,12 @@ pub struct Props<'a> {
 pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let val = use_ref(cx, || cx.props.default_text.clone());
 
-    if !get_value(&cx).is_empty() {
-        val.set(get_value(&cx));
+    if let Some(value) = &cx.props.value {
+        if value != &*val.read() {
+            val.set(value.clone());
+        }
     }
+    println!("val: {:?}", val.read());
 
     if let Some(hook) = &cx.props.reset {
         let should_reset = hook.get();

--- a/kit/src/layout/chatbar/mod.rs
+++ b/kit/src/layout/chatbar/mod.rs
@@ -30,7 +30,6 @@ pub struct Props<'a> {
     loading: Option<bool>,
     onchange: EventHandler<'a, String>,
     onreturn: EventHandler<'a, String>,
-    reset: Option<UseState<bool>>,
 }
 
 #[derive(Props)]
@@ -80,10 +79,9 @@ pub fn Chatbar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             class: "chatbar",
             cx.props.with_replying_to.as_ref(),
             cx.props.with_file_upload.as_ref(),
-            textarea::Input {
+            textarea::ControlledInput {
                 loading: cx.props.loading.unwrap_or_default(),
                 placeholder: cx.props.placeholder.clone(),
-                reset: cx.props.reset.clone(),
                 focus: cx.props.with_replying_to.is_some(),
                 value: cx.props.value.clone().unwrap_or_default(),
                 onchange: move |(v, _)| cx.props.onchange.call(v),

--- a/native_extensions/emoji_selector/src/lib.rs
+++ b/native_extensions/emoji_selector/src/lib.rs
@@ -142,14 +142,7 @@ impl EmojiSelector {
                                                 };
                                                 let draft: String = c.draft.unwrap_or_default();
                                                 let new_draft = format!("{draft}{emoji}");
-                                                match state.inner().try_borrow_mut() {
-                                                    Ok(state) => {
-                                                        state.write().mutate(Action::SetChatDraft(c.id, new_draft));
-                                                    }
-                                                    Err(_) => {
-                                                        println!("emoji selector: try_borrow_mut error")
-                                                    }
-                                                };
+                                                state.write().mutate(Action::SetChatDraft(c.id, new_draft));
                                             },
                                             emoji.as_str()
                                         }

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -1,4 +1,5 @@
 use std::{
+    cell::Ref,
     path::PathBuf,
     rc::Rc,
     time::{Duration, Instant},
@@ -608,6 +609,56 @@ enum TypingIndicator {
     // resend the typing indicator
     Refresh(Uuid),
 }
+
+fn use_chat_text(cx: Scope<ComposeProps>) -> UseText {
+    let input = use_ref(cx, Vec::new);
+    let active_chat_id = cx.props.data.as_ref().map(|d| d.active_chat.id);
+    let state = use_shared_state::<State>(cx);
+    let typing_ch = use_coroutine_handle::<TypingIndicator>(cx).unwrap();
+
+    UseText {
+        local_text: input,
+        active_chat_id,
+        state,
+        typing_ch,
+    }
+}
+
+#[derive(Copy, Clone)]
+struct UseText<'a> {
+    local_text: &'a UseRef<Vec<String>>,
+    active_chat_id: Option<Uuid>,
+    state: Option<UseSharedState<'a, State>>,
+    typing_ch: &'a Coroutine<TypingIndicator>,
+}
+
+impl UseText<'_> {
+    pub fn read(&self) -> Ref<'_, Vec<String>> {
+        self.local_text.read()
+    }
+
+    pub fn with_mut(&self, f: impl FnOnce(&mut Vec<String>)) {
+        f(&mut self.local_text.write());
+        if let Some(id) = &self.active_chat_id {
+            self.typing_ch.send(TypingIndicator::Typing(*id));
+            // TODO: Maybe we should debounce this in the future so we don't do it on EVERY keypress.
+            if let Some(state) = self.state {
+                state
+                    .write()
+                    .mutate(Action::SetChatDraft(*id, self.local_text.read().join("\n")));
+            }
+        }
+    }
+
+    pub fn set(&self, text: Vec<String>) {
+        self.with_mut(|v| *v = text);
+    }
+
+    pub fn clear(&self) {
+        self.with_mut(|v| v.clear());
+    }
+}
+
 #[derive(Clone)]
 struct TypingInfo {
     pub chat_id: Uuid,
@@ -618,11 +669,9 @@ struct TypingInfo {
 fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
     log::trace!("get_chatbar");
     let state = use_shared_state::<State>(cx)?;
+    let active_chat_id = cx.props.data.as_ref().map(|d| d.active_chat.id);
     let data = cx.props.data.clone();
     let is_loading = data.is_none();
-    let input = use_ref(cx, Vec::<String>::new);
-    let should_clear_input = use_state(cx, || false);
-    let active_chat_id = data.as_ref().map(|d| d.active_chat.id);
 
     let is_reply = active_chat_id
         .and_then(|id| {
@@ -769,6 +818,8 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
         }
     });
 
+    let input = use_chat_text(cx);
+
     // drives the sending of TypingIndicator
     let local_typing_ch1 = local_typing_ch.clone();
     use_future(cx, &active_chat_id.clone(), |current_chat| async move {
@@ -790,8 +841,7 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
 
         let msg = input.read().clone();
         // clearing input here should prevent the possibility to double send a message if enter is pressed twice
-        input.write().clear();
-        should_clear_input.set(true);
+        input.clear();
 
         if !msg_valid(&msg) {
             return;
@@ -823,14 +873,8 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
     let chatbar = cx.render(rsx!(Chatbar {
         loading: is_loading,
         placeholder: get_local_text("messages.say-something-placeholder"),
-        reset: should_clear_input.clone(),
         onchange: move |v: String| {
-            *input.write_silent() = v.lines().map(|x| x.to_string()).collect::<Vec<String>>();
-            if let Some(id) = &active_chat_id {
-                local_typing_ch.send(TypingIndicator::Typing(*id));
-                // TODO: Maybe we should debounce this in the future so we don't do it on EVERY keypress.
-                state.write_silent().mutate(Action::SetChatDraft(*id, v));
-            }
+            input.set(v.lines().map(|x| x.to_string()).collect::<Vec<String>>());
         },
         value: data
             .as_ref()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- fixes an issue arising from the state of textarea being stored in multiple places 
- fixes a bug where using `state.inner()` prevents the subscribers from being notified of a change. (that one was my fault)

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

