### PR TITLE
fix(welcome): make settings welcome active again

### DIFF
--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -1036,6 +1036,10 @@ impl State {
     pub fn set_theme(&mut self, theme: Option<Theme>) {
         self.ui.theme = theme;
     }
+
+    pub fn show_settings_welcome(&mut self, active: bool) {
+        self.ui.active_welcome = active;
+    }
     /// Updates the display of the overlay
     fn toggle_overlay(&mut self, enabled: bool) {
         self.ui.enable_overlay = enabled;

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -1036,10 +1036,6 @@ impl State {
     pub fn set_theme(&mut self, theme: Option<Theme>) {
         self.ui.theme = theme;
     }
-
-    pub fn show_settings_welcome(&mut self, active: bool) {
-        self.ui.active_welcome = active;
-    }
     /// Updates the display of the overlay
     fn toggle_overlay(&mut self, enabled: bool) {
         self.ui.enable_overlay = enabled;

--- a/common/src/state/ui.rs
+++ b/common/src/state/ui.rs
@@ -52,6 +52,7 @@ pub struct UI {
     pub toast_notifications: HashMap<Uuid, ToastNotification>,
     pub theme: Option<Theme>,
     pub enable_overlay: bool,
+    pub active_welcome: bool,
     pub sidebar_hidden: bool,
     pub metadata: WindowMeta,
     #[serde(skip)]
@@ -158,6 +159,9 @@ impl UI {
         if let Some(id) = self.take_debug_logger_id() {
             desktop_context.close_window(id);
         };
+    }
+    pub fn settings_welcome(&mut self) {
+        self.active_welcome = true;
     }
     pub fn add_file_preview(&mut self, key: Uuid, window_id: WindowId) {
         self.file_previews.insert(key, window_id);

--- a/ui/src/components/settings/sub_pages/profile/mod.rs
+++ b/ui/src/components/settings/sub_pages/profile/mod.rs
@@ -155,13 +155,14 @@ pub fn ProfileSettings(cx: Scope) -> Element {
 
     let mut did_short = "#".to_string();
     did_short.push_str(&state.read().get_own_identity().short_id());
+    let show_welcome = &state.read().ui.active_welcome;
 
     let change_banner_text = get_local_text("settings-profile.change-banner");
     cx.render(rsx!(
         div {
             id: "settings-profile",
             aria_label: "settings-profile",
-            (state.read().ui.show_settings_welcome).then(|| rsx!(
+            (!show_welcome).then(|| rsx!(
                 div {
                     class: "new-profile-welcome",
                     div {
@@ -176,7 +177,7 @@ pub fn ProfileSettings(cx: Scope) -> Element {
                             text: get_local_text("uplink.dismiss"),
                             icon: Icon::XMark,
                             onpress: move |_| {
-                                state.write().ui.show_settings_welcome = false;
+                                state.write().ui.settings_welcome();
                                 let _ = state.write().save();
                             }
                         },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- welcome img in settings was relying on a default bool that wasn't working. Added some simple logic to make welcome dismissible 

### Which issue(s) this PR fixes 🔨

- Resolve #471 


