### PR TITLE
fix(messages): prevent messages jumping around on re-render

### DIFF
--- a/kit/src/components/context_menu/mod.rs
+++ b/kit/src/components/context_menu/mod.rs
@@ -4,7 +4,7 @@ use dioxus::{
     events::{MouseData, MouseEvent},
     prelude::*,
 };
-use dioxus_desktop::use_window;
+use dioxus_desktop::{use_eval, use_window};
 
 #[derive(Props)]
 pub struct ItemProps<'a> {
@@ -65,10 +65,18 @@ pub struct Props<'a> {
 
 #[allow(non_snake_case)]
 pub fn ContextMenu<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
-    // Handles the hiding and showing of the context menu
-    let script = include_str!("./context.js").replace("UUID", &cx.props.id);
     let id = format!("{}-context-menu", &cx.props.id);
     let window = use_window(cx);
+
+    // Handles the hiding and showing of the context menu
+    let eval = use_eval(cx);
+    use_effect(cx, (&id,), |(id,)| {
+        to_owned![eval];
+        async move {
+            let script = include_str!("./context.js").replace("UUID", &id);
+            eval(script);
+        }
+    });
 
     cx.render(rsx! {
         div {
@@ -92,6 +100,5 @@ pub fn ContextMenu<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 ))
             },
         },
-        script { "{script}" }
     })
 }

--- a/kit/src/elements/button/mod.rs
+++ b/kit/src/elements/button/mod.rs
@@ -103,9 +103,7 @@ pub fn emit(cx: &Scope<Props>, e: Event<MouseData>) {
 /// ```
 #[allow(non_snake_case)]
 pub fn Button<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
-    let UUID = Uuid::new_v4().to_string();
-
-    let script = get_script(SCRIPT, &UUID);
+    let UUID = &*cx.use_hook(|| Uuid::new_v4().to_string());
 
     let text = get_text(&cx);
     let aria_label = get_aria_label(&cx);
@@ -114,6 +112,17 @@ pub fn Button<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let appearance = get_appearance(&cx);
     let small = cx.props.small.unwrap_or_default();
     let text2 = text.clone();
+
+    let eval = dioxus_desktop::use_eval(cx);
+    // only run this after the component has been mounted
+    use_effect(cx, (UUID,), move |(UUID,)| {
+        to_owned![eval];
+        async move {
+            let script = get_script(SCRIPT, &UUID);
+            eval(script);
+        }
+    });
+
     cx.render(
         rsx!(
             div {
@@ -160,7 +169,6 @@ pub fn Button<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     (!text.is_empty()).then(|| rsx!( "{text2}" )),
                 }
             },
-            script{ "{script}" },
         )
     )
 }

--- a/kit/src/elements/file/mod.rs
+++ b/kit/src/elements/file/mod.rs
@@ -2,7 +2,6 @@ use std::ffi::OsStr;
 
 use dioxus::prelude::*;
 use dioxus_elements::input_data::keyboard_types::Code;
