### PR TITLE
fix(sidebar): Fix missing scrollbar in sidebar

### DIFF
--- a/ui/src/layouts/style.scss
+++ b/ui/src/layouts/style.scss
@@ -103,11 +103,12 @@
 
     }
     // hide scrollbar to prevent issues with 6 pixel scrollbar
-    ::-webkit-scrollbar {
+    .files-list::-webkit-scrollbar {
         display: none;
+        scrollbar-width: none;  /* Firefox */
     }
+
     -ms-overflow-style: none;  /* IE and Edge */
-    scrollbar-width: none;  /* Firefox */
 
     .files-list {
         display: flex;

--- a/ui/src/style.scss
+++ b/ui/src/style.scss
@@ -103,13 +103,9 @@ html, body {
 
 /* width */
 ::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
+    width: 8px;
+    height: 8px;
     opacity: 1;
-
-    &:hover {
-        width: 10px;
-    }
 }
 
 /* Track */


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Fixes the scrollbar in for sidebar in files missing causing it to jump around when switching tabs
- Also disable scrollbar onhover increasing width as on hover seems unreliable. Instead scrollbar width in general increased a bit:

Before when you hover over any scrollbar it gets bigger. At least that should be the case but that seems really unreliable. I managed to trigger it reliably by middle and right clicking while hovering over it. Else it also flickers if you move the mouse across it quickly. (for demonstration purposes i set the width increase in the vid to 14px).

I removed this feature and instead increased the base size of it from 6->8px.

https://user-images.githubusercontent.com/34157027/225683131-a92541b3-032f-461d-a41c-de472d2906d7.mp4

### Which issue(s) this PR fixes 🔨

- Resolve #422

