### PR TITLE
chore(extensions): fix typing indicator

### DIFF
--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -157,10 +157,10 @@ struct EditProps<'a> {
 #[allow(non_snake_case)]
 fn EditMsg<'a>(cx: Scope<'a, EditProps<'a>>) -> Element<'a> {
     log::trace!("rendering EditMsg");
-    cx.render(rsx!(textarea::Input {
+    cx.render(rsx!(textarea::ControlledInput {
         id: cx.props.id.clone(),
         focus: true,
-        default_text: cx.props.text.clone(),
+        value: cx.props.text.clone(),
         onchange: move |_| {},
         onreturn: move |(s, is_valid, _): (String, bool, _)| {
             if is_valid {

--- a/kit/src/elements/input/mod.rs
+++ b/kit/src/elements/input/mod.rs
@@ -238,14 +238,6 @@ pub fn get_icon(cx: &Scope<Props>) -> Icon {
     cx.props.icon.unwrap_or(Icon::QuestionMarkCircle)
 }
 
-pub fn get_text(cx: &Scope<Props>) -> String {
-    cx.props.default_text.clone().unwrap_or_default()
-}
-
-pub fn get_value(cx: &Scope<Props>) -> String {
-    cx.props.value.clone().unwrap_or_default()
-}
-
 pub fn get_aria_label(cx: &Scope<Props>) -> String {
     cx.props.aria_label.clone().unwrap_or_default()
 }
@@ -300,15 +292,15 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
         }
     });
     let error = use_state(cx, || String::from(""));
-    let val = use_ref(cx, || get_text(&cx));
+    let val = use_ref(cx, || cx.props.default_text.clone().unwrap_or_default());
     let max_length = cx.props.max_length.unwrap_or(std::i32::MAX);
     let options = cx.props.options.clone().unwrap_or_default();
     let should_validate = options.with_validation.is_some();
     let valid = use_state(cx, || false);
     let onblur_active = !cx.props.disable_onblur;
 
-    if !get_value(&cx).is_empty() {
-        val.set(get_value(&cx));
+    if let Some(value) = &cx.props.value {
+        val.set(value.clone());
     }
 
     let reset_fn = || {

--- a/kit/src/elements/textarea/mod.rs
+++ b/kit/src/elements/textarea/mod.rs
@@ -23,58 +23,6 @@ impl Size {
 }
 
 #[derive(Props)]
-pub struct Props<'a> {
-    #[props(default = "".to_owned())]
-    id: String,
-    #[props(default = false)]
-    focus: bool,
-    #[props(default = false)]
-    loading: bool,
-    #[props(default = "".to_owned())]
-    placeholder: String,
-    #[props(default = 1024)]
-    max_length: i32,
-    #[props(default = Size::Normal)]
-    size: Size,
-    #[props(default = "".to_owned())]
-    default_text: String,
-    #[props(default = "".to_owned())]
-    aria_label: String,
-    onchange: EventHandler<'a, (String, bool)>,
-    onreturn: EventHandler<'a, (String, bool, Code)>,
-}
-
-#[allow(non_snake_case)]
-pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
-    let Props {
-        id,
-        focus,
-        loading,
-        placeholder,
-        max_length,
-        size,
-        default_text,
-        aria_label,
-        onchange,
-        onreturn,
-    } = &cx.props;
-
-    render_input(
-        cx,
-        id,
-        *focus,
-        *loading,
-        placeholder,
-        *max_length,
-        *size,
-        aria_label,
-        onchange,
-        onreturn,
-        default_text.as_str(),
-    )
-}
-
-#[derive(Props)]
 pub struct ControlledInputProps<'a> {
     #[props(default = "".to_owned())]
     id: String,
@@ -110,35 +58,6 @@ pub fn ControlledInput<'a>(cx: Scope<'a, ControlledInputProps<'a>>) -> Element<'
         value,
     } = &cx.props;
 
-    render_input(
-        cx,
-        id,
-        *focus,
-        *loading,
-        placeholder,
-        *max_length,
-        *size,
-        aria_label,
-        onchange,
-        onreturn,
-        value.as_str(),
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-fn render_input<'a>(
-    cx: &'a ScopeState,
-    id: &String,
-    focus: bool,
-    loading: bool,
-    placeholder: &String,
-    max_length: i32,
-    size: Size,
-    aria_label: &String,
-    onchange: &'a EventHandler<'a, (String, bool)>,
-    onreturn: &'a EventHandler<'a, (String, bool, Code)>,
-    value: &str,
-) -> Element<'a> {
     let height_script = include_str!("./update_input_height.js");
     let focus_script = include_str!("./focus.js").replace("UUID", id);
     dioxus_desktop::use_eval(cx)(height_script.to_string());
@@ -157,7 +76,7 @@ fn render_input<'a>(
 
     cx.render(rsx! (
         div {
-            class: format_args!("input-group {}", if loading { "disabled" } else { " " }),
+            class: format_args!("input-group {}", if *loading { "disabled" } else { " " }),
             div {
                 class: "input",
                 height: "{size.get_height()}",
@@ -167,7 +86,7 @@ fn render_input<'a>(
                     class: "input_textarea",
                     id: "{id}",
                     // todo: troubleshoot this. it isn't working
-                    autofocus: focus,
+                    autofocus: *focus,
                     aria_label: "{aria_label}",
                     disabled: "{loading}",
                     value: "{current_val}",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- this is a merge into another feature branch, not into dev. 
- fixes an issue with the typing indicator and removes unnecessary code. 
- I don't really care if the chatbar uses a `textare::Input` or `textarea::ControlledInput`. feel free to change the names if you want. They both did the same thing and one was used for EditMsg and the other was used for chatbar. 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

