### PR TITLE
fix(login): Login page displays "UNKNOWN"

### DIFF
--- a/common/locales/en-US/main.ftl
+++ b/common/locales/en-US/main.ftl
@@ -211,6 +211,8 @@ unlock = Unlock
     .enter-pin = Enter Pin
     .create-account = Create Account
     .unlock-account = Unlock Account
+    .welcome = Welcome back, { $name }
+    .create-password = Let's choose your password
 
 auth = Create Account 
     .enter-username = Enter Username

--- a/common/src/language/mod.rs
+++ b/common/src/language/mod.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 
-use fluent_templates::{once_cell::sync::Lazy, LanguageIdentifier, Loader};
+use fluent_templates::{
+    fluent_bundle::FluentValue, once_cell::sync::Lazy, LanguageIdentifier, Loader,
+};
 use unic_langid::langid;
 use warp::sync::RwLock;
 
@@ -49,4 +51,28 @@ pub fn get_available_languages() -> Vec<String> {
 
 pub fn get_local_text(text: &str) -> String {
     LOCALES.lookup(&APP_LANG.read().0, text).unwrap_or_default()
+}
+
+// Looks and formats a local text using the given args
+pub fn get_local_text_with_args<T: AsRef<str>>(
+    text: &str,
+    args: &HashMap<T, FluentValue>,
+) -> String {
+    LOCALES
+        .lookup_with_args(&APP_LANG.read().0, text, args)
+        .unwrap_or_default()
+}
+
+pub fn get_local_text_args_builder<F, T: AsRef<str>>(text: &str, builder: F) -> String
+where
+    F: FnOnce(&mut HashMap<T, FluentValue>),
+{
+    let args = {
+        let mut map = HashMap::new();
+        builder(&mut map);
+        map
+    };
+    LOCALES
+        .lookup_with_args(&APP_LANG.read().0, text, &args)
+        .unwrap_or_default()
 }

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -1105,6 +1105,7 @@ impl State {
     }
     pub fn set_own_identity(&mut self, identity: Identity) {
         self.id = identity.did_key();
+        self.ui.cached_username = Some(identity.username().clone());
         self.identities.insert(identity.did_key(), identity);
     }
     pub fn update_identity(&mut self, id: DID, ident: identity::Identity) {

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -1105,7 +1105,7 @@ impl State {
     }
     pub fn set_own_identity(&mut self, identity: Identity) {
         self.id = identity.did_key();
-        self.ui.cached_username = Some(identity.username().clone());
+        self.ui.cached_username = Some(identity.username());
         self.identities.insert(identity.did_key(), identity);
     }
     pub fn update_identity(&mut self, id: DID, ident: identity::Identity) {

--- a/common/src/state/ui.rs
+++ b/common/src/state/ui.rs
@@ -65,6 +65,8 @@ pub struct UI {
     pub file_previews: HashMap<Uuid, WindowId>,
     #[serde(default = "bool_true")]
     pub show_settings_welcome: bool,
+    // Cached username used in login page
+    pub cached_username: Option<String>,
 }
 
 #[derive(Default, Deserialize, Serialize)]

--- a/kit/src/elements/input/mod.rs
+++ b/kit/src/elements/input/mod.rs
@@ -82,7 +82,7 @@ pub struct Options {
     pub with_clear_btn: bool,
     pub clear_btn_icon: Icon,
     pub clear_on_submit: bool,
-    pub with_label: Option<&'static str>,
+    pub with_label: Option<String>,
     pub react_to_esc_key: bool,
 }
 

--- a/kit/src/elements/input/mod.rs
+++ b/kit/src/elements/input/mod.rs
@@ -244,10 +244,7 @@ pub fn get_aria_label(cx: &Scope<Props>) -> String {
 
 pub fn get_label(cx: &Scope<Props>) -> String {
     let options = cx.props.options.clone().unwrap_or_default();
-    options
-        .with_label
-        .map(|text| text.to_string())
-        .unwrap_or_default()
+    options.with_label.unwrap_or_default()
 }
 
 pub fn validate(cx: &Scope<Props>, val: &str) -> Option<ValidationError> {

--- a/ui/src/extension_browser/mod.rs
+++ b/ui/src/extension_browser/mod.rs
@@ -65,7 +65,7 @@ pub fn Explore(cx: Scope) -> Element {
                 aria_label: "extensions-search-input".into(),
                 icon: Icon::MagnifyingGlass,
                 options: Options {
-                    with_label: "Search Extensions".into(),
+                    with_label: String::from("Search Extensions").into(),
                     with_clear_btn: true,
                     ..Default::default()
                 }

--- a/ui/src/layouts/unlock.rs
+++ b/ui/src/layouts/unlock.rs
@@ -1,5 +1,5 @@
 use common::{
-    language::{get_local_text, get_local_text_args_builder, get_local_text_with_args},
+    language::{get_local_text, get_local_text_args_builder},
     state::{configuration::Configuration, State},
     warp_runner::TesseractCmd,
     STATIC_ARGS,
@@ -257,6 +257,5 @@ fn get_welcome_message() -> String {
     };
     get_local_text_args_builder("unlock.welcome", |m| {
         m.insert("name", name.into());
-        ()
     })
 }

--- a/ui/src/layouts/unlock.rs
+++ b/ui/src/layouts/unlock.rs
@@ -11,6 +11,7 @@ use kit::elements::{
     button::Button,
     input::{Input, Options, Validation},
 };
+use once_cell::sync::Lazy;
 use warp::{logging::tracing::log, multipass};
 
 use common::icons::outline::Shape as Icon;
@@ -21,6 +22,15 @@ use common::{
 };
 
 use crate::AuthPages;
+
+static LAZY_WELCOME_MESSAGE: Lazy<String> = Lazy::new(|| {
+    let state = State::load();
+    let name = match &state.ui.cached_username {
+        Some(name) => name.clone(),
+        None => String::from("UNKNOWN"),
+    };
+    format!("Welcome back, {}", name)
+});
 
 enum UnlockError {
     ValidationError,
@@ -175,7 +185,7 @@ pub fn UnlockLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -
                             with_validation: Some(pin_validation),
                             with_clear_btn: true,
                             with_label: if STATIC_ARGS.cache_path.exists()
-                                {Some("Welcome back, UNKNOWN")}
+                            {Some(&LAZY_WELCOME_MESSAGE)}
                             else
                                 {Some("Let's choose your password")}, // TODO: Implement this.
                             ..Default::default()


### PR DESCRIPTION
### What this PR does 📖

- Caches the username and during login displays that name instead of "UNKNOWN"
  Username is simply saved in the state ui instance

### Which issue(s) this PR fixes 🔨

- Resolve #439

