### PR TITLE
fix(DragAndDrop): Fix wrong feedback when user is not dragging a file

### DIFF
--- a/native_extensions/emoji_selector/src/lib.rs
+++ b/native_extensions/emoji_selector/src/lib.rs
@@ -120,12 +120,14 @@ impl EmojiSelector {
         let state = use_shared_state::<State>(cx)?;
         #[cfg(not(target_os = "macos"))]
         let mouse_over_emoji_selector = use_ref(cx, || false);
+        #[cfg(not(target_os = "macos"))]
+        let eval = use_eval(cx);
 
         let focus_script = r#"
             var emoji_selector = document.getElementById('emoji_selector');
             emoji_selector.focus();
         "#;
-        let eval = use_eval(cx);
+
         cx.render(rsx! (
             div {
                 onmouseenter: |_| {

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -1329,37 +1329,41 @@ async fn drag_and_drop_function(
         let file_drop_event = get_drag_event();
         match file_drop_event {
             FileDropEvent::Hovered(files_local_path) => {
-                let mut script = overlay_script.replace("$IS_DRAGGING", "true");
-                if files_local_path.len() > 1 {
-                    script.push_str(&FEEDBACK_TEXT_SCRIPT.replace(
-                        "$TEXT",
-                        &format!(
-                            "{} {}!",
-                            files_local_path.len(),
-                            get_local_text("files.files-to-upload")
-                        ),
-                    ));
-                } else {
-                    script.push_str(&FEEDBACK_TEXT_SCRIPT.replace(
-                        "$TEXT",
-                        &format!(
-                            "{} {}!",
-                            files_local_path.len(),
-                            get_local_text("files.one-file-to-upload")
-                        ),
-                    ));
+                if !files_local_path.is_empty() {
+                    let mut script = overlay_script.replace("$IS_DRAGGING", "true");
+                    if files_local_path.len() > 1 {
+                        script.push_str(&FEEDBACK_TEXT_SCRIPT.replace(
+                            "$TEXT",
+                            &format!(
+                                "{} {}!",
+                                files_local_path.len(),
+                                get_local_text("files.files-to-upload")
+                            ),
+                        ));
+                    } else {
+                        script.push_str(&FEEDBACK_TEXT_SCRIPT.replace(
+                            "$TEXT",
+                            &format!(
+                                "{} {}!",
+                                files_local_path.len(),
+                                get_local_text("files.one-file-to-upload")
+                            ),
+                        ));
+                    }
+                    window.eval(&script);
                 }
-                window.eval(&script);
             }
             FileDropEvent::Dropped(files_local_path) => {
-                *drag_event.write_silent() = None;
-                new_files_to_upload = decoded_pathbufs(files_local_path);
-                let mut script = overlay_script.replace("$IS_DRAGGING", "false");
-                script.push_str(ANIMATION_DASH_SCRIPT);
-                script.push_str(SELECT_CHAT_BAR);
-                window.set_focus();
-                window.eval(&script);
-                break;
+                if !files_local_path.is_empty() {
+                    *drag_event.write_silent() = None;
+                    new_files_to_upload = decoded_pathbufs(files_local_path);
+                    let mut script = overlay_script.replace("$IS_DRAGGING", "false");
+                    script.push_str(ANIMATION_DASH_SCRIPT);
+                    script.push_str(SELECT_CHAT_BAR);
+                    window.set_focus();
+                    window.eval(&script);
+                    break;
+                }
             }
             _ => {
                 *drag_event.write_silent() = None;

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -60,7 +60,8 @@ use wry::webview::FileDropEvent;
 use crate::{
     components::media::player::MediaPlayer,
     layouts::storage::{
-        decoded_pathbufs, get_drag_event, ANIMATION_DASH_SCRIPT, FEEDBACK_TEXT_SCRIPT,
+        decoded_pathbufs, get_drag_event, verify_if_there_are_valid_paths, ANIMATION_DASH_SCRIPT,
+        FEEDBACK_TEXT_SCRIPT,
     },
     utils::{
         build_participants, build_user_from_identity, format_timestamp::format_timestamp_timeago,
@@ -1329,7 +1330,7 @@ async fn drag_and_drop_function(
         let file_drop_event = get_drag_event();
         match file_drop_event {
             FileDropEvent::Hovered(files_local_path) => {
-                if !files_local_path.is_empty() {
+                if verify_if_there_are_valid_paths(&files_local_path) {
                     let mut script = overlay_script.replace("$IS_DRAGGING", "true");
                     if files_local_path.len() > 1 {
                         script.push_str(&FEEDBACK_TEXT_SCRIPT.replace(
@@ -1354,7 +1355,7 @@ async fn drag_and_drop_function(
                 }
             }
             FileDropEvent::Dropped(files_local_path) => {
-                if !files_local_path.is_empty() {
+                if verify_if_there_are_valid_paths(&files_local_path) {
                     *drag_event.write_silent() = None;
                     new_files_to_upload = decoded_pathbufs(files_local_path);
                     let mut script = overlay_script.replace("$IS_DRAGGING", "false");

--- a/ui/src/layouts/storage.rs
+++ b/ui/src/layouts/storage.rs
@@ -809,7 +809,7 @@ async fn drag_and_drop_function(
         let file_drop_event = get_drag_event();
         match file_drop_event {
             FileDropEvent::Hovered(files_local_path) => {
-                if !files_local_path.is_empty() {
+                if verify_if_there_are_valid_paths(&files_local_path) {
                     let mut script = main_script.replace("$IS_DRAGGING", "true");
                     if files_local_path.len() > 1 {
                         script.push_str(&FEEDBACK_TEXT_SCRIPT.replace(
@@ -834,7 +834,7 @@ async fn drag_and_drop_function(
                 }
             }
             FileDropEvent::Dropped(files_local_path) => {
-                if !files_local_path.is_empty() {
+                if verify_if_there_are_valid_paths(&files_local_path) {
                     let new_files_to_upload = decoded_pathbufs(files_local_path);
                     ch.send(ChanCmd::UploadFiles(new_files_to_upload));
                     break;
@@ -848,6 +848,14 @@ async fn drag_and_drop_function(
             }
         };
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+}
+
+pub fn verify_if_there_are_valid_paths(files_local_path: &Vec<PathBuf>) -> bool {
+    if files_local_path.is_empty() {
+        false
+    } else {
+        files_local_path.first().map_or(false, |path| path.exists())
     }
 }
 

--- a/ui/src/layouts/storage.rs
+++ b/ui/src/layouts/storage.rs
@@ -809,32 +809,36 @@ async fn drag_and_drop_function(
         let file_drop_event = get_drag_event();
         match file_drop_event {
             FileDropEvent::Hovered(files_local_path) => {
-                let mut script = main_script.replace("$IS_DRAGGING", "true");
-                if files_local_path.len() > 1 {
-                    script.push_str(&FEEDBACK_TEXT_SCRIPT.replace(
-                        "$TEXT",
-                        &format!(
-                            "{} {}!",
-                            files_local_path.len(),
-                            get_local_text("files.files-to-upload")
-                        ),
-                    ));
-                } else {
-                    script.push_str(&FEEDBACK_TEXT_SCRIPT.replace(
-                        "$TEXT",
-                        &format!(
-                            "{} {}!",
-                            files_local_path.len(),
-                            get_local_text("files.one-file-to-upload")
-                        ),
-                    ));
+                if !files_local_path.is_empty() {
+                    let mut script = main_script.replace("$IS_DRAGGING", "true");
+                    if files_local_path.len() > 1 {
+                        script.push_str(&FEEDBACK_TEXT_SCRIPT.replace(
+                            "$TEXT",
+                            &format!(
+                                "{} {}!",
+                                files_local_path.len(),
+                                get_local_text("files.files-to-upload")
+                            ),
+                        ));
+                    } else {
+                        script.push_str(&FEEDBACK_TEXT_SCRIPT.replace(
+                            "$TEXT",
+                            &format!(
+                                "{} {}!",
+                                files_local_path.len(),
+                                get_local_text("files.one-file-to-upload")
+                            ),
+                        ));
+                    }
+                    window.eval(&script);
                 }
-                window.eval(&script);
             }
             FileDropEvent::Dropped(files_local_path) => {
-                let new_files_to_upload = decoded_pathbufs(files_local_path);
-                ch.send(ChanCmd::UploadFiles(new_files_to_upload));
-                break;
+                if !files_local_path.is_empty() {
+                    let new_files_to_upload = decoded_pathbufs(files_local_path);
+                    ch.send(ChanCmd::UploadFiles(new_files_to_upload));
+                    break;
+                }
             }
             _ => {
                 *drag_event.write_silent() = None;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
### 1. Fix feedback error when user drag in app but object is not a file
- 

### Which issue(s) this PR fixes 🔨

- Resolve #505 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

