### PR TITLE
fix(chat): Save the last active chat when switching tabs

### DIFF
--- a/common/src/state/chats.rs
+++ b/common/src/state/chats.rs
@@ -63,6 +63,8 @@ pub struct Chats {
     pub in_sidebar: VecDeque<Uuid>,
     // Favorite Chats
     pub favorites: Vec<Uuid>,
+    // The last active chat when one switches tab
+    pub last_active: Option<Uuid>,
 }
 
 impl Chats {
@@ -105,6 +107,7 @@ impl Serialize for Chats {
         state.skip_field("active_media")?;
         state.serialize_field("in_sidebar", &self.in_sidebar)?;
         state.serialize_field("favorites", &self.favorites)?;
+        state.serialize_field("last_active", &self.last_active)?;
 
         state.end()
     }

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -639,6 +639,9 @@ impl State {
     }
     /// Clears the active chat in the `State` struct.
     fn clear_active_chat(&mut self) {
+        if let Some(c) = self.chats.active {
+            self.chats.last_active = Some(c);
+        }
         self.chats.active = None;
     }
     pub fn clear_typing_indicator(&mut self, instant: Instant) -> bool {

--- a/common/src/testing/mock.rs
+++ b/common/src/testing/mock.rs
@@ -80,6 +80,7 @@ pub fn generate_mock() -> State {
         active_media: None,
         in_sidebar,
         favorites: vec![],
+        last_active: None,
     };
     let friends = Friends {
         initialized: true,

--- a/ui/src/layouts/chat.rs
+++ b/ui/src/layouts/chat.rs
@@ -30,6 +30,13 @@ pub fn ChatLayout(cx: Scope<Props>) -> Element {
 
     state.write_silent().ui.current_layout = ui::Layout::Welcome;
 
+    let chats = state.read().chats().clone();
+    if chats.active.is_none() {
+        if let Some(a) = chats.last_active {
+            state.write().mutate(Action::ChatWith(&a, false));
+        }
+    }
+
     let is_minimal_view = state.read().ui.is_minimal_view();
     let sidebar_hidden = state.read().ui.sidebar_hidden;
     let show_welcome = state.read().chats().active.is_none();


### PR DESCRIPTION
### What this PR does 📖

- Saves the uuid of the active chat when one switches to another tabs so when it switches back it still shows the chat
- The uuid is saved in the chats struct of `chats.rs` as `last_active` so it also persists over saves

### Which issue(s) this PR fixes 🔨

- Resolve #459