-use uuid::Uuid;
 
 use crate::elements::{
     button::Button,
@@ -126,7 +125,6 @@ pub fn File<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 with_rename.then(||
                     rsx! (
                         Input {
-                                id: Uuid::new_v4().to_string(),
                                 disabled: disabled,
                                 placeholder: placeholder,
                                 focus: true,

--- a/kit/src/elements/folder/mod.rs
+++ b/kit/src/elements/folder/mod.rs
@@ -1,6 +1,5 @@
 use dioxus::prelude::*;
 use dioxus_elements::input_data::keyboard_types::Code;
-use uuid::Uuid;
 
 use crate::elements::input::{Input, Options, Size, SpecialCharsAction, Validation};
 
@@ -74,7 +73,6 @@ pub fn Folder<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 with_rename.then(||
                         rsx! (
                             Input {
-                                id: Uuid::new_v4().to_string(),
                                 disabled: disabled,
                                 placeholder: placeholder,
                                 focus: true,

--- a/kit/src/elements/tooltip/mod.rs
+++ b/kit/src/elements/tooltip/mod.rs
@@ -49,7 +49,7 @@ pub struct Props {
 #[allow(non_snake_case)]
 pub fn Tooltip(cx: Scope<Props>) -> Element {
     // You don't always need a UUID. It's used in this case because although the tooltip has generic styles, it needs a unique identifier for runtime actions.
-    let UUID: String = Uuid::new_v4().to_string();
+    let UUID = cx.use_hook(|| Uuid::new_v4().to_string());
 
     let arrow_position = get_arrow_position(&cx);
 

--- a/kit/src/layout/sidebar/mod.rs
+++ b/kit/src/layout/sidebar/mod.rs
@@ -1,4 +1,5 @@
 use dioxus::prelude::*;
+use dioxus_desktop::use_eval;
 
 #[derive(Props)]
 pub struct Props<'a> {
@@ -18,6 +19,15 @@ const SCRIPT: &str = include_str!("./script.js");
 pub fn Sidebar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let hidden = cx.props.hidden.unwrap_or(false);
 
+    // Run the script after the component is mounted
+    let eval = use_eval(cx);
+    use_effect(cx, (), |_| {
+        to_owned![eval];
+        async move {
+            eval(SCRIPT.to_string());
+        }
+    });
+
     cx.render(rsx!(
         div {
             class: {
@@ -36,6 +46,5 @@ pub fn Sidebar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             },
             cx.props.with_nav.as_ref(),
         },
-        script { SCRIPT }
     ))
 }

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -331,8 +331,14 @@ fn get_messages(cx: Scope<ComposeProps>) -> Element {
     let edit_msg: &UseState<Option<Uuid>> = use_state(cx, || None);
     let user = state.read().did_key();
 
-    let script = include_str!("./script.js");
-    use_eval(cx)(script.to_string());
+    let eval = use_eval(cx);
+    use_effect(cx, (), move |_| {
+        to_owned![eval];
+        async move {
+            let script = include_str!("./script.js");
+            eval(script.to_string());
+        }
+    });
 
     let ch = use_coroutine(cx, |mut rx: UnboundedReceiver<MessagesCommand>| {
         //to_owned![];

--- a/ui/src/components/debug_logger/mod.rs
+++ b/ui/src/components/debug_logger/mod.rs
@@ -1,5 +1,6 @@
 use dioxus::prelude::*;
 
+use dioxus_desktop::use_eval;
 use kit::elements::label::Label;
 
 use crate::logger;
@@ -19,6 +20,15 @@ pub fn DebugLogger(cx: Scope) -> Element {
             while let Some(log) = log_ch.recv().await {
                 logs_to_show.with_mut(|x| x.push(log.to_string()));
             }
+        }
+    });
+
+    // Run the script after the component is mounted
+    let eval = use_eval(cx);
+    use_effect(cx, (), |_| {
+        to_owned![eval];
+        async move {
+            eval(SCRIPT.to_string());
         }
     });
 
@@ -75,6 +85,5 @@ pub fn DebugLogger(cx: Scope) -> Element {
                 }
             }
         },
-        script { SCRIPT }
     ))
 }

--- a/ui/src/components/media/popout_player.rs
+++ b/ui/src/components/media/popout_player.rs
@@ -1,4 +1,5 @@
 use dioxus::prelude::*;
+use dioxus_desktop::use_eval;
 
 use common::icons::outline::Shape as Icon;
 use common::icons::Icon as IconElement;
@@ -17,6 +18,15 @@ pub const SCRIPT: &str = include_str!("./script.js");
 #[allow(non_snake_case)]
 pub fn PopoutPlayer(cx: Scope, _drop_handler: WindowDropHandler) -> Element {
     let cmd_tx = WINDOW_CMD_CH.tx.clone();
+
+    // Run the script after the component is mounted
+    let eval = use_eval(cx);
+    use_effect(cx, (), |_| {
+        to_owned![eval];
+        async move {
+            eval(SCRIPT.to_string());
+        }
+    });
 
     cx.render(
         rsx! (
@@ -68,6 +78,5 @@ pub fn PopoutPlayer(cx: Scope, _drop_handler: WindowDropHandler) -> Element {
                 }
             },
         },
-        script { "{SCRIPT}" }
     ))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Fixes messages jumping around when they re-render. This was caused by scripts running every render instead of just the first render.
- Moves all scripts from script elements to use_eval calls inside use_effect hooks. 
- Fixes some Uuid's regenerating ids every render causing poor performance.

Resizing the window now runs less scripts:
Old:
![image](https://user-images.githubusercontent.com/66571940/224462462-3162f6d2-b086-4f5e-90d1-3db6188c34ad.png)
New:
![image](https://user-images.githubusercontent.com/66571940/224462343-f213a193-7392-420d-88e3-8fcaaec5f0c2.png)

### Which issue(s) this PR fixes 🔨

- Resolve #343 

