### PR TITLE
chore(Sidebar): fix double scrollbar bug

### DIFF
--- a/kit/src/layout/sidebar/style.scss
+++ b/kit/src/layout/sidebar/style.scss
@@ -31,6 +31,7 @@
     // -ms-overflow-style: none;  /* IE and Edge */
     // scrollbar-width: none;  /* Firefox */
     overflow-y: scroll;
+    overflow-x: hidden;
   }
 
   &.hidden {

--- a/ui/src/components/chat/sidebar.rs
+++ b/ui/src/components/chat/sidebar.rs
@@ -279,7 +279,7 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
                             icon: Icon::ChatPlus,
                             tooltip: cx.render(rsx!(
                                 Tooltip {
-                                    arrow_position: ArrowPosition::Bottom,
+                                    arrow_position: ArrowPosition::Right,
                                     text: String::from("Create Group Chat")
                                 }
                             )),

--- a/ui/src/components/chat/style.scss
+++ b/ui/src/components/chat/style.scss
@@ -8,8 +8,6 @@
   display: inline-flex;
   flex-direction: column;
   gap: var(--gap);
-  overflow-y: scroll;
-  overflow-x: hidden;
   label {
     align-self: center;
   }


### PR DESCRIPTION


### What this PR does 📖
previously the sidebar children were nested in scrolled elements, making for two scrollbar tracks side by side, this removes the un-needed one on chats.