### PR TITLE
chore(cargo): Update dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,10 @@ humansize = "2.1.3"
 window-vibrancy = "0.3.2"
 uuid = { version = "1", features = ["serde", "v4"] }
 libloading = "0.7.4"
-warp = { git = "https://github.com/Satellite-im/Warp", rev = "6980686ea5514ca78b209aca76e0fe3d13bed64d" }
-warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "6980686ea5514ca78b209aca76e0fe3d13bed64d" }
-warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "6980686ea5514ca78b209aca76e0fe3d13bed64d" }
-warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "6980686ea5514ca78b209aca76e0fe3d13bed64d" }
+warp = { git = "https://github.com/Satellite-im/Warp", rev = "8182c5e029ac25f35b5bef46bf6dc785815a3590" }
+warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "8182c5e029ac25f35b5bef46bf6dc785815a3590" }
+warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "8182c5e029ac25f35b5bef46bf6dc785815a3590" }
+warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "8182c5e029ac25f35b5bef46bf6dc785815a3590" }
 rfd = "0.10.0"
 mime = "0.3.16"
 serde = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,10 @@ humansize = "2.1.3"
 window-vibrancy = "0.3.2"
 uuid = { version = "1", features = ["serde", "v4"] }
 libloading = "0.7.4"
-warp = { git = "https://github.com/Satellite-im/Warp", rev = "2ee12774c30c47b00fafc4c8984c3710219de61f" }
-warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "2ee12774c30c47b00fafc4c8984c3710219de61f" }
-warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "2ee12774c30c47b00fafc4c8984c3710219de61f" }
-warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "2ee12774c30c47b00fafc4c8984c3710219de61f" }
+warp = { git = "https://github.com/Satellite-im/Warp", rev = "6dd36eb8e777f206ac57482411f6a0f8daf4e3e8" }
+warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "6dd36eb8e777f206ac57482411f6a0f8daf4e3e8" }
+warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "6dd36eb8e777f206ac57482411f6a0f8daf4e3e8" }
+warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "6dd36eb8e777f206ac57482411f6a0f8daf4e3e8" }
 rfd = "0.10.0"
 mime = "0.3.16"
 serde = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,10 @@ humansize = "2.1.3"
 window-vibrancy = "0.3.2"
 uuid = { version = "1", features = ["serde", "v4"] }
 libloading = "0.7.4"
-warp = { git = "https://github.com/Satellite-im/Warp", rev = "39239db4e9330bdbba0ac5dcbda2a7c04b282279" }
-warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "39239db4e9330bdbba0ac5dcbda2a7c04b282279" }
-warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "39239db4e9330bdbba0ac5dcbda2a7c04b282279" }
-warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "39239db4e9330bdbba0ac5dcbda2a7c04b282279" }
+warp = { git = "https://github.com/Satellite-im/Warp", rev = "2ee12774c30c47b00fafc4c8984c3710219de61f" }
+warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "2ee12774c30c47b00fafc4c8984c3710219de61f" }
+warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "2ee12774c30c47b00fafc4c8984c3710219de61f" }
+warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "2ee12774c30c47b00fafc4c8984c3710219de61f" }
 rfd = "0.10.0"
 mime = "0.3.16"
 serde = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,10 @@ humansize = "2.1.3"
 window-vibrancy = "0.3.2"
 uuid = { version = "1", features = ["serde", "v4"] }
 libloading = "0.7.4"
-warp = { git = "https://github.com/Satellite-im/Warp", rev = "8182c5e029ac25f35b5bef46bf6dc785815a3590" }
-warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "8182c5e029ac25f35b5bef46bf6dc785815a3590" }
-warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "8182c5e029ac25f35b5bef46bf6dc785815a3590" }
-warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "8182c5e029ac25f35b5bef46bf6dc785815a3590" }
+warp = { git = "https://github.com/Satellite-im/Warp", rev = "39239db4e9330bdbba0ac5dcbda2a7c04b282279" }
+warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "39239db4e9330bdbba0ac5dcbda2a7c04b282279" }
+warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "39239db4e9330bdbba0ac5dcbda2a7c04b282279" }
+warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "39239db4e9330bdbba0ac5dcbda2a7c04b282279" }
 rfd = "0.10.0"
 mime = "0.3.16"
 serde = "1.0"

--- a/common/src/warp_runner/mod.rs
+++ b/common/src/warp_runner/mod.rs
@@ -327,6 +327,7 @@ async fn warp_initialization(tesseract: Tesseract) -> Result<manager::Warp, warp
     config.ipfs_setting.portmapping = true;
     config.ipfs_setting.agent_version = Some("Uplink".into());
     config.store_setting.emit_online_event = true;
