### PR TITLE
fix(notification): make sound when chat UI is not active

### DIFF
--- a/common/src/state/action.rs
+++ b/common/src/state/action.rs
@@ -126,6 +126,9 @@ pub enum Action {
     /// Sets the active chat to a given chat
     #[display(fmt = "ChatWith")]
     ChatWith(Chat),
+    /// Removes the active chat
+    #[display(fmt = "ClearActiveChat")]
+    ClearActiveChat,
     /// Adds a chat to the sidebar
     #[display(fmt = "AddToSidebar")]
     AddToSidebar(Chat),

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -195,6 +195,9 @@ impl State {
                 let chat = self.chats.all.entry(chat.id).or_insert(chat);
                 chat.unreads = 0;
             }
+            Action::ClearActiveChat => {
+                self.clear_active_chat();
+            }
             Action::NewMessage(_, _) => todo!(),
             Action::StartReplying(chat, message) => self.start_replying(&chat, &message),
             Action::CancelReply(chat_id) => self.cancel_reply(chat_id),

--- a/ui/src/layouts/chat.rs
+++ b/ui/src/layouts/chat.rs
@@ -1,7 +1,10 @@
 use dioxus::prelude::*;
 
-use crate::components::chat::{
-    compose::Compose, sidebar::Sidebar as ChatSidebar, welcome::Welcome, RouteInfo,
+use crate::{
+    components::chat::{
+        compose::Compose, sidebar::Sidebar as ChatSidebar, welcome::Welcome, RouteInfo,
+    },
+    utils::lifecycle::use_on_unmount,
 };
 use common::state::{ui, Action, State};
 
@@ -14,6 +17,16 @@ pub struct Props {
 pub fn ChatLayout(cx: Scope<Props>) -> Element {
     let state = use_shared_state::<State>(cx)?;
     let first_render = use_state(cx, || true);
+
+    // when the user leaves the chat layout, no chat is active anymore
+    use_on_unmount(cx, {
+        // we need to call inner here in order to move into the closure, but we lose updates
+        // TODO: next version of dioxus will fix this
+        let state = state.inner();
+        move || {
+            state.borrow_mut().write().mutate(Action::ClearActiveChat);
+        }
+    });
 
     state.write_silent().ui.current_layout = ui::Layout::Welcome;
 

--- a/ui/src/utils/lifecycle.rs
+++ b/ui/src/utils/lifecycle.rs
@@ -1,0 +1,18 @@
+use dioxus::prelude::*;
+
+pub fn use_on_unmount<F: FnOnce() + 'static>(cx: &ScopeState, on_unmount: F) -> &LifeCycle<F> {
+    cx.use_hook(|| LifeCycle {
+        on_unmount: Some(on_unmount),
+    })
+}
+
+pub struct LifeCycle<D: FnOnce()> {
+    on_unmount: Option<D>,
+}
+
+impl<D: FnOnce()> Drop for LifeCycle<D> {
+    fn drop(&mut self) {
+        let f = self.on_unmount.take().unwrap();
+        f();
+    }
+}

--- a/ui/src/utils/mod.rs
+++ b/ui/src/utils/mod.rs
@@ -10,6 +10,7 @@ use walkdir::WalkDir;
 use kit::User as UserInfo;
 
 pub mod format_timestamp;
+pub mod lifecycle;
 
 pub fn get_available_themes() -> Vec<Theme> {
     let mut themes = vec![];


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Remove the active chat when the chat UI is removed which enables notification sounds when in non-chat sections of the app like settings.

### Which issue(s) this PR fixes 🔨

- Resolve #306
