### PR TITLE
chore(ui): Update dioxus to latest commit 46cc07e

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,15 +18,15 @@ codegen-units = 1
 version = "0.1.0"
 
 [workspace.dependencies]
-dioxus = { git = "https://github.com/DioxusLabs/dioxus", rev = "d521da1991719760e271457dfe4f9ddf281afbb3" }
-dioxus-hooks = { git = "https://github.com/DioxusLabs/dioxus", rev = "d521da1991719760e271457dfe4f9ddf281afbb3" }
-dioxus-html = { git = "https://github.com/DioxusLabs/dioxus", rev = "d521da1991719760e271457dfe4f9ddf281afbb3" }
-dioxus-router = { git = "https://github.com/DioxusLabs/dioxus", rev = "d521da1991719760e271457dfe4f9ddf281afbb3" }
-dioxus-desktop = { git = "https://github.com/DioxusLabs/dioxus", rev = "d521da1991719760e271457dfe4f9ddf281afbb3", features = [
+dioxus = { git = "https://github.com/DioxusLabs/dioxus", rev = "46cc07e04827f8ea63bd210eaf6b72727441b6bf" }
+dioxus-hooks = { git = "https://github.com/DioxusLabs/dioxus", rev = "46cc07e04827f8ea63bd210eaf6b72727441b6bf" }
+dioxus-html = { git = "https://github.com/DioxusLabs/dioxus", rev = "46cc07e04827f8ea63bd210eaf6b72727441b6bf" }
+dioxus-router = { git = "https://github.com/DioxusLabs/dioxus", rev = "46cc07e04827f8ea63bd210eaf6b72727441b6bf" }
+dioxus-desktop = { git = "https://github.com/DioxusLabs/dioxus", rev = "46cc07e04827f8ea63bd210eaf6b72727441b6bf", features = [
     "transparent",
 ] }
 raw-window-handle = "0.5"
-dioxus-core = { git = "https://github.com/DioxusLabs/dioxus", rev = "d521da1991719760e271457dfe4f9ddf281afbb3" }
+dioxus-core = { git = "https://github.com/DioxusLabs/dioxus", rev = "46cc07e04827f8ea63bd210eaf6b72727441b6bf" }
 fermi = { git = "https://github.com/DioxusLabs/dioxus", rev = "22e71a71bdcdc03c3ae83ae1c3b3fb5417ebaa80" }
 tokio-util = { version = "0.7", features = ["full"] }
 arboard = "3.2"

--- a/native_extensions/emoji_selector/Cargo.toml
+++ b/native_extensions/emoji_selector/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-dioxus = { git = "https://github.com/DioxusLabs/dioxus", rev="d521da1991719760e271457dfe4f9ddf281afbb3" }
-dioxus-desktop = { git = "https://github.com/DioxusLabs/dioxus", rev = "d521da1991719760e271457dfe4f9ddf281afbb3", features = [
+dioxus = { git = "https://github.com/DioxusLabs/dioxus", rev="46cc07e04827f8ea63bd210eaf6b72727441b6bf" }
+dioxus-desktop = { git = "https://github.com/DioxusLabs/dioxus", rev = "46cc07e04827f8ea63bd210eaf6b72727441b6bf", features = [
     "transparent",
 ] }
 extensions = { path = "../../extensions" }

--- a/ui/src/components/friends/friends_list/mod.rs
+++ b/ui/src/components/friends/friends_list/mod.rs
@@ -36,7 +36,7 @@ enum ChanCmd {
 
 #[allow(non_snake_case)]
 pub fn Friends(cx: Scope) -> Element {
-    let state: UseSharedState<State> = use_shared_state::<State>(cx).unwrap();
+    let state: &UseSharedState<State> = use_shared_state::<State>(cx)?;
     let friends_list = HashMap::from_iter(
         state
             .read()

--- a/ui/src/components/friends/incoming_requests/mod.rs
+++ b/ui/src/components/friends/incoming_requests/mod.rs
@@ -29,7 +29,7 @@ enum ChanCmd {
 
 #[allow(non_snake_case)]
 pub fn PendingFriends(cx: Scope) -> Element {
-    let state: UseSharedState<State> = use_shared_state::<State>(cx).unwrap();
+    let state: &UseSharedState<State> = use_shared_state::<State>(cx)?;
     let friends_list = state.read().incoming_fr_identities();
 
     let ch = use_coroutine(cx, |mut rx: UnboundedReceiver<ChanCmd>| {

--- a/ui/src/components/friends/outgoing_requests/mod.rs
+++ b/ui/src/components/friends/outgoing_requests/mod.rs
@@ -21,7 +21,7 @@ use warp::{crypto::DID, logging::tracing::log, multipass::identity::Relationship
 
 #[allow(non_snake_case)]
 pub fn OutgoingRequests(cx: Scope) -> Element {
-    let state: UseSharedState<State> = use_shared_state::<State>(cx).unwrap();
+    let state: &UseSharedState<State> = use_shared_state::<State>(cx)?;
     let friends_list = state.read().outgoing_fr_identities();
 
     let ch = use_coroutine(cx, |mut rx: UnboundedReceiver<DID>| {

--- a/ui/src/components/toast/mod.rs
+++ b/ui/src/components/toast/mod.rs
@@ -19,7 +19,7 @@ pub struct Props {
 
 #[allow(non_snake_case)]
 pub fn Toast(cx: Scope<Props>) -> Element {
-    let state: UseSharedState<State> = use_shared_state::<State>(cx).unwrap();
+    let state: &UseSharedState<State> = use_shared_state::<State>(cx)?;
     cx.render(rsx!(kit::components::toast::Toast {
         id: cx.props.id,
         on_hover: move |_| state.write_silent().reset_toast_timer(&cx.props.id),

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -491,7 +491,7 @@ fn app(cx: Scope) -> Element {
                 event: WindowEvent::Focused(focused),
                 ..
             } => {
-                state.write().ui.metadata.focused = *focused;
+                state.write_silent().ui.metadata.focused = *focused;
                 //crate::utils::sounds::Play(Sounds::Notification);
             }
             WryEvent::WindowEvent {
@@ -499,7 +499,7 @@ fn app(cx: Scope) -> Element {
                 ..
             } => {
                 state
-                    .write()
+                    .write_silent()
                     .mutate(Action::ClearAllPopoutWindows(desktop.clone()));
             }
             WryEvent::WindowEvent {
@@ -514,6 +514,7 @@ fn app(cx: Scope) -> Element {
                     minimal_view: size.width < 600,
                     ..metadata
                 };
+
                 if metadata != new_metadata {
                     state.write().ui.sidebar_hidden = new_metadata.minimal_view;
                     state.write().ui.metadata = new_metadata;
@@ -529,7 +530,7 @@ fn app(cx: Scope) -> Element {
         async move {
             // don't process warp events until friends and chats have been loaded
             while !(*friends_init.read() && *chats_init.read()) {
-                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
             }
             let warp_event_rx = WARP_EVENT_CH.rx.clone();
             log::trace!("starting warp_runner use_future");
@@ -581,6 +582,7 @@ fn app(cx: Scope) -> Element {
             loop {
                 // simply triggering an update will refresh the message timestamps
                 sleep(Duration::from_secs(60)).await;
+                log::trace!("refresh");
                 state.write();
             }
         }
@@ -638,7 +640,7 @@ fn app(cx: Scope) -> Element {
             };
             log::trace!("init friends successful");
             state.write().set_friends(friends.0, friends.1);
-            *friends_init.write_silent() = true;
+            *friends_init.write() = true;
         }
     });
 
@@ -726,7 +728,7 @@ fn app(cx: Scope) -> Element {
             };
             log::trace!("init chats successful");
             state.write().set_chats(chats.0, chats.1);
-            *chats_init.write_silent() = true;
+            *chats_init.write() = true;
         }
     });
 

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -428,7 +428,7 @@ fn app(cx: Scope) -> Element {
 
     // don't fetch friends and conversations from warp when using mock data
     let friends_init = use_ref(cx, || STATIC_ARGS.use_mock);
-    let items_init = use_ref(cx, || STATIC_ARGS.use_mock);
+    let files_init = use_ref(cx, || STATIC_ARGS.use_mock);
     let chats_init = use_ref(cx, || STATIC_ARGS.use_mock);
 
     // this gets rendered at the bottom. this way you don't have to scroll past all the use_futures to see what this function renders
@@ -644,9 +644,9 @@ fn app(cx: Scope) -> Element {
 
     // initialize files
     use_future(cx, (), |_| {
-        to_owned![items_init, state];
+        to_owned![files_init, state];
         async move {
-            if *items_init.read() {
+            if *files_init.read() {
                 return;
             }
 
@@ -679,7 +679,7 @@ fn app(cx: Scope) -> Element {
             };
             log::trace!("init files successful");
             state.write().storage = storage;
-            *items_init.write_silent() = true;
+            *files_init.write_silent() = true;
         }
     });
 

--- a/ui/src/window_manager/mod.rs
+++ b/ui/src/window_manager/mod.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc};
+use std::sync::Arc;
 
 use dioxus_desktop::DesktopContext;
 use dioxus_hooks::UseSharedState;

--- a/ui/src/window_manager/mod.rs
+++ b/ui/src/window_manager/mod.rs
@@ -1,7 +1,7 @@
-use std::{cell::RefCell, rc::Rc, sync::Arc};
+use std::{sync::Arc};
 
 use dioxus_desktop::DesktopContext;
-use dioxus_hooks::ProvidedStateInner;
+use dioxus_hooks::UseSharedState;
 use tokio::sync::{
     mpsc::{UnboundedReceiver, UnboundedSender},
     Mutex,
@@ -28,38 +28,22 @@ pub enum WindowManagerCmd {
 }
 
 pub async fn handle_cmd(
-    state: Rc<RefCell<ProvidedStateInner<State>>>,
+    state: UseSharedState<State>,
     cmd: WindowManagerCmd,
     desktop: DesktopContext,
 ) {
     match cmd {
         WindowManagerCmd::ClosePopout => {
-            if let Ok(s) = state.try_borrow_mut() {
-                s.write().mutate(Action::ClearCallPopout(desktop));
-            } else {
-                //todo: add logging
-            }
+            state.write().mutate(Action::ClearCallPopout(desktop));
         }
         WindowManagerCmd::CloseDebugLogger => {
-            if let Ok(s) = state.try_borrow_mut() {
-                s.write().mutate(Action::ClearDebugLogger(desktop));
-            } else {
-                //todo: add logging
-            }
+            state.write().mutate(Action::ClearDebugLogger(desktop));
         }
         WindowManagerCmd::CloseFilePreview => {
-            if let Ok(s) = state.try_borrow_mut() {
-                s.write().mutate(Action::ClearFilePreviews(desktop));
-            } else {
-                //todo: add logging
-            }
+            state.write().mutate(Action::ClearFilePreviews(desktop));
         }
         WindowManagerCmd::ForgetFilePreview(id) => {
-            if let Ok(s) = state.try_borrow_mut() {
-                s.write().mutate(Action::ForgetFilePreview(id));
-            } else {
-                //todo: add logging
-            }
+            state.write().mutate(Action::ForgetFilePreview(id));
         }
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Updates dioxus dependency to latest commit
- Remove functions to access inner reference counter and clone and use the state directly

### Which issue(s) this PR fixes 🔨

- N/A

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
Assuming my understanding of the changes done in dioxus is correct, we would no longer need to access the reference counter directly when borrowing it into another scope to try to mutate the values through it. Of course, while the UI runs with this PR, there should be extensive testing done to ensure everything is operational. 
