### PR TITLE
feat(chat): Disable various chat feature if not friend anymore

### DIFF
--- a/common/locales/en-US/main.ftl
+++ b/common/locales/en-US/main.ftl
@@ -39,7 +39,7 @@ messages = Messages
     .say-something-placeholder = Say Something...
     .user-sent-message = sent you a message.
     .unknown-sent-message = someone sent you a message.
-    .not-friends = You are not friends
+    .not-friends = You are not friends anymore
     
 favorites = Favorites
     .favorites = Favorites

--- a/common/locales/en-US/main.ftl
+++ b/common/locales/en-US/main.ftl
@@ -39,7 +39,8 @@ messages = Messages
     .say-something-placeholder = Say Something...
     .user-sent-message = sent you a message.
     .unknown-sent-message = someone sent you a message.
-
+    .not-friends = You are not friends
+    
 favorites = Favorites
     .favorites = Favorites
     .add = Add to Favorites

--- a/common/locales/en-US/main.ftl
+++ b/common/locales/en-US/main.ftl
@@ -39,7 +39,8 @@ messages = Messages
     .say-something-placeholder = Say Something...
     .user-sent-message = sent you a message.
     .unknown-sent-message = someone sent you a message.
-
+    .not-friends = You are not friends anymore
+    
 favorites = Favorites
     .favorites = Favorites
     .add = Add to Favorites

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -727,6 +727,22 @@ impl State {
             })
             .cloned()
     }
+    pub fn can_use_active_chat(&self) -> bool {
+        self.get_active_chat()
+            .map(|c| {
+                let participants = &c.participants;
+                if participants.len() == 2 {
+                    return c
+                        .participants
+                        .iter()
+                        .all(|e| e.eq(&self.did_key()) || self.has_friend_with_did(e));
+                }
+                // If more than 2 participants -> group chat
+                // Dont need to be friends with all in a group
+                true
+            })
+            .unwrap_or_default()
+    }
     // Define a method for sorting a vector of messages.
     pub fn get_sort_messages(&self, chat: &Chat) -> Vec<MessageGroup> {
         if chat.messages.is_empty() {

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -900,8 +900,6 @@ impl State {
             None => return,
         };
 
-        self.remove_sidebar_chat(direct_chat.id);
-
         // If the friend's direct chat is currently the active chat, clear the active chat
         if let Some(id) = self.chats.active {
             if id == direct_chat.id {

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -647,6 +647,22 @@ impl State {
             c.replying_to = None;
         }
     }
+    pub fn can_use_active_chat(&self) -> bool {
+        self.get_active_chat()
+            .map(|c| {
+                let participants = &c.participants;
+                if participants.len() == 2 {
+                    return c
+                        .participants
+                        .iter()
+                        .all(|e| e.eq(&self.did_key()) || self.has_friend_with_did(e));
+                }
+                // If more than 2 participants -> group chat
+                // Dont need to be friends with all in a group
+                true
+            })
+            .unwrap_or_default()
+    }
     /// Clears the active chat in the `State` struct.
     fn clear_active_chat(&mut self) {
         self.chats.active = None;
@@ -916,8 +932,6 @@ impl State {
             Some(c) => c,
             None => return,
         };
-
-        self.remove_sidebar_chat(direct_chat.id);
 
         // If the friend's direct chat is currently the active chat, clear the active chat
         if let Some(id) = self.chats.active {

--- a/kit/src/elements/textarea/mod.rs
+++ b/kit/src/elements/textarea/mod.rs
@@ -44,10 +44,10 @@ pub struct Props<'a> {
     onreturn: EventHandler<'a, (String, bool, Code)>,
     #[props(!optional)]
     reset: Option<UseState<bool>>,
-    #[props(optional)]
-    is_disabled: Option<bool>,
-    #[props(optional)]
-    tooltip: Option<String>,
+    #[props(default = false)]
+    is_disabled: bool,
+    #[props(default = "".to_owned())]
+    tooltip: String,
 }
 
 #[allow(non_snake_case)]
@@ -66,7 +66,7 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let element_label = &cx.props.aria_label;
     let element_max_length = cx.props.max_length;
     let element_placeholder = &cx.props.placeholder;
-    let disabled = cx.props.loading || cx.props.is_disabled.unwrap_or_default();
+    let disabled = cx.props.loading || cx.props.is_disabled;
 
     let eval = dioxus_desktop::use_eval(cx);
     // only run this after the component has been mounted and when the id of the input changes
@@ -104,7 +104,7 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     disabled: "{disabled}",
                     value: "{val.read()}",
                     maxlength: "{element_max_length}",
-                    placeholder: format_args!("{}", if cx.props.is_disabled.unwrap_or_default() {""} else {element_placeholder}),
+                    placeholder: format_args!("{}", if cx.props.is_disabled {""} else {element_placeholder}),
                     onblur: move |_| {
                         cx.props.onreturn.call((val.read().to_string(), false, Code::Enter));
                     },
@@ -123,12 +123,14 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     }
                 }
             },
-            cx.props.tooltip.as_deref().filter(|s| cx.props.is_disabled.unwrap_or_default() && !s.is_empty()).map(|s| cx.render(rsx!(
-                Tooltip {
-                    arrow_position: ArrowPosition::None,
-                    text: s.to_string(),
-                }
-            )))
+            if cx.props.is_disabled && !cx.props.tooltip.is_empty() {
+                cx.render(rsx!(
+                    Tooltip {
+                        arrow_position: ArrowPosition::None,
+                        text: cx.props.tooltip.clone(),
+                    }
+                ))
+            }
         }
     ))
 }

