### PR TITLE
fix(chats): fix notifications and chats view

### DIFF
--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -46,7 +46,7 @@ use warp::{
 };
 
 use self::storage::Storage;
-use self::ui::Call;
+use self::ui::{Call, Layout};
 
 // todo: create an Identity cache and only store UUID in state.friends and state.chats
 // store the following information in the cache: key: DID, value: { Identity, HashSet<UUID of conversations this identity is participating in> }
@@ -355,7 +355,7 @@ impl State {
                 // TODO: Get state available in this scope.
                 // Dispatch notifications only when we're not already focused on the application.
                 let notifications_enabled = self.configuration.notifications.messages_notifications;
-                let should_play_sound = self.chats.active != Some(conversation_id)
+                let should_play_sound = self.ui.current_layout != Layout::Compose
                     && self.configuration.audiovideo.message_sounds;
                 let should_dispatch_notification =
                     notifications_enabled && !self.ui.metadata.focused;

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -343,9 +343,9 @@ impl State {
                 // todo: don't load all the messages by default. if the user scrolled up, for example, this incoming message may not need to be fetched yet.
                 self.add_msg_to_chat(conversation_id, message);
 
-                if self.chats.in_sidebar.contains(&conversation_id) {
-                    self.send_chat_to_top_of_sidebar(conversation_id);
-                }
+                //if self.chats.in_sidebar.contains(&conversation_id) {
+                self.send_chat_to_top_of_sidebar(conversation_id);
+                //}
 
                 self.mutate(Action::AddNotification(
                     notifications::NotificationKind::Message,

--- a/ui/src/layouts/chat.rs
+++ b/ui/src/layouts/chat.rs
@@ -1,10 +1,7 @@
 use dioxus::prelude::*;
 
-use crate::{
-    components::chat::{
-        compose::Compose, sidebar::Sidebar as ChatSidebar, welcome::Welcome, RouteInfo,
-    },
-    utils::lifecycle::use_on_unmount,
+use crate::components::chat::{
+    compose::Compose, sidebar::Sidebar as ChatSidebar, welcome::Welcome, RouteInfo,
 };
 use common::state::{ui, Action, State};
 
@@ -17,16 +14,6 @@ pub struct Props {
 pub fn ChatLayout(cx: Scope<Props>) -> Element {
     let state = use_shared_state::<State>(cx)?;
     let first_render = use_state(cx, || true);
-
-    // when the user leaves the chat layout, no chat is active anymore
-    use_on_unmount(cx, {
-        // we need to call inner here in order to move into the closure, but we lose updates
-        // TODO: next version of dioxus will fix this
-        let state = state.inner();
-        move || {
-            state.borrow_mut().write().mutate(Action::ClearActiveChat);
-        }
-    });
 
     state.write_silent().ui.current_layout = ui::Layout::Welcome;
 

--- a/ui/src/utils/lifecycle.rs
+++ b/ui/src/utils/lifecycle.rs
@@ -1,11 +1,11 @@
-use dioxus::prelude::*;
+//use dioxus::prelude::*;
 
-pub fn use_on_unmount<F: FnOnce() + 'static>(cx: &ScopeState, on_unmount: F) -> &LifeCycle<F> {
-    cx.use_hook(|| LifeCycle {
-        on_unmount: Some(on_unmount),
-    })
-}
-
+// pub fn use_on_unmount<F: FnOnce() + 'static>(cx: &ScopeState, on_unmount: F) -> &LifeCycle<F> {
+//     cx.use_hook(|| LifeCycle {
+//         on_unmount: Some(on_unmount),
+//     })
+// }
+//
 pub struct LifeCycle<D: FnOnce()> {
     on_unmount: Option<D>,
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- don't clear the active chat when leaving the chats view 
- play a notification for the active chat if a message is received while not on the chats view 
- add a chat to the sidebar if a message is received. There wasn't a ticket for this but it seems weird to not know someone is messaging you unless you explicitly click the "chat with" button. 

### Which issue(s) this PR fixes 🔨

- Resolve #306 #459 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
I left in the addition to `utils` in case someone wants to use it later. I commented it out to avoid a clippy warning. 
