### PR TITLE
fix(compose): fix compose view

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ dioxus-desktop = { git = "https://github.com/DioxusLabs/dioxus", rev = "d521da19
 ] }
 raw-window-handle = "0.5"
 dioxus-core = { git = "https://github.com/DioxusLabs/dioxus", rev = "d521da1991719760e271457dfe4f9ddf281afbb3" }
-fermi = { git = "https://github.com/DioxusLabs/dioxus", rev = "22e71a71bdcdc03c3ae83ae1c3b3fb5417ebaa80" }
+fermi = { git = "https://github.com/DioxusLabs/dioxus", rev = "d521da1991719760e271457dfe4f9ddf281afbb3" }
 tokio-util = { version = "0.7", features = ["full"] }
 arboard = "3.2"
 humansize = "2.1.3"

--- a/common/src/state/action.rs
+++ b/common/src/state/action.rs
@@ -147,12 +147,6 @@ pub enum Action<'a> {
     /// chat id, message id
     #[display(fmt = "StartReplying")]
     StartReplying(&'a Uuid, &'a ui_adapter::Message),
-    /// Sets a draft message for the chatbar for a given chat.
-    #[display(fmt = "SetChatDraft")]
-    SetChatDraft(Uuid, String),
-    /// Clears a drafted message from a given chat.
-    #[display(fmt = "ClearChatDraft")]
-    ClearChatDraft(Uuid),
     /// Clears the reply for a given chat
     #[display(fmt = "CancelReply")]
     CancelReply(Uuid),

