### PR TITLE
chore(ui): suggest changes to AddFilePreview branch 

### DIFF
--- a/common/src/state/action.rs
+++ b/common/src/state/action.rs
@@ -67,15 +67,17 @@ pub enum Action {
     AddOverlay(Weak<WebView>),
     /// used for the popout player or media player
     #[display(fmt = "SetPopout")]
-    SetPopout(WindowId),
-    #[display(fmt = "ClearPopout")]
-    ClearPopout(DesktopContext),
+    SetCallPopout(WindowId),
+    #[display(fmt = "ClearCallPopout")]
+    ClearCallPopout(DesktopContext),
     #[display(fmt = "SetDebugLogger")]
     SetDebugLogger(WindowId),
     #[display(fmt = "ClearDebugLogger")]
     ClearDebugLogger(DesktopContext),
-    #[display(fmt = "SetFilePreview")]
-    SetFilePreview(WindowId),
+    #[display(fmt = "AddFilePreview")]
+    AddFilePreview(WindowId),
+    #[display(fmt = "ForgetFilePreview")]
+    ForgetFilePreview(WindowId),
     #[display(fmt = "ClearFilePreview")]
     ClearFilePreview(DesktopContext),
     #[display(fmt = "ClearAllPopoutWindows")]

--- a/common/src/state/action.rs
+++ b/common/src/state/action.rs
@@ -75,11 +75,11 @@ pub enum Action {
     #[display(fmt = "ClearDebugLogger")]
     ClearDebugLogger(DesktopContext),
     #[display(fmt = "AddFilePreview")]
-    AddFilePreview(WindowId),
+    AddFilePreview(Uuid, WindowId),
     #[display(fmt = "ForgetFilePreview")]
-    ForgetFilePreview(WindowId),
+    ForgetFilePreview(Uuid),
     #[display(fmt = "ClearFilePreview")]
-    ClearFilePreview(DesktopContext),
+    ClearFilePreviews(DesktopContext),
     #[display(fmt = "ClearAllPopoutWindows")]
     ClearAllPopoutWindows(DesktopContext),
     // Notifications

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -178,14 +178,15 @@ impl State {
             Action::Navigate(to) => self.set_active_route(to),
             // Generic UI
             Action::SetMeta(metadata) => self.ui.metadata = metadata,
-            Action::ClearPopout(window) => self.ui.clear_popout(window),
-            Action::SetPopout(webview) => self.ui.set_popout(webview),
+            Action::ClearCallPopout(window) => self.ui.clear_call_popout(&window),
+            Action::SetCallPopout(webview) => self.ui.set_call_popout(webview),
             // Development
             Action::SetDebugLogger(webview) => self.ui.set_debug_logger(webview),
-            Action::ClearDebugLogger(window) => self.ui.clear_debug_logger(window),
-            Action::SetFilePreview(webview) => self.ui.set_file_preview(webview),
-            Action::ClearFilePreview(window) => self.ui.clear_file_preview(window),
-            Action::ClearAllPopoutWindows(window) => self.ui.clear_all_popout_windows(window),
+            Action::ClearDebugLogger(window) => self.ui.clear_debug_logger(&window),
+            Action::AddFilePreview(id) => self.ui.add_file_preview(id),
+            Action::ForgetFilePreview(id) => self.ui.file_preview.retain(|x| x != &id),
+            Action::ClearFilePreview(window) => self.ui.clear_file_previews(&window),
+            Action::ClearAllPopoutWindows(window) => self.ui.clear_all_popout_windows(&window),
             // Themes
             Action::SetTheme(theme) => self.set_theme(Some(theme)),
             Action::ClearTheme => self.set_theme(None),
@@ -537,13 +538,15 @@ impl State {
         state
     }
     fn load_mock() -> Self {
-        let contents = match fs::read_to_string(&STATIC_ARGS.mock_cache_path) {
-            Ok(r) => r,
-            Err(_) => {
-                return generate_mock();
-            }
-        };
-        serde_json::from_str(&contents).unwrap_or_else(|_| generate_mock())
+        generate_mock()
+        // the following doesn't work anymore now that Identities are centralized
+        // let contents = match fs::read_to_string(&STATIC_ARGS.mock_cache_path) {
+        //     Ok(r) => r,
+        //     Err(_) => {
+        //         return generate_mock();
+        //     }
+        // };
+        // serde_json::from_str(&contents).unwrap_or_else(|_| generate_mock())
     }
 }
 

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -183,9 +183,11 @@ impl State {
             // Development
             Action::SetDebugLogger(webview) => self.ui.set_debug_logger(webview),
             Action::ClearDebugLogger(window) => self.ui.clear_debug_logger(&window),
-            Action::AddFilePreview(id) => self.ui.add_file_preview(id),
-            Action::ForgetFilePreview(id) => self.ui.file_preview.retain(|x| x != &id),
-            Action::ClearFilePreview(window) => self.ui.clear_file_previews(&window),
+            Action::AddFilePreview(id, window_id) => self.ui.add_file_preview(id, window_id),
+            Action::ForgetFilePreview(id) => {
+                let _ = self.ui.file_previews.remove(&id);
+            }
+            Action::ClearFilePreviews(window) => self.ui.clear_file_previews(&window),
             Action::ClearAllPopoutWindows(window) => self.ui.clear_all_popout_windows(&window),
             // Themes
             Action::SetTheme(theme) => self.set_theme(Some(theme)),

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -1003,7 +1003,7 @@ impl State {
     /// Analogous to Hang Up
     fn disable_media(&mut self) {
         self.chats.active_media = None;
-        self.ui.popout_player = false;
+        self.ui.popout_media_player = false;
         self.ui.current_call = None;
     }
     pub fn has_toasts(&self) -> bool {

--- a/common/src/state/ui.rs
+++ b/common/src/state/ui.rs
@@ -59,7 +59,7 @@ pub struct UI {
     #[serde(skip)]
     pub overlays: Vec<Weak<WebView>>,
     #[serde(skip)]
-    pub file_preview: Vec<WindowId>,
+    pub file_previews: HashMap<Uuid, WindowId>,
     #[serde(skip)]
     pub extensions: HashMap<String, ExtensionProxy>,
     #[serde(default = "bool_true")]
@@ -125,12 +125,12 @@ impl UI {
             desktop_context.close_window(id);
         };
     }
-    pub fn add_file_preview(&mut self, id: WindowId) {
-        self.file_preview.push(id);
+    pub fn add_file_preview(&mut self, key: Uuid, window_id: WindowId) {
+        self.file_previews.insert(key, window_id);
     }
     pub fn clear_file_previews(&mut self, desktop_context: &DesktopContext) {
-        for id in self.file_preview.drain(..) {
-            desktop_context.close_window(id);
+        for (_, id) in self.file_previews.iter() {
+            desktop_context.close_window(*id);
         }
     }
 

--- a/common/src/state/ui.rs
+++ b/common/src/state/ui.rs
@@ -41,12 +41,10 @@ pub struct UI {
     pub current_call: Option<Call>,
     #[serde(skip)]
     pub current_debug_logger: Option<DebugLogger>,
-    #[serde(skip)]
-    pub current_file_preview: Option<FilePreview>,
     // false: the media player is anchored in place
     // true: the media player can move around
     #[serde(skip)]
-    pub popout_player: bool,
+    pub popout_media_player: bool,
     #[serde(skip)]
     pub toast_notifications: HashMap<Uuid, ToastNotification>,
     pub theme: Option<Theme>,
@@ -78,7 +76,7 @@ impl Drop for UI {
 
 impl UI {
     fn take_call_popout_id(&mut self) -> Option<WindowId> {
-        self.popout_player = false;
+        self.popout_media_player = false;
         match self.current_call.take() {
             Some(mut call) => {
                 let id = call.take_window_id();
@@ -115,7 +113,7 @@ impl UI {
     }
     pub fn set_call_popout(&mut self, id: WindowId) {
         self.current_call = Some(Call::new(Some(id)));
-        self.popout_player = true;
+        self.popout_media_player = true;
     }
     pub fn set_debug_logger(&mut self, id: WindowId) {
         self.current_debug_logger = Some(DebugLogger::new(Some(id)));

--- a/common/src/state/ui.rs
+++ b/common/src/state/ui.rs
@@ -47,7 +47,6 @@ pub struct UI {
     // true: the media player can move around
     #[serde(skip)]
     pub popout_player: bool,
-    pub popout_windows_id: Option<AllPopoutWindowsId>,
     #[serde(skip)]
     pub toast_notifications: HashMap<Uuid, ToastNotification>,
     pub theme: Option<Theme>,
@@ -59,6 +58,8 @@ pub struct UI {
     // overlays or other windows are created via DesktopContext::new_window. they are stored here so they can be closed later.
     #[serde(skip)]
     pub overlays: Vec<Weak<WebView>>,
+    #[serde(skip)]
+    pub file_preview: Vec<WindowId>,
     #[serde(skip)]
     pub extensions: HashMap<String, ExtensionProxy>,
     #[serde(default = "bool_true")]
@@ -76,18 +77,7 @@ impl Drop for UI {
 }
 
 impl UI {
-    fn take_all_popout_ids(&mut self) -> Vec<Option<WindowId>> {
-        match self.popout_windows_id.take() {
-            Some(all_popout_windows_id) => {
-                let ids = all_popout_windows_id.popout_windows_id.clone();
-                self.popout_windows_id = Some(all_popout_windows_id);
-                ids
-            }
-            None => Vec::new(),
-        }
-    }
-
-    fn take_popout_id(&mut self) -> Option<WindowId> {
+    fn take_call_popout_id(&mut self) -> Option<WindowId> {
         self.popout_player = false;
         match self.current_call.take() {
             Some(mut call) => {
@@ -110,17 +100,6 @@ impl UI {
         }
     }
 
-    fn take_file_preview_id(&mut self) -> Option<WindowId> {
-        match self.current_file_preview.take() {
-            Some(mut file_preview) => {
-                let id = file_preview.take_window_id();
-                self.current_file_preview = None;
-                id
-            }
-            None => None,
-        }
-    }
-
     pub fn get_meta(&self) -> WindowMeta {
         self.metadata.clone()
     }
@@ -129,50 +108,37 @@ impl UI {
         self.metadata.minimal_view
     }
 
-    pub fn clear_popout(&mut self, desktop_context: DesktopContext) {
-        if let Some(id) = self.take_popout_id() {
+    pub fn clear_call_popout(&mut self, desktop_context: &DesktopContext) {
+        if let Some(id) = self.take_call_popout_id() {
             desktop_context.close_window(id);
         };
     }
-    pub fn set_popout(&mut self, id: WindowId) {
+    pub fn set_call_popout(&mut self, id: WindowId) {
         self.current_call = Some(Call::new(Some(id)));
-        self.popout_windows_id = Some(AllPopoutWindowsId::add_one(
-            self.popout_windows_id.clone(),
-            Some(id),
-        ));
         self.popout_player = true;
     }
     pub fn set_debug_logger(&mut self, id: WindowId) {
         self.current_debug_logger = Some(DebugLogger::new(Some(id)));
-        self.popout_windows_id = Some(AllPopoutWindowsId::add_one(
-            self.popout_windows_id.clone(),
-            Some(id),
-        ));
     }
-    pub fn clear_debug_logger(&mut self, desktop_context: DesktopContext) {
+    pub fn clear_debug_logger(&mut self, desktop_context: &DesktopContext) {
         if let Some(id) = self.take_debug_logger_id() {
             desktop_context.close_window(id);
         };
     }
-    pub fn set_file_preview(&mut self, id: WindowId) {
-        self.current_file_preview = Some(FilePreview::new(Some(id)));
-        self.popout_windows_id = Some(AllPopoutWindowsId::add_one(
-            self.popout_windows_id.clone(),
-            Some(id),
-        ));
+    pub fn add_file_preview(&mut self, id: WindowId) {
+        self.file_preview.push(id);
     }
-    pub fn clear_file_preview(&mut self, desktop_context: DesktopContext) {
-        if let Some(id) = self.take_file_preview_id() {
+    pub fn clear_file_previews(&mut self, desktop_context: &DesktopContext) {
+        for id in self.file_preview.drain(..) {
             desktop_context.close_window(id);
-        };
+        }
     }
 
-    pub fn clear_all_popout_windows(&mut self, desktop_context: DesktopContext) {
-        for id in self.take_all_popout_ids() {
-            if let Some(id) = id {
-                desktop_context.close_window(id);
-            };
-        }
+    pub fn clear_all_popout_windows(&mut self, desktop_context: &DesktopContext) {
+        self.clear_file_previews(desktop_context);
+        self.clear_debug_logger(desktop_context);
+        self.clear_call_popout(desktop_context);
+        self.clear_overlays();
     }
     pub fn clear_overlays(&mut self) {
         for overlay in &self.overlays {
@@ -218,28 +184,6 @@ impl UI {
             x.silenced = !x.silenced;
             x
         });
-    }
-}
-
-#[derive(Clone, Default, Deserialize, Serialize)]
-pub struct AllPopoutWindowsId {
-    #[serde(skip)]
-    pub popout_windows_id: Vec<Option<WindowId>>,
-}
-
-impl AllPopoutWindowsId {
-    pub fn add_one(
-        all_popout_windows_id: Option<AllPopoutWindowsId>,
-        new_window_id: Option<WindowId>,
-    ) -> Self {
-        let mut windows_id = Vec::new();
-        if let Some(data) = all_popout_windows_id {
-            windows_id = data.popout_windows_id;
-        }
-        windows_id.push(new_window_id);
-        Self {
-            popout_windows_id: windows_id,
-        }
     }
 }
 

--- a/common/src/warp_runner/manager/commands/constellation_commands.rs
+++ b/common/src/warp_runner/manager/commands/constellation_commands.rs
@@ -693,7 +693,7 @@ fn set_thumbnail_if_file_is_document(
         .stderr(Stdio::null())
         .spawn()?;
 
-    if let Some(_) = output.stdout {
+    if output.stdout.is_some() {
         let path_2 = format!("{}.jpg", temp_path.to_string_lossy());
         std::thread::sleep(std::time::Duration::from_secs(1));
         let image = std::fs::read(path_2)?;

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -224,7 +224,7 @@ fn get_controls(cx: Scope<ComposeProps>) -> Element {
                 if let Some(chat) = active_chat2.clone() {
                     state
                         .write_silent()
-                        .mutate(Action::ClearPopout(desktop.clone()));
+                        .mutate(Action::ClearCallPopout(desktop.clone()));
                     state.write_silent().mutate(Action::DisableMedia);
                     state.write().mutate(Action::SetActiveMedia(chat.id));
                 }

--- a/ui/src/components/media/player.rs
+++ b/ui/src/components/media/player.rs
@@ -90,7 +90,7 @@ pub fn MediaPlayer(cx: Scope<Props>) -> Element {
                         }
                     )),
                     onpress: move |_| {
-                         if state.read().ui.popout_player {
+                         if state.read().ui.popout_media_player {
                              state.write().mutate(Action::ClearCallPopout(window.clone()));
                              return;
                          }
@@ -109,13 +109,13 @@ pub fn MediaPlayer(cx: Scope<Props>) -> Element {
                     }
                 },
                 // don't render MediadPlayer if the video is popped out
-                state.read().ui.popout_player.then(|| rsx!(
+                state.read().ui.popout_media_player.then(|| rsx!(
                     span {
                         class: "popped-out",
                         video {}
                     }
                 )),
-                (!state.read().ui.popout_player).then(|| rsx!(
+                (!state.read().ui.popout_media_player).then(|| rsx!(
                     video {
                         src: "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/Sintel.mp4",
                         autoplay: "true",

--- a/ui/src/components/media/popout_player.rs
+++ b/ui/src/components/media/popout_player.rs
@@ -9,9 +9,8 @@ use kit::elements::{
     Appearance,
 };
 
-use crate::{window_manager::WindowManagerCmd, WINDOW_CMD_CH};
+use crate::{utils::WindowDropHandler, window_manager::WindowManagerCmd, WINDOW_CMD_CH};
 
-use super::player::WindowDropHandler;
 pub const SCRIPT: &str = include_str!("./script.js");
 
 #[inline_props]

--- a/ui/src/components/media/remote_control.rs
+++ b/ui/src/components/media/remote_control.rs
@@ -80,7 +80,7 @@ pub fn RemoteControls(cx: Scope<Props>) -> Element {
                 appearance: Appearance::Danger,
                 text: cx.props.end_text.clone(),
                 onpress: move |_| {
-                    state.write().mutate(Action::ClearPopout(window.clone()));
+                    state.write().mutate(Action::ClearCallPopout(window.clone()));
                     state.write().mutate(Action::DisableMedia);
                 },
             }

--- a/ui/src/layouts/file_preview.rs
+++ b/ui/src/layouts/file_preview.rs
@@ -13,6 +13,8 @@ use kit::elements::file::get_file_extension;
 use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
 use std::sync::mpsc::channel;
 
+use crate::utils::WindowDropHandler;
+
 const CSS_STYLE: &str = include_str!("./style.scss");
 
 #[derive(Clone, PartialEq, Eq)]
@@ -47,7 +49,7 @@ pub fn get_file_format(file_name: String) -> FileFormat {
 
 #[inline_props]
 #[allow(non_snake_case)]
-pub fn FilePreview(cx: Scope, file: File) -> Element {
+pub fn FilePreview(cx: Scope, file: File, _drop_handler: WindowDropHandler) -> Element {
     let file_format = get_file_format(file.name());
     let file_name = file.name();
     let thumbnail = file.thumbnail();

--- a/ui/src/layouts/file_preview.rs
+++ b/ui/src/layouts/file_preview.rs
@@ -7,7 +7,6 @@ use common::{
 use dioxus::prelude::*;
 use warp::constellation::file::File;
 
-use super::storage::WindowDropHandler;
 use dioxus_desktop::{use_window, DesktopContext, LogicalSize};
 use image::io::Reader as ImageReader;
 use kit::elements::file::get_file_extension;
@@ -48,7 +47,7 @@ pub fn get_file_format(file_name: String) -> FileFormat {
 
 #[inline_props]
 #[allow(non_snake_case)]
-pub fn FilePreview(cx: Scope, _drop_handler: WindowDropHandler, file: File) -> Element {
+pub fn FilePreview(cx: Scope, file: File) -> Element {
     let file_format = get_file_format(file.name());
     let file_name = file.name();
     let thumbnail = file.thumbnail();

--- a/ui/src/layouts/file_preview.rs
+++ b/ui/src/layouts/file_preview.rs
@@ -42,7 +42,7 @@ pub fn get_file_format(file_name: String) -> FileFormat {
     if doc_formats.iter().any(|f| f == &file_extension) {
         return FileFormat::Document;
     }
-    return FileFormat::Other;
+    FileFormat::Other
 }
 
 #[inline_props]
@@ -56,7 +56,7 @@ pub fn FilePreview(cx: Scope, file: File) -> Element {
     let mut css_style = update_theme_colors();
     let update_state: &UseRef<Option<()>> = use_ref(cx, || Some(()));
 
-    if update_state.read().is_some().clone() {
+    if update_state.read().is_some() {
         css_style = update_theme_colors();
         *update_state.write_silent() = None;
     }
@@ -83,14 +83,17 @@ pub fn FilePreview(cx: Scope, file: File) -> Element {
             let fs_event_watcher_result = RecommendedWatcher::new(tx, Config::default());
             if let Ok(fs_event_watcher) = fs_event_watcher_result {
                 let mut watcher: RecommendedWatcher = fs_event_watcher;
-                if let Ok(_) = watcher.watch(
-                    STATIC_ARGS.cache_path.clone().as_path(),
-                    RecursiveMode::NonRecursive,
-                ) {
+                if watcher
+                    .watch(
+                        STATIC_ARGS.cache_path.clone().as_path(),
+                        RecursiveMode::NonRecursive,
+                    )
+                    .is_ok()
+                {
                     loop {
                         let mut event_processed = false;
                         tokio::time::sleep(std::time::Duration::from_millis(300)).await;
-                        while let Ok(_) = rx.try_recv() {
+                        while rx.try_recv().is_ok() {
                             if update_state.read().is_none() && !event_processed {
                                 update_state.with_mut(|i| *i = Some(()));
                                 event_processed = true;

--- a/ui/src/layouts/storage.rs
+++ b/ui/src/layouts/storage.rs
@@ -1,5 +1,6 @@
 use std::rc::Weak;
-use std::{ffi::OsStr, path::PathBuf, time::Duration};
+use std::time::Duration;
+use std::{ffi::OsStr, path::PathBuf};
 
 use common::icons::outline::Shape as Icon;
 use common::icons::Icon as IconElement;
@@ -45,8 +46,6 @@ use wry::webview::FileDropEvent;
 
 use crate::components::chat::{sidebar::Sidebar as ChatSidebar, RouteInfo};
 use crate::layouts::file_preview::{FilePreview, FilePreviewProps};
-use crate::window_manager::{WindowManagerCmd, WindowManagerCmdTx};
-use crate::WINDOW_CMD_CH;
 
 const FEEDBACK_TEXT_SCRIPT: &str = r#"
     const feedback_element = document.getElementById('overlay-text');
@@ -711,20 +710,18 @@ pub fn FilesLayout(cx: Scope<Props>) -> Element {
                                             key: "{key}-file",
                                             thumbnail: file.thumbnail(),
                                             text: file.name(),
+                                            aria_label: file.name(),
+                                            with_rename: *is_renaming_map.read() == Some(key),
                                             onpress: move |_| {
-                                                let drop_handler = WindowDropHandler::new(WINDOW_CMD_CH.tx.clone());
-                                                let file_preview = VirtualDom::new_with_props(FilePreview, FilePreviewProps{
-                                                    _drop_handler: drop_handler,
-                                                    file: file3.clone(),
+                                                let file_preview = VirtualDom::new_with_props(FilePreview, FilePreviewProps{ 
+                                                    file: file3.clone()
                                                 });
                                                 let window = window.new_window(file_preview, Default::default());
                                                 if let Some(wv) = Weak::upgrade(&window) {
                                                     let id = wv.window().id();
-                                                    state.write().mutate(Action::SetFilePreview(id));
+                                                    state.write().mutate(Action::AddFilePreview(id));
                                                 }
                                             },
-                                            aria_label: file.name(),
-                                            with_rename: *is_renaming_map.read() == Some(key),
                                             onrename: move |(val, key_code)| {
                                                 is_renaming_map.with_mut(|i| *i = None);
                                                 if key_code == Code::Enter {
@@ -767,30 +764,6 @@ fn update_items_with_mock_data(
         files: files_list.read().clone(),
     };
     storage_state.set(Some(storage_mock));
-}
-
-pub struct WindowDropHandler {
-    cmd_tx: WindowManagerCmdTx,
-}
-
-impl PartialEq for WindowDropHandler {
-    fn eq(&self, _other: &Self) -> bool {
-        false
-    }
-}
-
-impl WindowDropHandler {
-    pub fn new(cmd_tx: WindowManagerCmdTx) -> Self {
-        Self { cmd_tx }
-    }
-}
-
-impl Drop for WindowDropHandler {
-    fn drop(&mut self) {
-        if let Err(_e) = self.cmd_tx.send(WindowManagerCmd::CloseFilePreview) {
-            // todo: log error
-        }
-    }
 }
 
 fn get_drag_event() -> FileDropEvent {

--- a/ui/src/layouts/storage.rs
+++ b/ui/src/layouts/storage.rs
@@ -713,7 +713,7 @@ pub fn FilesLayout(cx: Scope<Props>) -> Element {
                                             aria_label: file.name(),
                                             with_rename: *is_renaming_map.read() == Some(key),
                                             onpress: move |_| {
-                                                let file_preview = VirtualDom::new_with_props(FilePreview, FilePreviewProps{ 
+                                                let file_preview = VirtualDom::new_with_props(FilePreview, FilePreviewProps {
                                                     file: file3.clone()
                                                 });
                                                 let window = window.new_window(file_preview, Default::default());

--- a/ui/src/layouts/storage.rs
+++ b/ui/src/layouts/storage.rs
@@ -46,6 +46,8 @@ use wry::webview::FileDropEvent;
 
 use crate::components::chat::{sidebar::Sidebar as ChatSidebar, RouteInfo};
 use crate::layouts::file_preview::{FilePreview, FilePreviewProps};
+use crate::utils::WindowDropHandler;
+use crate::window_manager::WindowManagerCmd;
 
 const FEEDBACK_TEXT_SCRIPT: &str = r#"
     const feedback_element = document.getElementById('overlay-text');
@@ -713,13 +715,16 @@ pub fn FilesLayout(cx: Scope<Props>) -> Element {
                                             aria_label: file.name(),
                                             with_rename: *is_renaming_map.read() == Some(key),
                                             onpress: move |_| {
+                                                let key = Uuid::new_v4();
+                                                let drop_handler = WindowDropHandler::new(WindowManagerCmd::ForgetFilePreview(key));
                                                 let file_preview = VirtualDom::new_with_props(FilePreview, FilePreviewProps {
-                                                    file: file3.clone()
+                                                    file: file3.clone(),
+                                                    _drop_handler: drop_handler
                                                 });
                                                 let window = window.new_window(file_preview, Default::default());
                                                 if let Some(wv) = Weak::upgrade(&window) {
                                                     let id = wv.window().id();
-                                                    state.write().mutate(Action::AddFilePreview(id));
+                                                    state.write().mutate(Action::AddFilePreview(key, id));
                                                 }
                                             },
                                             onrename: move |(val, key_code)| {

--- a/ui/src/window_manager/mod.rs
+++ b/ui/src/window_manager/mod.rs
@@ -18,6 +18,7 @@ pub struct WindowManagerCmdChannels {
 }
 
 #[derive(Clone, Copy)]
+#[allow(clippy::enum_variant_names)]
 pub enum WindowManagerCmd {
     ClosePopout,
     CloseDebugLogger,

--- a/ui/src/window_manager/mod.rs
+++ b/ui/src/window_manager/mod.rs
@@ -17,6 +17,7 @@ pub struct WindowManagerCmdChannels {
     pub rx: WindowManagerCmdRx,
 }
 
+#[derive(Clone, Copy)]
 pub enum WindowManagerCmd {
     ClosePopout,
     CloseDebugLogger,
@@ -31,7 +32,7 @@ pub async fn handle_cmd(
     match cmd {
         WindowManagerCmd::ClosePopout => {
             if let Ok(s) = state.try_borrow_mut() {
-                s.write().mutate(Action::ClearPopout(desktop));
+                s.write().mutate(Action::ClearCallPopout(desktop));
             } else {
                 //todo: add logging
             }

--- a/ui/src/window_manager/mod.rs
+++ b/ui/src/window_manager/mod.rs
@@ -8,6 +8,7 @@ use tokio::sync::{
 };
 
 use common::state::{Action, State};
+use uuid::Uuid;
 
 pub type WindowManagerCmdTx = UnboundedSender<WindowManagerCmd>;
 pub type WindowManagerCmdRx = Arc<Mutex<UnboundedReceiver<WindowManagerCmd>>>;
@@ -23,6 +24,7 @@ pub enum WindowManagerCmd {
     ClosePopout,
     CloseDebugLogger,
     CloseFilePreview,
+    ForgetFilePreview(Uuid),
 }
 
 pub async fn handle_cmd(
@@ -47,7 +49,14 @@ pub async fn handle_cmd(
         }
         WindowManagerCmd::CloseFilePreview => {
             if let Ok(s) = state.try_borrow_mut() {
-                s.write().mutate(Action::ClearFilePreview(desktop));
+                s.write().mutate(Action::ClearFilePreviews(desktop));
+            } else {
+                //todo: add logging
+            }
+        }
+        WindowManagerCmd::ForgetFilePreview(id) => {
+            if let Ok(s) = state.try_borrow_mut() {
+                s.write().mutate(Action::ForgetFilePreview(id));
             } else {
                 //todo: add logging
             }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Essentially an `Option<Vec<Option<WindowId>>>` was added to `UI` for handling file previews. This was changed to a `Vec<WindowId>`. 
- The `WindowDropHandler` was moved into the utils folder and changed so that it can be reusable
- The `WindowDropHandler` was removed from `FilePreviewProps` because there isn't a way to tell which window id was created in time. This would have to happen before the `WindowDropHandler` was created. 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

