### PR TITLE
feat(files): Remove bottom corner rect of scrollbars

### DIFF
--- a/ui/src/style.scss
+++ b/ui/src/style.scss
@@ -124,6 +124,11 @@ html, body {
     background: var(--primary);
 }    
 
+/* Disable the corner of scrollbars */
+::-webkit-scrollbar-corner {
+    background-color: transparent;
+}
+
 .drag-handle {
     position: absolute;
     top: 0;


### PR DESCRIPTION
### What this PR does 📖

- Removes the bottom rectangle bit of scrollbars noticeable for e.g. the files window as a white dot

### Which issue(s) this PR fixes 🔨

- Resolve #489
