### PR TITLE
update(StateManagement): Update just chatbar when select emoji

### DIFF
--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -5,6 +5,7 @@ pub mod friends;
 pub mod identity;
 pub mod notifications;
 pub mod route;
+pub mod scope_ids;
 pub mod settings;
 pub mod storage;
 pub mod ui;
@@ -61,6 +62,7 @@ pub struct State {
     friends: friends::Friends,
     #[serde(skip)]
     pub storage: storage::Storage,
+    pub scope_ids: scope_ids::ScopeIds,
     pub settings: settings::Settings,
     pub ui: ui::UI,
     pub configuration: configuration::Configuration,
@@ -89,6 +91,7 @@ impl Clone for State {
             friends: self.friends.clone(),
             storage: self.storage.clone(),
             settings: Default::default(),
+            scope_ids: Default::default(),
             ui: Default::default(),
             configuration: self.configuration.clone(),
             identities: HashMap::new(),

--- a/common/src/state/scope_ids.rs
+++ b/common/src/state/scope_ids.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Default, Debug, Deserialize, Serialize)]
 pub struct ScopeIds {
     #[serde(skip)]
-    pub chatbar: usize,
+    pub chatbar: Option<usize>,
 }
 
 impl ScopeIds {

--- a/common/src/state/scope_ids.rs
+++ b/common/src/state/scope_ids.rs
@@ -1,0 +1,14 @@
+use dioxus::prelude::ScopeId;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Default, Debug, Deserialize, Serialize)]
+pub struct ScopeIds {
+    #[serde(skip)]
+    pub chatbar: usize,
+}
+
+impl ScopeIds {
+    pub fn scope_id_from_usize(scope_usize: usize) -> ScopeId {
+        ScopeId(scope_usize)
+    }
+}

--- a/native_extensions/emoji_selector/src/lib.rs
+++ b/native_extensions/emoji_selector/src/lib.rs
@@ -184,9 +184,12 @@ impl EmojiSelector {
                                                 };
                                                 let draft: String = c.draft.unwrap_or_default();
                                                 let new_draft = format!("{draft}{emoji}");
-                                                state.write_silent().mutate(Action::SetChatDraft(c.id, new_draft));
-                                                let chatbar_scope_id = state.read().scope_ids.chatbar;
-                                                cx.needs_update_any(ScopeIds::scope_id_from_usize(chatbar_scope_id));
+                                                if let Some(scope_id_usize) = state.read().scope_ids.chatbar {
+                                                    state.write_silent().mutate(Action::SetChatDraft(c.id, new_draft));
+                                                    cx.needs_update_any(ScopeIds::scope_id_from_usize(scope_id_usize));
+                                                } else {
+                                                    state.write().mutate(Action::SetChatDraft(c.id, new_draft));
+                                                }
                                                 // Hide the selector when clicking an emoji
                                                 hide.set(false)
                                             },

--- a/native_extensions/emoji_selector/src/lib.rs
+++ b/native_extensions/emoji_selector/src/lib.rs
@@ -1,6 +1,6 @@
 use common::{
     icons::outline::Shape as Icon,
-    state::{Action, State},
+    state::{scope_ids::ScopeIds, Action, State},
 };
 use dioxus::prelude::*;
 use dioxus_desktop::use_eval;
@@ -184,7 +184,9 @@ impl EmojiSelector {
                                                 };
                                                 let draft: String = c.draft.unwrap_or_default();
                                                 let new_draft = format!("{draft}{emoji}");
-                                                state.write().mutate(Action::SetChatDraft(c.id, new_draft));
+                                                state.write_silent().mutate(Action::SetChatDraft(c.id, new_draft));
+                                                let chatbar_scope_id = state.read().scope_ids.chatbar;
+                                                cx.needs_update_any(ScopeIds::scope_id_from_usize(chatbar_scope_id));
                                                 // Hide the selector when clicking an emoji
                                                 hide.set(false)
                                             },

--- a/native_extensions/emoji_selector/src/lib.rs
+++ b/native_extensions/emoji_selector/src/lib.rs
@@ -184,12 +184,10 @@ impl EmojiSelector {
                                                 };
                                                 let draft: String = c.draft.unwrap_or_default();
                                                 let new_draft = format!("{draft}{emoji}");
+                                                state.write_silent().mutate(Action::SetChatDraft(c.id, new_draft));
                                                 if let Some(scope_id_usize) = state.read().scope_ids.chatbar {
-                                                    state.write_silent().mutate(Action::SetChatDraft(c.id, new_draft));
                                                     cx.needs_update_any(ScopeIds::scope_id_from_usize(scope_id_usize));
-                                                } else {
-                                                    state.write().mutate(Action::SetChatDraft(c.id, new_draft));
-                                                }
+                                                };
                                                 // Hide the selector when clicking an emoji
                                                 hide.set(false)
                                             },

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -923,7 +923,7 @@ struct TypingInfo {
 fn get_chatbar<'a>(cx: &'a Scoped<'a, ComposeProps>) -> Element<'a> {
     log::trace!("get_chatbar");
     let state = use_shared_state::<State>(cx)?;
-    state.write_silent().scope_ids.chatbar = cx.scope_id().0;
+    state.write_silent().scope_ids.chatbar = Some(cx.scope_id().0);
     let data = &cx.props.data;
     let is_loading = data.is_none();
     let active_chat_id = data.as_ref().map(|d| d.active_chat.id);

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -923,12 +923,12 @@ struct TypingInfo {
 fn get_chatbar<'a>(cx: &'a Scoped<'a, ComposeProps>) -> Element<'a> {
     log::trace!("get_chatbar");
     let state = use_shared_state::<State>(cx)?;
+    state.write_silent().scope_ids.chatbar = cx.scope_id().0;
     let data = &cx.props.data;
     let is_loading = data.is_none();
     let active_chat_id = data.as_ref().map(|d| d.active_chat.id);
 
     let files_to_upload: &UseState<Vec<PathBuf>> = cx.props.upload_files.as_ref().unwrap();
-
     // used to render the typing indicator
     // for now it doesn't quite work for group messages
     let my_id = state.read().did_key();
@@ -1144,9 +1144,7 @@ fn get_chatbar<'a>(cx: &'a Scoped<'a, ComposeProps>) -> Element<'a> {
         onchange: move |v: String| {
             if let Some(id) = &active_chat_id {
                 match inner_state.try_borrow_mut() {
-                    Ok(state) => state
-                        .write()
-                        .mutate(Action::SetChatDraft(*id, v)),
+                    Ok(state) => state.write().mutate(Action::SetChatDraft(*id, v)),
                     Err(e) => log::error!("{e}"),
                 };
                 local_typing_ch.send(TypingIndicator::Typing(*id));


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
### 1. Update just chatbar instead of entire compose when select an emoji 


https://user-images.githubusercontent.com/63157656/229807756-cb00d428-e154-4038-85fb-ef5494d7bd9c.mov

### 2. Old code as reference 

https://user-images.githubusercontent.com/63157656/229807831-fd848939-a328-401c-84c5-74002eaad9d7.mov




- 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