--- a/kit/src/elements/textarea/script.js
+++ b/kit/src/elements/textarea/script.js
@@ -1,3 +1,27 @@
+(() => {
+    const input_group = document.getElementById("$UUID").parentNode.parentNode
+    // parent: input, parent of parent: input-group
+    const tooltip = input_group.getElementsByClassName("tooltip")[0]
+
+    if (tooltip != null) {
+        input_group.addEventListener("mouseover", function (e) {
+            tooltip.classList.remove("hidden")
+            tooltip.classList.add("visible")
+            tooltip.style.position = "fixed"
+            tooltip.style.left = e.clientX + "px"
+            tooltip.style.top = (e.clientY - 50) + "px"
+        })
+        input_group.addEventListener("mousemove", function (e) {
+            tooltip.style.position = "fixed"
+            tooltip.style.left = e.clientX + "px"
+            tooltip.style.top = (e.clientY - 50) + "px"
+        })
+        input_group.addEventListener("mouseout", function (e) {
+            tooltip.classList.remove("visible")
+            tooltip.classList.add("hidden")
+        })
+    }
+})()
 
 var MULTI_LINE = $MULTI_LINE;
 

--- a/kit/src/elements/textarea/script.js
+++ b/kit/src/elements/textarea/script.js
@@ -1,3 +1,29 @@
+(() => {
+    // Handle moving and hiding/showing tooltip
+    const input_group = document.getElementById("$UUID").parentNode.parentNode
+    // parent: input, parent of parent: input-group
+    // tooltip is child of input-group
+    const tooltip = input_group.getElementsByClassName("tooltip")[0]
+
+    if (tooltip != null) {
+        input_group.addEventListener("mouseover", function (e) {
+            tooltip.classList.remove("hidden")
+            tooltip.classList.add("visible")
+            tooltip.style.position = "fixed"
+            tooltip.style.left = e.clientX + "px"
+            tooltip.style.top = (e.clientY - 50) + "px"
+        })
+        input_group.addEventListener("mousemove", function (e) {
+            tooltip.style.position = "fixed"
+            tooltip.style.left = e.clientX + "px"
+            tooltip.style.top = (e.clientY - 50) + "px"
+        })
+        input_group.addEventListener("mouseout", function (e) {
+            tooltip.classList.remove("visible")
+            tooltip.classList.add("hidden")
+        })
+    }
+})()
 
 var MULTI_LINE = $MULTI_LINE;
 

