### PR TITLE
chore(appium): add job to run tests for chats in parallel

### DIFF
--- a/.github/workflows/ui-test-execution.yml
+++ b/.github/workflows/ui-test-execution.yml
@@ -90,13 +90,26 @@ jobs:
       - name: Setup Node.js 🔨
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
+          cache: "npm"
+
+      - name: Cache NPM dependencies 🔨
+        uses: actions/cache@v3
+        id: cache-macos
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+
+      - name: Install NPM dependencies 📦
+        if: steps.cache-macos.outputs.cache-hit != 'true'
+        working-directory: ./appium-tests
+        run: npm ci
 
       - name: Enable opening app not codesigned 🖥️
         run: sudo spctl --master-disable
 
       - name: Download the app 🗳️
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: app-macos
           path: ./appium-tests/apps
@@ -104,15 +117,10 @@ jobs:
       - name: Copy DMG to Appium Apps Directory 💿
         working-directory: ./appium-tests/apps
         run: |
-          ls -la
           unzip Uplink-Mac-Universal.zip
           perl -i -pe 's/>ui</>uplink</g' ./Uplink.app/Contents/Info.plist
           cp -r ./Uplink.app /Applications/
           sudo xattr -r -d com.apple.quarantine /Applications/Uplink.app
-
-      - name: Install NPM dependencies 📦
-        run: |
-          cd appium-tests && npm install
 
       - name: Install and Run Appium Server 💻
         run: |
@@ -154,3 +162,92 @@ jobs:
         if: failure()
         with:
           file-name: "desktop.jpg"
+
+  test-chats:
+    if: ${{ always() }}
+    needs: test
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        user: ["ChatUserA", "ChatUserB"]
+        include:
+          - user: "ChatUserA"
+            npm-command: "npm run mac.chatA"
+          - user: "ChatUserB"
+            npm-command: "npm run mac.chatB"
+
+    steps:
+      - name: Checkout working directory 🔖
+        uses: actions/checkout@v3
+
+      - name: Checkout testing directory 🔖
+        uses: actions/checkout@v3
+        with:
+          repository: Satellite-im/testing-uplink
+          path: "./appium-tests"
+
+      - name: Setup Node.js 🔨
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: "npm"
+
+      - name: Cache NPM dependencies 🔨
+        uses: actions/cache@v3
+        id: cache-appium
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+
+      - name: Install NPM dependencies 📦
+        if: steps.cache-appium.outputs.cache-hit != 'true'
+        working-directory: appium-tests
+        run: npm ci
+
+      - name: Enable opening app not codesigned 🖥️
+        run: sudo spctl --master-disable
+
+      - name: Download the app 🗳️
+        uses: actions/download-artifact@v3
+        with:
+          name: app-macos
+          path: ./appium-tests/apps
+
+      - name: Copy DMG to Appium Apps Directory 💿
+        working-directory: ./appium-tests/apps
+        run: |
+          unzip Uplink-Mac-Universal.zip
+          perl -i -pe 's/>ui</>uplink</g' ./Uplink.app/Contents/Info.plist
+          cp -r ./Uplink.app /Applications/
+          sudo xattr -r -d com.apple.quarantine /Applications/Uplink.app
+
+      - name: Install and Run Appium Server 💻
+        run: |
+          npm install -g appium@next
+          appium -v
+          appium driver install mac2
+          appium driver list
+
+      - name: Delete Cache Folder if exists
+        run: |
+          rm -rf ~/.uplink
+          cp -r ./appium-tests/tests/fixtures/users/${{ matrix.user }}/. ~/.uplink
+
+      - name: Run WebdriverIO tests on MacOS 🧪
+        working-directory: ./appium-tests
+        run: ${{ matrix.npm-command }}
+
+      - name: Upload Screenshots for ${{ matrix.user }} 📷
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: appium-screenshots-${{ matrix.user }}
+          path: ./appium-tests/test-results
+
+      - name: Upload Appium Log for ${{ matrix.user }} 📷
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: appium-log-${{ matrix.user }}
+          path: ./appium-tests/appium.log

--- a/.github/workflows/ui-test-execution.yml
+++ b/.github/workflows/ui-test-execution.yml
@@ -89,20 +89,10 @@ jobs:
 
       - name: Setup Node.js 🔨
         uses: actions/setup-node@v3
