### PR TITLE
chore(windows): hide textarea scrollbar that shows up in windows only

### DIFF
--- a/kit/src/style.scss
+++ b/kit/src/style.scss
@@ -54,6 +54,7 @@ input, textarea {
 /* revert the 'white-space' property for textarea elements on Safari */
 textarea {
     white-space: revert;
+    overflow: hidden;
 }
 
 /* minimum style to allow to style meter element */

--- a/kit/src/style.scss
+++ b/kit/src/style.scss
@@ -54,7 +54,9 @@ input, textarea {
 /* revert the 'white-space' property for textarea elements on Safari */
 textarea {
     white-space: revert;
-    overflow: hidden;
+}
+textarea::-webkit-scrollbar {
+    display: none;
 }
 
 /* minimum style to allow to style meter element */


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
On windows you see this:
![image](https://user-images.githubusercontent.com/2993032/227339924-6b3dcc8d-7d9a-4245-8d98-1666eae38ffa.png)
 which will go away when it overflows like so:
 
![image](https://user-images.githubusercontent.com/2993032/227340016-f61d07d6-8c59-4fae-be70-2084d57927e8.png)




This PR hides the scrollbar, here it is on windows:
![image](https://user-images.githubusercontent.com/2993032/227340253-dd97c38a-ac38-4cee-96ac-9836652330cc.png)


![image](https://user-images.githubusercontent.com/2993032/227339595-65768414-1abf-436c-80a7-017946e3b507.png)




And on mac it does not change anything:
![Screenshot 2023-03-23 at 2 10 36 PM](https://user-images.githubusercontent.com/2993032/227340804-27e2dbdf-c678-4e0b-a622-afe30333d414.png)

![Screenshot 2023-03-23 at 2 11 11 PM](https://user-images.githubusercontent.com/2993032/227340864-492cbdff-f634-4716-acff-e7f296f7cefb.png)

- 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