--- a/kit/src/elements/textarea/style.scss
+++ b/kit/src/elements/textarea/style.scss
@@ -4,6 +4,10 @@ textarea {
 	width: 100%;
 	height: "auto";
 	max-height: 250px; //Maybe make max variable?
+	&.disabled {
+		cursor: not-allowed;
+		filter: brightness(85%);
+	}
 }
 
 textarea::-webkit-scrollbar-track {

--- a/kit/src/elements/tooltip/mod.rs
+++ b/kit/src/elements/tooltip/mod.rs
@@ -5,6 +5,8 @@ use uuid::Uuid;
 #[derive(PartialEq, Eq, Copy, Clone, Display)]
 /// Which direction will the arrow on the popup point?
 pub enum ArrowPosition {
+    #[display(fmt = "arrow-top-none")]
+    None,
     #[display(fmt = "arrow-top-left")]
     TopLeft,
 

--- a/kit/src/layout/chatbar/mod.rs
+++ b/kit/src/layout/chatbar/mod.rs
@@ -36,10 +36,10 @@ pub struct Props<'a> {
     onchange: EventHandler<'a, String>,
     onreturn: EventHandler<'a, String>,
     reset: Option<UseState<bool>>,
-    #[props(optional)]
-    is_disabled: Option<bool>,
-    #[props(optional)]
-    tooltip: Option<String>,
+    #[props(default = false)]
+    is_disabled: bool,
+    #[props(default = "".to_owned())]
+    tooltip: String,
 }
 
 #[derive(Props)]
@@ -105,8 +105,8 @@ pub fn Chatbar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                         cx.props.onreturn.call(v);
                     }
                 },
-                is_disabled: cx.props.is_disabled.unwrap_or_default(),
-                tooltip: cx.props.tooltip.clone().unwrap_or_default(),
+                is_disabled: cx.props.is_disabled,
+                tooltip: cx.props.tooltip.clone(),
             },
             cx.props.extensions.as_ref(),
             div {

--- a/kit/src/layout/chatbar/mod.rs
+++ b/kit/src/layout/chatbar/mod.rs
@@ -31,6 +31,10 @@ pub struct Props<'a> {
     loading: Option<bool>,
     onchange: EventHandler<'a, String>,
     onreturn: EventHandler<'a, String>,
+    #[props(default = false)]
+    is_disabled: bool,
+    #[props(default = "".to_owned())]
+    tooltip: String,
 }
 
 #[derive(Props)]
@@ -94,6 +98,8 @@ pub fn Chatbar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                         cx.props.onreturn.call(v);
                     }
                 },
+                is_disabled: cx.props.is_disabled,
+                tooltip: cx.props.tooltip.clone(),
             },
             cx.props.extensions.as_ref(),
             div {

--- a/kit/src/layout/chatbar/mod.rs
+++ b/kit/src/layout/chatbar/mod.rs
@@ -36,6 +36,10 @@ pub struct Props<'a> {
     onchange: EventHandler<'a, String>,
     onreturn: EventHandler<'a, String>,
     reset: Option<UseState<bool>>,
+    #[props(optional)]
+    is_disabled: Option<bool>,
+    #[props(optional)]
+    tooltip: Option<String>,
 }
 
 #[derive(Props)]
@@ -97,6 +101,8 @@ pub fn Chatbar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 focus: cx.props.with_replying_to.is_some(),
                 onchange: move |(v, _)| cx.props.onchange.call(v),
                 onreturn: move |(v, _, _)| cx.props.onreturn.call(v),
