### PR TITLE
feat(chats): lazier loading

### DIFF
--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -1131,6 +1131,8 @@ pub struct GroupedMessage<'a> {
     pub message: &'a ui_adapter::Message,
     pub is_first: bool,
     pub is_last: bool,
+    // if the user scrolls over this message, more messages should be loaded
+    pub should_fetch_more: bool,
 }
 
 impl<'a> GroupedMessage<'a> {
@@ -1142,12 +1144,20 @@ impl<'a> GroupedMessage<'a> {
 pub fn group_messages<'a>(
     my_did: DID,
     num: usize,
+    when_to_fetch_more: usize,
     input: &'a VecDeque<ui_adapter::Message>,
 ) -> Vec<MessageGroup<'a>> {
     let mut messages: Vec<MessageGroup<'a>> = vec![];
     let to_skip = input.len().saturating_sub(num);
     // the most recent message appears last in the list.
     let iter = input.iter().skip(to_skip);
+    let mut need_to_fetch_more = when_to_fetch_more;
+
+    let mut need_more = || {
+        let r = need_to_fetch_more > 0;
+        need_to_fetch_more = need_to_fetch_more.saturating_sub(1);
+        r
+    };
 
     for msg in iter {
         if let Some(group) = messages.iter_mut().last() {
@@ -1156,6 +1166,7 @@ pub fn group_messages<'a>(
                     message: msg,
                     is_first: false,
                     is_last: true,
+                    should_fetch_more: need_more(),
                 };
                 // I really hope last() is O(1) time
                 if let Some(g) = group.messages.iter_mut().last() {
@@ -1173,6 +1184,7 @@ pub fn group_messages<'a>(
             message: msg,
             is_first: true,
             is_last: true,
+            should_fetch_more: need_more(),
         };
         grp.messages.push(g);
         messages.push(grp);

--- a/kit/src/components/context_menu/mod.rs
+++ b/kit/src/components/context_menu/mod.rs
@@ -83,7 +83,7 @@ pub fn ContextMenu<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
         div {
             class: "context-wrap",
             onmouseenter: |e| {
-                cx.props.on_mouseenter.as_ref().map(|f| f.call(e));
+                if let Some(f) = cx.props.on_mouseenter.as_ref() { f.call(e) }
             },
             div {
                 id: "{id}",

--- a/kit/src/components/context_menu/mod.rs
+++ b/kit/src/components/context_menu/mod.rs
@@ -61,7 +61,7 @@ pub struct Props<'a> {
     children: Element<'a>,
     #[props(optional)]
     devmode: Option<bool>,
-    on_mouseout: Option<EventHandler<'a, MouseEvent>>,
+    on_mouseenter: Option<EventHandler<'a, MouseEvent>>,
 }
 
 #[allow(non_snake_case)]
@@ -83,7 +83,7 @@ pub fn ContextMenu<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
         div {
             class: "context-wrap",
             onmouseenter: |e| {
-                cx.props.on_mouseout.as_ref().map(|f| f.call(e));
+                cx.props.on_mouseenter.as_ref().map(|f| f.call(e));
             },
             div {
                 id: "{id}",

--- a/kit/src/components/context_menu/mod.rs
+++ b/kit/src/components/context_menu/mod.rs
@@ -61,6 +61,7 @@ pub struct Props<'a> {
     children: Element<'a>,
     #[props(optional)]
     devmode: Option<bool>,
+    on_mouseout: Option<EventHandler<'a, MouseEvent>>,
 }
 
 #[allow(non_snake_case)]
@@ -81,6 +82,9 @@ pub fn ContextMenu<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     cx.render(rsx! {
         div {
             class: "context-wrap",
+            onmouseout: |e| {
+                cx.props.on_mouseout.as_ref().map(|f| f.call(e));
+            },
             div {
                 id: "{id}",
                 &cx.props.children,

--- a/kit/src/components/context_menu/mod.rs
+++ b/kit/src/components/context_menu/mod.rs
@@ -82,7 +82,7 @@ pub fn ContextMenu<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     cx.render(rsx! {
         div {
             class: "context-wrap",
-            onmouseout: |e| {
+            onmouseenter: |e| {
                 cx.props.on_mouseout.as_ref().map(|f| f.call(e));
             },
             div {

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -337,8 +337,6 @@ enum MessagesCommand {
 /// load DEFAULT_NUM_TO_TAKE messages to start.
 /// tell group_messages to flag the first X messages.
 /// if onmouseout triggers over any of those messages, load Y more.
-/// if X is half of DEFAULT_NUM_TO_TAKE and Y = DEFAULT_NUM_TO_TAKE,
-/// it seems to work pretty good.
 const DEFAULT_NUM_TO_TAKE: usize = 20;
 #[inline_props]
 fn get_messages(cx: Scope, data: Rc<ComposeData>) -> Element {
@@ -609,7 +607,7 @@ fn render_messages<'a>(cx: Scope<'a, MessagesProps<'a>>) -> Element<'a> {
         rsx!(ContextMenu {
             key: "{context_key}",
             id: context_key,
-            on_mouseout: move |_| {
+            on_mouseenter: move |_| {
                 if should_fetch_more {
                     if *cx.props.num_to_take.get() < cx.props.num_messages_in_conversation {
                         cx.props

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -608,13 +608,13 @@ fn render_messages<'a>(cx: Scope<'a, MessagesProps<'a>>) -> Element<'a> {
             key: "{context_key}",
             id: context_key,
             on_mouseenter: move |_| {
-                if should_fetch_more {
-                    if *cx.props.num_to_take.get() < cx.props.num_messages_in_conversation {
-                        cx.props
-                            .num_to_take
-                            .modify(|x| x.saturating_add(DEFAULT_NUM_TO_TAKE * 2));
-                        //log::info!("lazy loading");
-                    }
+                if should_fetch_more
+                    && *cx.props.num_to_take.get() < cx.props.num_messages_in_conversation
+                {
+                    cx.props
+                        .num_to_take
+                        .modify(|x| x.saturating_add(DEFAULT_NUM_TO_TAKE * 2));
+                    //log::info!("lazy loading");
                 }
             },
             children: cx.render(rsx!(render_message {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- I'm not sure this one is better than the previous version, but let's test it and decide. This version won't load the entire conversation, which might seen as a good thing. However, not continuously loading the entire conversation will make it a little easier to scroll to the top of the container before more messages are loaded. 

- Another difference is that doing it this lazier way makes it possible to retain the scroll position so long as another chat isn't selected. In theory one could switch to the settings view and then back to chats and keep their scroll  position (that won't work now because something else is de-selecting the current chat on purpose). 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

