### PR TITLE
feat(chats): fetch messages from warp on demand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,10 @@ humansize = "2.1.3"
 window-vibrancy = "0.3.2"
 uuid = { version = "1", features = ["serde", "v4"] }
 libloading = "0.7.4"
-warp = { git = "https://github.com/Satellite-im/Warp", rev = "6980686ea5514ca78b209aca76e0fe3d13bed64d" }
-warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "6980686ea5514ca78b209aca76e0fe3d13bed64d" }
-warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "6980686ea5514ca78b209aca76e0fe3d13bed64d" }
-warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "6980686ea5514ca78b209aca76e0fe3d13bed64d" }
+warp = { git = "https://github.com/Satellite-im/Warp", rev = "39239db4e9330bdbba0ac5dcbda2a7c04b282279" }
+warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "39239db4e9330bdbba0ac5dcbda2a7c04b282279" }
+warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "39239db4e9330bdbba0ac5dcbda2a7c04b282279" }
+warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "39239db4e9330bdbba0ac5dcbda2a7c04b282279" }
 rfd = "0.10.0"
 mime = "0.3.16"
 serde = "1.0"

--- a/common/src/state/chats.rs
+++ b/common/src/state/chats.rs
@@ -46,6 +46,9 @@ pub struct Chat {
     pub typing_indicator: HashMap<DID, Instant>,
     #[serde(skip)]
     pub draft: Option<String>,
+    // for loading messages into the UI - indicates if more messages can be fetched from warp and added to Chat.messages
+    #[serde(skip)]
+    pub has_more_messages: bool,
 }
 
 // warning: Chats implements Serialize

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -718,6 +718,18 @@ impl State {
             })
             .cloned()
     }
+    // assumes the messages are sorted by most recent to oldest
+    pub fn prepend_messages_to_chat(
+        &mut self,
+        conversation_id: Uuid,
+        mut messages: Vec<ui_adapter::Message>,
+    ) {
+        if let Some(chat) = self.chats.all.get_mut(&conversation_id) {
+            for message in messages.drain(..) {
+                chat.messages.push_front(message.clone());
+            }
+        }
+    }
 
     /// Check if given chat is favorite on `State` struct.
     ///

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -583,6 +583,7 @@ impl State {
         for (id, chat) in chats {
             if let Some(conv) = self.chats.all.get_mut(&id) {
                 conv.messages = chat.messages;
+                conv.has_more_messages = chat.has_more_messages
             } else {
                 self.chats.all.insert(id, chat);
             }

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -698,6 +698,11 @@ impl State {
             self.chats.favorites.push(*chat);
         }
     }
+    pub fn finished_loading_chat(&mut self, chat_id: Uuid) {
+        if let Some(chat) = self.chats.all.get_mut(&chat_id) {
+            chat.has_more_messages = false;
+        }
+    }
     /// Get the active chat on `State` struct.
     pub fn get_active_chat(&self) -> Option<Chat> {
         self.chats

--- a/common/src/testing/mock.rs
+++ b/common/src/testing/mock.rs
@@ -123,6 +123,7 @@ fn generate_fake_chat(participants: Vec<Identity>, conversation: Uuid) -> Chat {
         replying_to: None,
         typing_indicator: HashMap::new(),
         draft: None,
+        has_more_messages: false,
     }
 }
 

--- a/common/src/warp_runner/manager/commands/raygun_commands.rs
+++ b/common/src/warp_runner/manager/commands/raygun_commands.rs
@@ -39,7 +39,9 @@ pub enum RayGunCmd {
         recipient: DID,
         rsp: oneshot::Sender<Result<ChatAdapter, warp::error::Error>>,
     },
-    #[display(fmt = "FetchMessages {{ conv_id: {conv_id} }} ")]
+    #[display(
+        fmt = "FetchMessages {{ conv_id: {conv_id}, req_len: {new_len}, current_len: {current_len} }} "
+    )]
     FetchMessages {
         conv_id: Uuid,
         // the total number of messages that should be in the conversation

--- a/common/src/warp_runner/ui_adapter/mod.rs
+++ b/common/src/warp_runner/ui_adapter/mod.rs
@@ -126,12 +126,8 @@ pub async fn fetch_messages_from_chat(
     let total = std::cmp::min(total, max_messages);
     let messages = messaging
         .get_messages(conv_id, MessageOptions::default().set_range(to_skip..total))
-        .await?;
-
-    let messages = match messages {
-        raygun::Messages::List(m) => m,
-        _ => return Err(Error::OtherWithContext("invalid messages container".into())),
-    };
+        .await
+        .and_then(Vec::<_>::try_from)?;
 
     let messages = FuturesOrdered::from_iter(
         messages
@@ -158,12 +154,8 @@ pub async fn conversation_to_chat(
     let to_take = std::cmp::min(unreads, 20);
     let messages = messaging
         .get_messages(conv.id(), MessageOptions::default().set_range(0..to_take))
-        .await?;
-
-    let messages = match messages {
-        raygun::Messages::List(m) => m,
-        _ => return Err(Error::OtherWithContext("invalid messages container".into())),
-    };
+        .await
+        .and_then(Vec::<_>::try_from)?;
 
     let messages: VecDeque<_> = FuturesOrdered::from_iter(
         messages

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -357,6 +357,7 @@ fn get_messages(cx: Scope, data: Rc<ComposeData>) -> Element {
 
     if let Some((id, m)) = newely_fetched_messages.write_silent().take() {
         if m.is_empty() {
+            log::debug!("finished loading chat: {id}");
             state.write().finished_loading_chat(id);
         } else {
             num_to_take.with_mut(|x| *x = x.saturating_add(m.len()));


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- now the Compose view will both lazily render messages and lazily fetch messages from warp.
- The time required for uplink to startup wasn't improved as much as I hoped. There's more work to do there.  
- Unfortunately another field was added to `Chat` - to tell the UI if it's possible to fetch more messages. Tracking that flag isn't fun. Not sure how else to do this though. 



### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