+                is_disabled: cx.props.is_disabled.unwrap_or_default(),
+                tooltip: cx.props.tooltip.clone().unwrap_or_default(),
             },
             cx.props.extensions.as_ref(),
             div {

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -836,12 +836,16 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
         .map(|(_, proxy)| rsx!(proxy.extension.render(cx)))
         .collect::<Vec<_>>();
 
+    let disabled = state.read().can_use_active_chat();
+
     let chatbar = cx.render(rsx!(Chatbar {
         key: "{id}",
         id: id.to_string(),
         loading: is_loading,
         placeholder: get_local_text("messages.say-something-placeholder"),
         reset: should_clear_input.clone(),
+        is_disabled: disabled,
+        tooltip: get_local_text("messages.not-friends"),
         onchange: move |v: String| {
             *input.write_silent() = v.lines().map(|x| x.to_string()).collect::<Vec<String>>();
             if let Some(id) = &active_chat_id {
@@ -856,7 +860,7 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
             },
             Button {
                 icon: Icon::ChevronDoubleRight,
-                disabled: is_loading,
+                disabled: is_loading || disabled,
                 appearance: Appearance::Secondary,
                 onpress: move |_| submit_fn(),
                 tooltip: cx.render(rsx!(Tooltip {
@@ -866,6 +870,7 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
             }
         )),
         with_replying_to: data
+            .filter(|_| !disabled)
             .map(|data| {
                 let active_chat = data.active_chat.clone();
                 cx.render(rsx!(active_chat.clone().replying_to.map(|msg| {
@@ -898,9 +903,12 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
             .unwrap_or(None),
         with_file_upload: cx.render(rsx!(Button {
             icon: Icon::Plus,
-            disabled: is_loading || is_reply,
+            disabled: is_loading || is_reply || disabled,
             appearance: Appearance::Primary,
             onpress: move |_| {
+                if disabled {
+                    return;
+                }
                 if let Some(new_files) = FileDialog::new()
                     .set_directory(dirs::home_dir().unwrap_or_default())
                     .pick_files()

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -853,22 +853,22 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
             }
         },
         onreturn: move |_| submit_fn(),
-        controls: cx.render(rsx!(
+        extensions: cx.render(rsx!(
             // Load extensions
             for node in ext_renders {
                 rsx!(node)
-            },
-            Button {
-                icon: Icon::ChevronDoubleRight,
-                disabled: is_loading || disabled,
-                appearance: Appearance::Secondary,
-                onpress: move |_| submit_fn(),
-                tooltip: cx.render(rsx!(Tooltip {
-                    arrow_position: ArrowPosition::Bottom,
-                    text: get_local_text("uplink.send"),
-                })),
             }
         )),
+        controls: cx.render(rsx!(Button {
+            icon: Icon::ChevronDoubleRight,
+            disabled: is_loading || disabled,
+            appearance: Appearance::Secondary,
+            onpress: move |_| submit_fn(),
+            tooltip: cx.render(rsx!(Tooltip {
+                arrow_position: ArrowPosition::Bottom,
+                text: get_local_text("uplink.send"),
+            })),
+        })),
         with_replying_to: data
             .filter(|_| !disabled)
             .map(|data| {

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -836,7 +836,7 @@ fn get_chatbar(cx: Scope<ComposeProps>) -> Element {
         .map(|(_, proxy)| rsx!(proxy.extension.render(cx)))
         .collect::<Vec<_>>();
 
-    let disabled = state.read().can_use_active_chat();
+    let disabled = !state.read().can_use_active_chat();
 
     let chatbar = cx.render(rsx!(Chatbar {
         key: "{id}",


### PR DESCRIPTION
### What this PR does 📖

- Disables various chatting feature when one isn't a friend anymore:
      Chatting will be grayed out with a text with a tooltip saying that you are not friends anymore
      Buttons will be disabled (for e.g. attachment, sending msg, replies)
- Note: Only applies to DM (participants of 2) and not group chats. One can always do things in group chats.
  Maybe someone else has something to add here
- Also fixed a thing in `get_chatbar` where extensions where assigned to the control field and not the extension field see [https://github.com/Satellite-im/Uplink/blob/friend_chat_disable/ui/src/components/chat/compose.rs#L856](https://github.com/Satellite-im/Uplink/blob/friend_chat_disable/ui/src/components/chat/compose.rs#L856)
- Also fixes chatbar resizing after sending message not working (#458)
see [https://github.com/Satellite-im/Uplink/pull/445/files#diff-6c3d4f34c9eca5781fecc62f1c2baf341f5a244271e0e1a291709c19cfb41973R85](https://github.com/Satellite-im/Uplink/pull/445/files#diff-6c3d4f34c9eca5781fecc62f1c2baf341f5a244271e0e1a291709c19cfb41973R85)

### Which issue(s) this PR fixes 🔨

- Resolve #421
- Also resolve #458