### PR TITLE
feat(conversations): clear unreads and move chats to top of sidebar

### DIFF
--- a/common/src/state/action.rs
+++ b/common/src/state/action.rs
@@ -129,9 +129,6 @@ pub enum Action {
     /// Removes the active chat
     #[display(fmt = "ClearActiveChat")]
     ClearActiveChat,
-    /// Adds a chat to the sidebar
-    #[display(fmt = "AddToSidebar")]
-    AddToSidebar(Chat),
     /// Removes a chat from the sidebar, also removes the active chat if the chat being removed matches
     #[display(fmt = "RemoveFromSidebar")]
     RemoveFromSidebar(Uuid),

--- a/common/src/state/action.rs
+++ b/common/src/state/action.rs
@@ -124,8 +124,9 @@ pub enum Action {
     #[display(fmt = "UnFavorite")]
     UnFavorite(Uuid),
     /// Sets the active chat to a given chat
+    /// chat, should_move_to_top
     #[display(fmt = "ChatWith")]
-    ChatWith(Chat),
+    ChatWith(Chat, bool),
     /// Removes the active chat
     #[display(fmt = "ClearActiveChat")]
     ClearActiveChat,

--- a/common/src/state/chats.rs
+++ b/common/src/state/chats.rs
@@ -48,7 +48,7 @@ pub struct Chats {
     #[serde(skip)]
     pub active_media: Option<Uuid>, // TODO: in the future, this should probably be a vec of media streams or something
     // Chats to show in the sidebar
-    pub in_sidebar: Vec<Uuid>,
+    pub in_sidebar: VecDeque<Uuid>,
     // Favorite Chats
     pub favorites: Vec<Uuid>,
 }

--- a/common/src/state/chats.rs
+++ b/common/src/state/chats.rs
@@ -14,18 +14,16 @@ use crate::{warp_runner::ui_adapter, STATIC_ARGS};
 pub struct Chat {
     // Warp generated UUID of the chat
     // TODO: This should be wired up to warp conversation id's
-    #[serde(default)]
     pub id: Uuid,
     // Includes the list of participants within a given chat.
     // these don't need to be stored in state either
-    #[serde(default)]
     pub participants: HashSet<DID>,
     // Messages should only contain messages we want to render. Do not include the entire message history.
     // don't store the actual message in state
+    // warn: Chat has a custom serialize method which skips this field when not using mock data.
     #[serde(default)]
     pub messages: VecDeque<ui_adapter::Message>,
     // Unread count for this chat, should be cleared when we view the chat.
-    #[serde(default)]
     pub unreads: u32,
     // If a value exists, we will render the message we're replying to above the chatbar
     #[serde(skip)]
@@ -42,20 +40,16 @@ pub struct Chats {
     #[serde(skip)]
     pub initialized: bool,
     // All active chats from warp.
-    #[serde(skip)]
     pub all: HashMap<Uuid, Chat>,
     // Chat to display / interact with currently.
-    #[serde(default)]
     pub active: Option<Uuid>,
     // don't persist a call across restarts
     // the Uuid is the chat associated with the current call
     #[serde(skip)]
     pub active_media: Option<Uuid>, // TODO: in the future, this should probably be a vec of media streams or something
     // Chats to show in the sidebar
-    #[serde(default)]
     pub in_sidebar: Vec<Uuid>,
     // Favorite Chats
-    #[serde(default)]
     pub favorites: Vec<Uuid>,
 }
 
@@ -115,12 +109,11 @@ impl Serialize for Chat {
     {
         let mut state = serializer.serialize_struct("Chat", 5)?;
         state.serialize_field("id", &self.id)?;
+        state.serialize_field("participants", &self.participants)?;
 
         if STATIC_ARGS.use_mock {
-            state.serialize_field("participants", &self.participants)?;
             state.serialize_field("messages", &self.messages)?;
         } else {
-            state.skip_field("participants")?;
             state.skip_field("messages")?;
         }
 

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -358,14 +358,7 @@ impl State {
                 // todo: don't load all the messages by default. if the user scrolled up, for example, this incoming message may not need to be fetched yet.
                 self.add_msg_to_chat(conversation_id, message);
 
-                if self
-                    .chats
-                    .active
-                    .as_ref()
-                    .map(|x| x != &conversation_id)
-                    .unwrap_or(true)
-                    && self.chats.in_sidebar.contains(&conversation_id)
-                {
+                if self.chats.in_sidebar.contains(&conversation_id) {
                     self.send_chat_to_top_of_sidebar(conversation_id);
                 }
 

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -163,10 +163,6 @@ impl State {
             Action::SetOverlay(enabled) => self.toggle_overlay(enabled),
             // Sidebar
             Action::RemoveFromSidebar(chat_id) => self.remove_sidebar_chat(chat_id),
-            Action::AddToSidebar(chat) => {
-                self.add_chat_to_sidebar(chat.clone());
-                self.chats.all.entry(chat.id).or_insert(chat);
-            }
             Action::SidebarHidden(hidden) => self.ui.sidebar_hidden = hidden,
             // Navigation
             Action::Navigate(to) => self.set_active_route(to),
@@ -361,6 +357,17 @@ impl State {
                 let id = self.identities.get(&message.inner.sender()).cloned();
                 // todo: don't load all the messages by default. if the user scrolled up, for example, this incoming message may not need to be fetched yet.
                 self.add_msg_to_chat(conversation_id, message);
+
+                if self
+                    .chats
+                    .active
+                    .as_ref()
+                    .map(|x| x != &conversation_id)
+                    .unwrap_or(true)
+                    && self.chats.in_sidebar.contains(&conversation_id)
+                {
+                    self.send_chat_to_top_of_sidebar(conversation_id);
+                }
 
                 self.mutate(Action::AddNotification(
                     notifications::NotificationKind::Message,
@@ -604,17 +611,6 @@ impl State {
         self.identities
             .extend(identities.iter().map(|x| (x.did_key(), x.clone())));
     }
-
-    /// Adds a chat to the sidebar in the `State` struct.
-    ///
-    /// # Arguments
-    ///
-    /// * `chat` - The chat to add to the sidebar.
-    fn add_chat_to_sidebar(&mut self, chat: Chat) {
-        if !self.chats.in_sidebar.contains(&chat.id) {
-            self.chats.in_sidebar.push(chat.id);
-        }
-    }
     fn add_msg_to_chat(&mut self, conversation_id: Uuid, message: ui_adapter::Message) {
         if let Some(chat) = self.chats.all.get_mut(&conversation_id) {
             chat.typing_indicator.remove(&message.inner.sender());
@@ -829,8 +825,12 @@ impl State {
     fn set_active_chat(&mut self, chat: &Chat) {
         self.chats.active = Some(chat.id);
         if !self.chats.in_sidebar.contains(&chat.id) {
-            self.chats.in_sidebar.push(chat.id);
+            self.chats.in_sidebar.push_front(chat.id);
         }
+    }
+    fn send_chat_to_top_of_sidebar(&mut self, chat_id: Uuid) {
+        self.chats.in_sidebar.retain(|id| id != &chat_id);
+        self.chats.in_sidebar.push_front(chat_id);
     }
     /// Begins replying to a message in the specified chat in the `State` struct.
     fn start_replying(&mut self, chat: &Chat, message: &Message) {

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -409,6 +409,7 @@ impl State {
                 if let Some(chat) = self.chats.all.get_mut(&conversation_id) {
                     chat.messages.push_back(message);
                 }
+                self.send_chat_to_top_of_sidebar(conversation_id);
             }
             MessageEvent::Edited {
                 conversation_id,

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -602,7 +602,6 @@ impl State {
         for (id, chat) in chats {
             if let Some(conv) = self.chats.all.get_mut(&id) {
                 conv.messages = chat.messages;
-                conv.participants = chat.participants;
             } else {
                 self.chats.all.insert(id, chat);
             }

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -816,9 +816,7 @@ impl State {
     /// * `chat` - The chat to set as the active chat.
     fn set_active_chat(&mut self, chat: &Chat) {
         self.chats.active = Some(chat.id);
-        if !self.chats.in_sidebar.contains(&chat.id) {
-            self.chats.in_sidebar.push_front(chat.id);
-        }
+        self.send_chat_to_top_of_sidebar(chat.id);
     }
     fn send_chat_to_top_of_sidebar(&mut self, chat_id: Uuid) {
         self.chats.in_sidebar.retain(|id| id != &chat_id);

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -178,10 +178,10 @@ impl State {
             Action::ClearTheme => self.set_theme(None),
 
             // ===== Chats =====
-            Action::ChatWith(chat) => {
+            Action::ChatWith(chat, should_move_to_top) => {
                 // warning: ensure that warp is used to get/create the chat which is passed in here
                 //todo: check if (for the side which created the conversation) a warp event comes in and consider using that instead
-                self.set_active_chat(&chat);
+                self.set_active_chat(&chat, should_move_to_top);
                 let chat = self.chats.all.entry(chat.id).or_insert(chat);
                 chat.unreads = 0;
             }
@@ -814,9 +814,13 @@ impl State {
     /// # Arguments
     ///
     /// * `chat` - The chat to set as the active chat.
-    fn set_active_chat(&mut self, chat: &Chat) {
+    fn set_active_chat(&mut self, chat: &Chat, should_move_to_top: bool) {
         self.chats.active = Some(chat.id);
-        self.send_chat_to_top_of_sidebar(chat.id);
+        if should_move_to_top {
+            self.send_chat_to_top_of_sidebar(chat.id);
+        } else if !self.chats.in_sidebar.contains(&chat.id) {
+            self.chats.in_sidebar.push_front(chat.id);
+        }
     }
     fn send_chat_to_top_of_sidebar(&mut self, chat_id: Uuid) {
         self.chats.in_sidebar.retain(|id| id != &chat_id);

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -47,7 +47,7 @@ use warp::{
 };
 
 use self::storage::Storage;
-use self::{action::ActionHook, configuration::Configuration, ui::Call};
+use self::{action::ActionHook, ui::Call};
 
 // todo: create an Identity cache and only store UUID in state.friends and state.chats
 // store the following information in the cache: key: DID, value: { Identity, HashSet<UUID of conversations this identity is participating in> }
@@ -56,19 +56,13 @@ use self::{action::ActionHook, configuration::Configuration, ui::Call};
 pub struct State {
     #[serde(skip)]
     id: DID,
-    #[serde(default)]
     pub route: route::Route,
-    #[serde(default)]
     chats: chats::Chats,
-    #[serde(default)]
     friends: friends::Friends,
     #[serde(skip)]
     pub storage: storage::Storage,
-    #[serde(default)]
     pub settings: settings::Settings,
-    #[serde(default)]
     pub ui: ui::UI,
-    #[serde(default)]
     pub configuration: configuration::Configuration,
     #[serde(skip_serializing, skip_deserializing)]
     pub(crate) hooks: Vec<action::ActionHook>,
@@ -520,13 +514,19 @@ impl State {
         let contents = match fs::read_to_string(&STATIC_ARGS.cache_path) {
             Ok(r) => r,
             Err(_) => {
-                return State {
-                    configuration: Configuration::new(),
-                    ..State::default()
-                };
+                log::info!("state.json not found. Initializing State with default values");
+                return State::default();
             }
         };
-        let mut state: Self = serde_json::from_str(&contents).unwrap_or_default();
+        let mut state: Self = match serde_json::from_str(&contents) {
+            Ok(s) => s,
+            Err(e) => {
+                log::error!(
+                    "state.json failed to deserialize: {e}. Initializing State with default values"
+                );
+                return State::default();
+            }
+        };
         // not sure how these defaulted to true, but this should serve as additional
         // protection in the future
         state.friends.initialized = false;
@@ -592,7 +592,14 @@ impl State {
             .collect()
     }
     pub fn set_chats(&mut self, chats: HashMap<Uuid, Chat>, identities: HashSet<Identity>) {
-        self.chats.all = chats;
+        for (id, chat) in chats {
+            if let Some(conv) = self.chats.all.get_mut(&id) {
+                conv.messages = chat.messages;
+                conv.participants = chat.participants;
+            } else {
+                self.chats.all.insert(id, chat);
+            }
+        }
         self.chats.initialized = true;
         self.identities
             .extend(identities.iter().map(|x| (x.did_key(), x.clone())));

--- a/common/src/testing/mock.rs
+++ b/common/src/testing/mock.rs
@@ -44,7 +44,7 @@ pub fn generate_mock() -> State {
 
     // all_chats.insert(group_chat.id, group_chat);
 
-    let in_sidebar = vec![];
+    let in_sidebar = VecDeque::new();
     // in_sidebar.push(group_chat_sidebar.id);
     let mut toast_notifications = HashMap::new();
     toast_notifications.insert(

--- a/ui/src/components/chat/sidebar.rs
+++ b/ui/src/components/chat/sidebar.rs
@@ -111,7 +111,7 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
                                                 if state.read().ui.is_minimal_view() {
                                                     state.write().mutate(Action::SidebarHidden(true));
                                                 }
-                                                state.write().mutate(Action::ChatWith(favorites_chat.clone()));
+                                                state.write().mutate(Action::ChatWith(favorites_chat.clone(), false));
                                                 if cx.props.route_info.active.to != UPLINK_ROUTES.chat {
                                                     use_router(cx).replace_route(UPLINK_ROUTES.chat, None, None);
                                                 }
@@ -133,7 +133,7 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
                                             if state.read().ui.is_minimal_view() {
                                                 state.write().mutate(Action::SidebarHidden(true));
                                             }
-                                            state.write().mutate(Action::ChatWith(chat.clone()));
+                                            state.write().mutate(Action::ChatWith(chat.clone(), false));
                                             if cx.props.route_info.active.to != UPLINK_ROUTES.chat {
                                                 use_router(cx).replace_route(UPLINK_ROUTES.chat, None, None);
                                             }
@@ -251,7 +251,7 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
                                 )),
                                 with_badge: badge,
                                 onpress: move |_| {
-                                    state.write().mutate(Action::ChatWith(chat_with.clone()));
+                                    state.write().mutate(Action::ChatWith(chat_with.clone(), false));
                                     if cx.props.route_info.active.to != UPLINK_ROUTES.chat {
                                         use_router(cx).replace_route(UPLINK_ROUTES.chat, None, None);
                                     }

--- a/ui/src/components/friends/friends_list/mod.rs
+++ b/ui/src/components/friends/friends_list/mod.rs
@@ -51,7 +51,7 @@ pub fn Friends(cx: Scope) -> Element {
 
     if let Some(chat) = chat_with.get().clone() {
         chat_with.set(None);
-        state.write().mutate(Action::ChatWith(chat));
+        state.write().mutate(Action::ChatWith(chat, true));
         if state.read().ui.is_minimal_view() {
             state.write().mutate(Action::SidebarHidden(true));
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Chats weren't being serialized, resulting in the unread messages resetting each time the app restarted. State was updated to persist chats. 
- When a new message comes in or a chat is added to the sidebar, the conversation is moved to the top of the sidebar (if it wasn't the active conversation)

### Which issue(s) this PR fixes 🔨

- Resolve #417 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
You may need to restart uplink once before it starts working. The first run may result in a Serde error. But once friends and chats are initialized, State will be saved and State should be successfully deserialized on subsequent runs. 