-        working-directory: ./appium-tests
         with:
           node-version: 18
-          cache: "npm"
-
-      - name: Cache NPM dependencies 🔨
-        uses: actions/cache@v3
-        id: cache-macos
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
 
       - name: Install NPM dependencies 📦
-        if: steps.cache-macos.outputs.cache-hit != 'true'
         working-directory: ./appium-tests
         run: npm ci
 
@@ -190,21 +180,11 @@ jobs:
 
       - name: Setup Node.js 🔨
         uses: actions/setup-node@v3
-        working-directory: ./appium-tests
         with:
           node-version: 18
-          cache: "npm"
-
-      - name: Cache NPM dependencies 🔨
-        uses: actions/cache@v3
-        id: cache-appium
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
 
       - name: Install NPM dependencies 📦
-        if: steps.cache-appium.outputs.cache-hit != 'true'
-        working-directory: appium-tests
+        working-directory: ./appium-tests
         run: npm ci
 
       - name: Enable opening app not codesigned 🖥️

--- a/.github/workflows/ui-test-execution.yml
+++ b/.github/workflows/ui-test-execution.yml
@@ -89,6 +89,7 @@ jobs:
 
       - name: Setup Node.js 🔨
         uses: actions/setup-node@v3
+        working-directory: ./appium-tests
         with:
           node-version: 18
           cache: "npm"
@@ -189,6 +190,7 @@ jobs:
 
       - name: Setup Node.js 🔨
         uses: actions/setup-node@v3
+        working-directory: ./appium-tests
         with:
           node-version: 18
           cache: "npm"

--- a/.github/workflows/ui-test-windows.yml
+++ b/.github/workflows/ui-test-windows.yml
@@ -76,20 +76,10 @@ jobs:
 
       - name: Setup Node.js 🔨
         uses: actions/setup-node@v3
-        working-directory: ./appium-tests
         with:
           node-version: 18
-          cache: "npm"
-
-      - name: Cache NPM dependencies 🔨
-        uses: actions/cache@v3
-        id: cache-windows
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
 
       - name: Install NPM dependencies 📦
-        if: steps.cache-windows.outputs.cache-hit != 'true'
         working-directory: ./appium-tests
         run: npm ci
 

--- a/.github/workflows/ui-test-windows.yml
+++ b/.github/workflows/ui-test-windows.yml
@@ -76,6 +76,7 @@ jobs:
 
       - name: Setup Node.js 🔨
         uses: actions/setup-node@v3
+        working-directory: ./appium-tests
         with:
           node-version: 18
           cache: "npm"

--- a/.github/workflows/ui-test-windows.yml
+++ b/.github/workflows/ui-test-windows.yml
@@ -77,17 +77,20 @@ jobs:
       - name: Setup Node.js 🔨
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
+          cache: "npm"
 
-      - name: Download the app 🗳️
-        uses: actions/download-artifact@v3
+      - name: Cache NPM dependencies 🔨
+        uses: actions/cache@v3
+        id: cache-windows
         with:
-          name: Uplink-Windows
-          path: ./appium-tests/apps
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
 
       - name: Install NPM dependencies 📦
-        run: |
-          cd appium-tests && npm install
+        if: steps.cache-windows.outputs.cache-hit != 'true'
+        working-directory: ./appium-tests
+        run: npm ci
 
       - name: Install and Run Appium Server 💻
         run: |
@@ -95,6 +98,12 @@ jobs:
           appium -v
           appium driver install --source=npm appium-windows-driver
           appium driver list
+
+      - name: Download the app 🗳️
+        uses: actions/download-artifact@v3
+        with:
+          name: Uplink-Windows
+          path: ./appium-tests/apps
 
       - name: Delete cache folder before starting
         run: If (Test-Path $home/.uplink) {Remove-Item -Recurse -Force $home/.uplink} Else { Break }


### PR DESCRIPTION
### What this PR does 📖

- Adding a job to run UI tests for chats between two users executing in parallel.
- Improvements to current appium tests workflows for windows and macos (using npm cache, installing dependencies with npm ci), in order to reduce the time required to run the appium tests

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