+    config.store_setting.share_platform = true;
 
     let account = warp_mp_ipfs::ipfs_identity_persistent(config, tesseract.clone(), None)
         .await

--- a/common/src/warp_runner/mod.rs
+++ b/common/src/warp_runner/mod.rs
@@ -14,7 +14,7 @@ use warp::{
     tesseract::Tesseract,
 };
 use warp_fs_ipfs::config::FsIpfsConfig;
-use warp_mp_ipfs::config::{MpIpfsConfig, UpdateEvents};
+use warp_mp_ipfs::config::MpIpfsConfig;
 use warp_rg_ipfs::config::RgIpfsConfig;
 
 use crate::{STATIC_ARGS, WARP_CMD_CH};

--- a/common/src/warp_runner/mod.rs
+++ b/common/src/warp_runner/mod.rs
@@ -325,7 +325,7 @@ async fn warp_initialization(tesseract: Tesseract) -> Result<manager::Warp, warp
     let path = &STATIC_ARGS.warp_path;
     let mut config = MpIpfsConfig::production(path, STATIC_ARGS.experimental);
     config.ipfs_setting.portmapping = true;
-    config.ipfs_setting.agent_version = Some("Uplink".into());
+    config.ipfs_setting.agent_version = Some(format!("uplink/{}", env!("CARGO_PKG_VERSION")));
     config.store_setting.emit_online_event = true;
     config.store_setting.share_platform = true;
 

--- a/common/src/warp_runner/mod.rs
+++ b/common/src/warp_runner/mod.rs
@@ -326,7 +326,7 @@ async fn warp_initialization(tesseract: Tesseract) -> Result<manager::Warp, warp
     let mut config = MpIpfsConfig::production(path, STATIC_ARGS.experimental);
     config.ipfs_setting.portmapping = true;
     config.ipfs_setting.agent_version = Some("Uplink".into());
-    config.store_setting.update_events = UpdateEvents::Enabled;
+    config.store_setting.emit_online_event = true;
 
     let account = warp_mp_ipfs::ipfs_identity_persistent(config, tesseract.clone(), None)
         .await

--- a/common/src/warp_runner/mod.rs
+++ b/common/src/warp_runner/mod.rs
@@ -14,7 +14,7 @@ use warp::{
     tesseract::Tesseract,
 };
 use warp_fs_ipfs::config::FsIpfsConfig;
-use warp_mp_ipfs::config::MpIpfsConfig;
+use warp_mp_ipfs::config::{MpIpfsConfig, UpdateEvents};
 use warp_rg_ipfs::config::RgIpfsConfig;
 
 use crate::{STATIC_ARGS, WARP_CMD_CH};
@@ -326,6 +326,8 @@ async fn warp_initialization(tesseract: Tesseract) -> Result<manager::Warp, warp
     let mut config = MpIpfsConfig::production(path, STATIC_ARGS.experimental);
     config.ipfs_setting.portmapping = true;
     config.ipfs_setting.agent_version = Some("Uplink".into());
+    config.store_setting.update_events = UpdateEvents::Enabled;
+
     let account = warp_mp_ipfs::ipfs_identity_persistent(config, tesseract.clone(), None)
         .await
         .map(|mp| Box::new(mp) as Account)?;

--- a/common/src/warp_runner/ui_adapter/mod.rs
+++ b/common/src/warp_runner/ui_adapter/mod.rs
@@ -128,7 +128,7 @@ pub async fn conversation_to_chat(
     let unreads = messaging.get_message_count(conv.id()).await?;
     let messages = messaging
         .get_messages(conv.id(), MessageOptions::default().set_range(0..unreads))
-        .await?;
+        .await.and_then(Vec::<_>::try_from)?;
 
     let messages = FuturesOrdered::from_iter(
         messages


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Update dependency
- refactored `RayGun::get_messages` to return an enum based on the type set in `MessageOptions`
- Enables flag to show phatform
- Enables flag to emit event for friend online or offline.

### Which issue(s) this PR fixes 🔨

- N/A

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️
Test with and without `--experimental-node` flag (primarily with if possible) for those who had issues with connections to relay or unable to support port forwarding.

### Additional comments 🎤
This update made changes to connect to the relay first while waiting for the nat status to determine if it could be needed or not. This would improve connectivity during initialization for those whose network or firewall doesnt support UPnP.

The update also make changes to `RayGun::get_messages` to return either a list, stream or pages of messages, which is determined by `MessageOptions::set_messages_type`, with default being `MessagesType::List`. 