--- a/common/src/state/chats.rs
+++ b/common/src/state/chats.rs
@@ -53,8 +53,6 @@ pub struct Chat {
     // (user id, last update time)
     #[serde(skip)]
     pub typing_indicator: HashMap<DID, Instant>,
-    #[serde(skip)]
-    pub draft: Option<String>,
     // for loading messages into the UI - indicates if more messages can be fetched from warp and added to Chat.messages
     #[serde(skip)]
     pub has_more_messages: bool,

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -108,11 +108,6 @@ impl State {
     }
 
     pub fn mutate(&mut self, action: Action) {
-        // ignore noisy events
-        if !matches!(action, Action::SetChatDraft(_, _)) {
-            log::debug!("state::mutate: {}", action);
-        }
-
         match action {
             Action::SetExtensionEnabled(extension, enabled) => {
                 if enabled {
@@ -206,8 +201,6 @@ impl State {
                     self.clear_unreads(id);
                 }
             }
-            Action::SetChatDraft(chat_id, value) => self.set_chat_draft(&chat_id, value),
-            Action::ClearChatDraft(chat_id) => self.clear_chat_draft(&chat_id),
             Action::AddReaction(_, _, _) => todo!(),
             Action::RemoveReaction(_, _, _) => todo!(),
             Action::MockSend(id, msg) => {
@@ -696,13 +689,6 @@ impl State {
         needs_update
     }
 
-    /// Clears the given chats draft message
-    fn clear_chat_draft(&mut self, chat_id: &Uuid) {
-        if let Some(mut c) = self.chats.all.get_mut(chat_id) {
-            c.draft = None;
-        }
-    }
-
     /// Clear unreads  within a given chat on `State` struct.
     ///
     /// # Arguments
@@ -834,12 +820,6 @@ impl State {
         self.chats.in_sidebar.push_front(chat_id);
     }
 
-    /// Sets the draft on a given chat to some contents.
-    fn set_chat_draft(&mut self, chat_id: &Uuid, value: String) {
-        if let Some(mut c) = self.chats.all.get_mut(chat_id) {
-            c.draft = Some(value);
-        }
-    }
     /// Begins replying to a message in the specified chat in the `State` struct.
     fn start_replying(&mut self, chat: &Uuid, message: &ui_adapter::Message) {
         if let Some(mut c) = self.chats.all.get_mut(chat) {

--- a/common/src/testing/mock.rs
+++ b/common/src/testing/mock.rs
@@ -127,7 +127,6 @@ fn generate_fake_chat(participants: Vec<Identity>, conversation: Uuid) -> Chat {
         unreads: rng.gen_range(0..2),
         replying_to: None,
         typing_indicator: HashMap::new(),
-        draft: None,
         has_more_messages: false,
     }
 }

--- a/common/src/warp_runner/ui_adapter/mod.rs
+++ b/common/src/warp_runner/ui_adapter/mod.rs
@@ -177,7 +177,6 @@ pub async fn conversation_to_chat(
             unreads: unreads as u32,
             replying_to: None,
             typing_indicator: HashMap::new(),
-            draft: None,
             has_more_messages,
         },
         identities,

--- a/native_extensions/emoji_selector/Cargo.toml
+++ b/native_extensions/emoji_selector/Cargo.toml
@@ -17,3 +17,4 @@ common = { path = "../../common" }
 kit = { path = "../../kit" }
 emojis = "0.5.2"
 once_cell = "1.17.1"
+uuid.workspace = true

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -8,6 +8,7 @@ use std::{
 
 use dioxus::prelude::*;
 
+use fermi::use_atom_state;
 use futures::{channel::oneshot, StreamExt};
 
 use kit::{
@@ -67,6 +68,7 @@ use crate::{
     utils::{
         build_participants, build_user_from_identity, format_timestamp::format_timestamp_timeago,
     },
+    CHAT_DRAFT,
 };
 
 pub const SELECT_CHAT_BAR: &str = r#"
@@ -929,7 +931,8 @@ fn get_chatbar<'a>(cx: &'a Scoped<'a, ComposeProps>) -> Element<'a> {
     let is_loading = data.is_none();
     let input = use_ref(cx, Vec::<String>::new);
     let active_chat_id = data.as_ref().map(|d| d.active_chat.id);
-    let chat_drafts = use_state(cx, || HashMap::<Uuid, String>::new());
+
+    let mut chat_drafts = use_atom_state(cx, CHAT_DRAFT);
 
     let files_to_upload: &UseState<Vec<PathBuf>> = cx.props.upload_files.as_ref().unwrap();
 

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -929,6 +929,7 @@ fn get_chatbar<'a>(cx: &'a Scoped<'a, ComposeProps>) -> Element<'a> {
     let is_loading = data.is_none();
     let input = use_ref(cx, Vec::<String>::new);
     let active_chat_id = data.as_ref().map(|d| d.active_chat.id);
+    let chat_drafts = use_state(cx, || HashMap::<Uuid, String>::new());
 
     let files_to_upload: &UseState<Vec<PathBuf>> = cx.props.upload_files.as_ref().unwrap();
 
@@ -1137,8 +1138,6 @@ fn get_chatbar<'a>(cx: &'a Scoped<'a, ComposeProps>) -> Element<'a> {
         .collect::<Vec<_>>();
 
     let disabled = !state.read().can_use_active_chat();
-
-    let chat_drafts = use_state(cx, || HashMap::<Uuid, String>::new());
 
     let chatbar = cx.render(rsx!(Chatbar {
         key: "{id}",

--- a/ui/src/components/chat/sidebar.rs
+++ b/ui/src/components/chat/sidebar.rs
@@ -142,7 +142,7 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
         (vec![], vec![], None)
     };
 
-    let show_create_group = use_state(&cx, || false);
+    let show_create_group = use_state(cx, || false);
 
     cx.render(rsx!(
         ReusableSidebar {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -12,6 +12,7 @@ use dioxus_desktop::tao::menu::AboutMetadata;
 use dioxus_desktop::Config;
 use dioxus_desktop::{tao, use_window};
 use extensions::UplinkExtension;
+use fermi::Atom;
 use fs_extra::dir::*;
 use futures::channel::oneshot;
 use futures::StreamExt;
@@ -75,6 +76,8 @@ pub static WINDOW_CMD_CH: Lazy<WindowManagerCmdChannels> = Lazy::new(|| {
         rx: Arc::new(Mutex::new(rx)),
     }
 });
+
+pub(crate) static CHAT_DRAFT: Atom<HashMap<Uuid, String>> = |_| HashMap::new();
 
 pub struct UplinkRoutes<'a> {
     pub chat: &'a str,

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -12,7 +12,6 @@ use dioxus_desktop::tao::menu::AboutMetadata;
 use dioxus_desktop::Config;
 use dioxus_desktop::{tao, use_window};
 use extensions::UplinkExtension;
-use fermi::Atom;
 use fs_extra::dir::*;
 use futures::channel::oneshot;
 use futures::StreamExt;
@@ -77,7 +76,7 @@ pub static WINDOW_CMD_CH: Lazy<WindowManagerCmdChannels> = Lazy::new(|| {
     }
 });
 
-pub(crate) static CHAT_DRAFT: Atom<HashMap<Uuid, String>> = |_| HashMap::new();
+pub type ChatDraft = HashMap<Uuid, String>;
 
 pub struct UplinkRoutes<'a> {
     pub chat: &'a str,
@@ -425,6 +424,7 @@ pub fn app_bootstrap(cx: Scope, identity: multipass::identity::Identity) -> Elem
     );
 
     use_shared_state_provider(cx, || state);
+    use_shared_state_provider(cx, ChatDraft::new);
 
     cx.render(rsx!(crate::app {}))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- the "chat draft" thing in State caused lots of re-renders and we finally decided to do it better. 
- now typing in the chatbar only re-renders the chatbar instead of the entire app. 
- I tried Fermi but Fermi doesn't support `make_mut` yet and I didn't want to clone a `HashMap` every time a chat draft was updated. 
- I was able to make a second `UseSharedState` just for chat drafts. I tested it with the emoji extension too, and it worked. 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

