### PR TITLE
update(CallButtons): Block call  and video call buttons in app

### DIFF
--- a/common/locales/en-US/main.ftl
+++ b/common/locales/en-US/main.ftl
@@ -2,6 +2,7 @@ uplink = Uplink
     .home = Home
     .add = Add
     .call = Call
+    .coming-soon = Coming soon
     .crash-report = Uplink crashed. Optionally save crash report to selected folder
     .video-call = Video Call
     .chat = Chat

--- a/kit/src/elements/button/mod.rs
+++ b/kit/src/elements/button/mod.rs
@@ -26,6 +26,8 @@ pub struct Props<'a> {
     #[props(optional)]
     disabled: Option<bool>,
     #[props(optional)]
+    disabled_with_tooltip: Option<bool>,
+    #[props(optional)]
     appearance: Option<Appearance>,
     #[props(optional)]
     with_badge: Option<String>,
@@ -70,6 +72,7 @@ pub fn Button<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let aria_label = cx.props.aria_label.clone().unwrap_or_default();
     let badge = cx.props.with_badge.clone().unwrap_or_default();
     let disabled = cx.props.disabled.unwrap_or_default();
+    let disabled_with_tooltip = cx.props.disabled_with_tooltip.unwrap_or_default();
     let appearance = get_appearance(&cx);
     let small = cx.props.small.unwrap_or_default();
     let text2 = text.clone();
