### PR TITLE
update(StatusMessage): Fix 128 chars status

### DIFF
--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -888,7 +888,11 @@ impl State {
         }
 
         for (_, list) in friends_by_first_letter.iter_mut() {
-            list.sort_by_key(|a| a.username())
+            list.sort_by(|a, b| {
+                a.username()
+                    .cmp(&b.username())
+                    .then(a.did_key().to_string().cmp(&b.did_key().to_string()))
+            })
         }
 
         friends_by_first_letter

--- a/ui/src/components/friends/friend/style.scss
+++ b/ui/src/components/friends/friend/style.scss
@@ -5,10 +5,19 @@
     align-items: center;
     .request-info {
         flex: 1;
+        display: inline-block;
+        width: 30px;
         p {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            max-width: 100%;
             color: var(--text-color);
-
             span {
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+                max-width: 100%;
                 color: var(--text-color-muted);
             }
         }
@@ -20,5 +29,10 @@
     .status-message {
         font-size: var(--text-size-less);
         color: var(--text-color-muted) !important;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        display: inline-block;
+        max-width: 100%;
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
### 1. Fix status message when it is so long 
### 2. Fix long username as well
### 3. Fix sort friends when users have same name 

**a. Tested on MacOS**

https://user-images.githubusercontent.com/63157656/226964301-c0c0344b-0024-4ab2-af5e-f0eca18b13dd.mov

**b. Tested on Windows**

https://user-images.githubusercontent.com/63157656/226966750-0105f140-192b-4d57-8abc-9e64a5c7ca43.mov





### 4. Just for comparison, this is behavior on dev branch 


https://user-images.githubusercontent.com/63157656/226963823-e77e1e59-7c43-472d-9e60-731735b693c1.mov



- 

### Which issue(s) this PR fixes 🔨

- Resolve #490 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

