### PR TITLE
chore(appium): update concurrency in appium workflow

### DIFF
--- a/.github/workflows/ui-test-execution.yml
+++ b/.github/workflows/ui-test-execution.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ui-test-windows.yml
+++ b/.github/workflows/ui-test-windows.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
### What this PR does 📖

- Update to UI tests workflow files to set concurrency level at workflow and github ref (branch), in order to avoid multiple executions of the tests workflow for the same branch. 
- Whenever a new commit is sent and UI tests workflow is not completed, a new execution of the same workflow is triggered and there is no need to keep running the validations on prior commits. With this concurrency setup, the workflow execution for the same branch will only run for the latest commit. Reference: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
- Tested already in appium repository

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