@@ -88,7 +91,7 @@ pub fn Button<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
         rsx!(
             div {
                 class: {
-                    format_args!("btn-wrap {} {}", if disabled { "disabled" } else { "" }, if small { "small" } else { "" })
+                    format_args!("btn-wrap {} {}", if disabled && !disabled_with_tooltip { "disabled" } else { "" }, if small { "small" } else { "" })
                 },
                 cx.props.tooltip.as_ref().map(|tooltip| rsx!(
                     tooltip
@@ -104,7 +107,7 @@ pub fn Button<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     id: "{UUID}",
                     aria_label: "{aria_label}",
                     title: "{text}",
-                    // disabled: "{disabled}",
+                    disabled: if disabled && !disabled_with_tooltip { "true" } else { "false" },
                     class: {
                         format_args!(
                             "btn appearance-{} btn-{} {} {}", 

--- a/kit/src/elements/button/mod.rs
+++ b/kit/src/elements/button/mod.rs
@@ -104,7 +104,7 @@ pub fn Button<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     id: "{UUID}",
                     aria_label: "{aria_label}",
                     title: "{text}",
-                    disabled: "{disabled}",
+                    // disabled: "{disabled}",
                     class: {
                         format_args!(
                             "btn appearance-{} btn-{} {} {}", 

--- a/kit/src/elements/button/mod.rs
+++ b/kit/src/elements/button/mod.rs
@@ -26,8 +26,6 @@ pub struct Props<'a> {
     #[props(optional)]
     disabled: Option<bool>,
     #[props(optional)]
-    disabled_with_tooltip: Option<bool>,
-    #[props(optional)]
     appearance: Option<Appearance>,
     #[props(optional)]
     with_badge: Option<String>,
@@ -72,7 +70,6 @@ pub fn Button<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let aria_label = cx.props.aria_label.clone().unwrap_or_default();
     let badge = cx.props.with_badge.clone().unwrap_or_default();
     let disabled = cx.props.disabled.unwrap_or_default();
-    let disabled_with_tooltip = cx.props.disabled_with_tooltip.unwrap_or_default();
     let appearance = get_appearance(&cx);
     let small = cx.props.small.unwrap_or_default();
     let text2 = text.clone();
@@ -91,7 +88,7 @@ pub fn Button<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
         rsx!(
             div {
                 class: {
-                    format_args!("btn-wrap {} {}", if disabled && !disabled_with_tooltip { "disabled" } else { "" }, if small { "small" } else { "" })
+                    format_args!("btn-wrap {} {}", if disabled && cx.props.tooltip.is_none() { "disabled" } else { "" }, if small { "small" } else { "" })
                 },
                 cx.props.tooltip.as_ref().map(|tooltip| rsx!(
                     tooltip
@@ -107,7 +104,7 @@ pub fn Button<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     id: "{UUID}",
                     aria_label: "{aria_label}",
                     title: "{text}",
-                    disabled: if disabled && !disabled_with_tooltip { "true" } else { "false" },
+                    disabled: if disabled && cx.props.tooltip.is_none() { "true" } else { "false" },
                     class: {
                         format_args!(
                             "btn appearance-{} btn-{} {} {}", 

--- a/kit/src/elements/button/style.scss
+++ b/kit/src/elements/button/style.scss
@@ -71,10 +71,10 @@
   &.appearance-disabled {
     cursor: default;
     opacity: 0.5;
-    background-color: var(--secondary-dark);
-    &:hover {
-      background-color: var(--secondary-dark);
-    }
+    // background-color: var(--secondary-dark);
+    // &:hover {
+    //   background-color: var(--secondary-dark);
+    // }
   }
 }
 .btn-wrap {

--- a/kit/src/elements/button/style.scss
+++ b/kit/src/elements/button/style.scss
@@ -71,10 +71,10 @@
   &.appearance-disabled {
     cursor: default;
     opacity: 0.5;
-    // background-color: var(--secondary-dark);
-    // &:hover {
-    //   background-color: var(--secondary-dark);
-    // }
+    background-color: var(--secondary-dark);
+    &:hover {
+      background-color: var(--secondary-dark);
+    }
   }
 }
 .btn-wrap {

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -295,7 +295,8 @@ fn get_controls(cx: Scope<ComposeProps>) -> Element {
         },
         Button {
             icon: Icon::PhoneArrowUpRight,
-            disabled: data.is_none() || STATIC_ARGS.is_debug,
+            disabled: true,
+            disabled_with_tooltip: true,
             aria_label: "Call".into(),
             appearance: Appearance::Secondary,
             tooltip: cx.render(rsx!(Tooltip {
@@ -314,7 +315,8 @@ fn get_controls(cx: Scope<ComposeProps>) -> Element {
         },
         Button {
             icon: Icon::VideoCamera,
-            disabled: data.is_none() || STATIC_ARGS.is_debug,
+            disabled: true,
+            disabled_with_tooltip: true,
             aria_label: "Videocall".into(),
             appearance: Appearance::Secondary,
             tooltip: cx.render(rsx!(Tooltip {

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -295,12 +295,12 @@ fn get_controls(cx: Scope<ComposeProps>) -> Element {
         },
         Button {
             icon: Icon::PhoneArrowUpRight,
-            disabled: data.is_none() || !STATIC_ARGS.is_debug,
+            disabled: data.is_none() || STATIC_ARGS.is_debug,
             aria_label: "Call".into(),
             appearance: Appearance::Secondary,
             tooltip: cx.render(rsx!(Tooltip {
                 arrow_position: ArrowPosition::Top,
-                text: get_local_text("uplink.call")
+                text: get_local_text("uplink.coming-soon")
             })),
             onpress: move |_| {
                 if let Some(chat) = active_chat.as_ref() {
@@ -314,12 +314,12 @@ fn get_controls(cx: Scope<ComposeProps>) -> Element {
         },
         Button {
             icon: Icon::VideoCamera,
-            disabled: data.is_none() || !STATIC_ARGS.is_debug,
+            disabled: data.is_none() || STATIC_ARGS.is_debug,
             aria_label: "Videocall".into(),
             appearance: Appearance::Secondary,
             tooltip: cx.render(rsx!(Tooltip {
                 arrow_position: ArrowPosition::TopRight,
-                text: get_local_text("uplink.video-call"),
+                text: get_local_text("uplink.coming-soon"),
             })),
         },
     ))

--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -295,7 +295,6 @@ fn get_controls(cx: Scope<ComposeProps>) -> Element {
         Button {
             icon: Icon::PhoneArrowUpRight,
             disabled: true,
-            disabled_with_tooltip: true,
             aria_label: "Call".into(),
             appearance: Appearance::Secondary,
             tooltip: cx.render(rsx!(Tooltip {
@@ -315,7 +314,6 @@ fn get_controls(cx: Scope<ComposeProps>) -> Element {
         Button {
             icon: Icon::VideoCamera,
             disabled: true,
-            disabled_with_tooltip: true,
             aria_label: "Videocall".into(),
             appearance: Appearance::Secondary,
             tooltip: cx.render(rsx!(Tooltip {

--- a/ui/src/components/chat/sidebar.rs
+++ b/ui/src/components/chat/sidebar.rs
@@ -360,13 +360,6 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
                                         state.write().mutate(Action::ClearUnreads(clear_unreads.id));
                                     }
                                 },
-                                hr{ },
-                                ContextItem {
-                                    icon: Icon::PhoneArrowUpRight,
-                                    text: get_local_text("uplink.call"),
-                                    //TODO: Wire to state
-
-                                },
                                 hr{ }
                                 ContextItem {
                                     icon: Icon::EyeSlash,

--- a/ui/src/components/friends/friends_list/mod.rs
+++ b/ui/src/components/friends/friends_list/mod.rs
@@ -193,11 +193,6 @@ pub fn Friends(cx: Scope) -> Element {
                                                 ch.send(ChanCmd::CreateConversation{recipient: context_friend.did_key(), chat: chat2.clone()});
                                             }
                                         },
-                                        ContextItem {
-                                            icon: Icon::PhoneArrowUpRight,
-                                            text: get_local_text("uplink.call"),
-                                            // TODO: Wire this up to state
-                                        },
                                         if let Some(f) = favorite {
                                             rsx!(ContextItem {
                                                 icon: if f {Icon::HeartSlash} else {Icon::Heart},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
### 1. Disable Call and Video Call buttons in app, add tooltip as coming soon 

https://user-images.githubusercontent.com/63157656/229880362-23f31523-ee24-4036-85e1-8dacd9fc88eb.mov


### 2. Remove call option in context item when we click with right button of the mouse in chat 


https://user-images.githubusercontent.com/63157656/229880746-9e7230d0-63ea-4749-b8c8-90f36d5a0827.mov




- 

### Which issue(s) this PR fixes 🔨

- Resolve #579
- Resolve #555 
- Resolve #519  
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

