### PR TITLE
chore(cargo): Update dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,10 +42,10 @@ humansize = "2.1.3"
 window-vibrancy = "0.3.2"
 uuid = { version = "1", features = ["serde", "v4"] }
 libloading = "0.7.4"
-warp = { git = "https://github.com/Satellite-im/Warp", rev = "109dc5f09d98a6724b91f0ce504516a164f6d77c" }
-warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "109dc5f09d98a6724b91f0ce504516a164f6d77c" }
-warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "109dc5f09d98a6724b91f0ce504516a164f6d77c" }
-warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "109dc5f09d98a6724b91f0ce504516a164f6d77c" }
+warp = { git = "https://github.com/Satellite-im/Warp", rev = "24971afdf1477c394e9137f2838da843de81e9af" }
+warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "24971afdf1477c394e9137f2838da843de81e9af" }
+warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "24971afdf1477c394e9137f2838da843de81e9af" }
+warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "24971afdf1477c394e9137f2838da843de81e9af" }
 rfd = "0.10.0"
 mime = "0.3.16"
 serde = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,13 @@
 [workspace]
-members = ["kit", "ui", "icons", "common", "extensions", "extension_example", "native_extensions/emoji_selector"]
+members = [
+    "kit",
+    "ui",
+    "icons",
+    "common",
+    "extensions",
+    "extension_example",
+    "native_extensions/emoji_selector",
+]
 
 [profile.rapid]
 inherits = "dev"
@@ -34,10 +42,10 @@ humansize = "2.1.3"
 window-vibrancy = "0.3.2"
 uuid = { version = "1", features = ["serde", "v4"] }
 libloading = "0.7.4"
-warp = { git = "https://github.com/Satellite-im/Warp", rev = "6dd36eb8e777f206ac57482411f6a0f8daf4e3e8" }
-warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "6dd36eb8e777f206ac57482411f6a0f8daf4e3e8" }
-warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "6dd36eb8e777f206ac57482411f6a0f8daf4e3e8" }
-warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "6dd36eb8e777f206ac57482411f6a0f8daf4e3e8" }
+warp = { git = "https://github.com/Satellite-im/Warp", rev = "109dc5f09d98a6724b91f0ce504516a164f6d77c" }
+warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "109dc5f09d98a6724b91f0ce504516a164f6d77c" }
+warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "109dc5f09d98a6724b91f0ce504516a164f6d77c" }
+warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "109dc5f09d98a6724b91f0ce504516a164f6d77c" }
 rfd = "0.10.0"
 mime = "0.3.16"
 serde = "1.0"

--- a/common/src/warp_runner/manager/commands/raygun_commands.rs
+++ b/common/src/warp_runner/manager/commands/raygun_commands.rs
@@ -161,7 +161,7 @@ pub async fn handle_raygun_cmd(
             let r = if attachments.is_empty() {
                 messaging.send(conv_id, msg).await
             } else {
-                messaging.attach(conv_id, attachments, msg).await
+                messaging.attach(conv_id, None, attachments, msg).await
             };
 
             let _ = rsp.send(r);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Adds an optional message id parameter to `RayGun::attach` to send an attachment as a reply to another message. 
- Refactor `RayGun::create_group_conversation` to allow setting a name to the group conversation
- Adds `RayGun::update_conversation_name` to modify/update group conversation name

### Which issue(s) this PR fixes 🔨

- N/A
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️
Nothing to review as these are either not implemented in uplink or have no impending effects on current functionality 

### Additional comments 🎤
- Setting or updating a name in a conversation is only allowed in group conversations. 
- Conversation name cannot exceed 255 characters
