### PR TITLE
update(Select): Never more crash with duplicate values on select

### DIFF
--- a/kit/src/elements/select/mod.rs
+++ b/kit/src/elements/select/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use dioxus::prelude::*;
 
 #[derive(Props)]
@@ -18,10 +20,17 @@ pub fn emit(cx: &Scope<Props>, s: String) {
     }
 }
 
+fn remove_duplicates(values: Vec<String>) -> Vec<String> {
+    let unique_values: HashSet<_> = values.iter().cloned().collect();
+    let mut unique_values_vec: Vec<String> = Vec::new();
+    unique_values_vec.extend(unique_values);
+    unique_values_vec
+}
+
 #[allow(non_snake_case)]
 pub fn Select<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let initial_value = cx.props.initial_value.clone();
-    let mut options = cx.props.options.clone();
+    let mut options = remove_duplicates(cx.props.options.clone());
     options.retain(|value| value != &initial_value);
     options.insert(0, initial_value.clone());
     let iter = IntoIterator::into_iter(options.clone());


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
### 1. Never more crash with duplicate values on select 
a. Remove duplicate values inside component, to avoid any kind of crash because of it 
![image](https://user-images.githubusercontent.com/63157656/230199823-07bf08b3-8bb9-46f9-9b1a-6025ccd37fa7.png)

- 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

