### PR TITLE
chore(sidebar): remove the minimal view from the sidebar collapse

### DIFF
--- a/kit/src/layout/sidebar/mod.rs
+++ b/kit/src/layout/sidebar/mod.rs
@@ -1,10 +1,8 @@
+use crate::elements::button::Button;
+use crate::elements::Appearance;
 use common::state::{Action, State};
 use dioxus::prelude::*;
 use dioxus_desktop::use_eval;
-use warp::multipass::identity::Platform;
-
-use crate::elements::button::Button;
-use crate::elements::Appearance;
 
 use common::icons::outline::Shape as Icon;
 
@@ -26,10 +24,8 @@ const SCRIPT: &str = include_str!("./script.js");
 pub fn Sidebar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let state = use_shared_state::<State>(cx)?;
     let hidden = cx.props.hidden.unwrap_or(false);
-    let minimal = use_state(cx, || false);
     // Run the script after the component is mounted
     let eval = use_eval(cx);
-    let mobile = state.read().get_own_identity().platform() == Platform::Mobile;
     use_effect(cx, (), |_| {
         to_owned![eval];
         async move {
@@ -42,49 +38,33 @@ pub fn Sidebar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
         icon: Icon::Bars3,
         appearance: Appearance::Transparent,
         onpress: move |_| {
-            if !mobile {
-                minimal.set(!minimal.get())
-            } else {
-                state.write().mutate(Action::SidebarHidden(true));
-            }
+            state.write().mutate(Action::SidebarHidden(true));
         }
     }));
 
     cx.render(rsx!(
         div {
             class: {
-                format_args!("sidebar resize-horiz-right {} {}", if hidden { "hidden" } else { "" }, if *minimal.get() { "minimal" } else { "" })
+                format_args!("sidebar resize-horiz-right {}", if hidden { "hidden" } else { "" })
             },
             aria_label: "sidebar",
-            match minimal.get() {
-                false => {
-                    rsx!(
-                        div {
-                            class: "search",
-                            aria_label: "sidebar-search",
-                            cx.props.with_search.as_ref(),
-                            div {
-                                class: "hamburger",
-                                hamburger
-                            }
-                        },
-                        div {
-                            class: "children",
-                            aria_label: "sidebar-children",
-                            cx.props.children.as_ref()
-                        },
-                        cx.props.with_nav.as_ref(),
-                    )
+            rsx!(
+                div {
+                    class: "search",
+                    aria_label: "sidebar-search",
+                    cx.props.with_search.as_ref(),
+                    div {
+                        class: "hamburger",
+                        hamburger
+                    }
                 },
-                true => {
-                    rsx!(
-                        div {
-                            class: "hamburger minimal",
-                            hamburger
-                        }
-                    )
-                }
-            }
+                div {
+                    class: "children",
+                    aria_label: "sidebar-children",
+                    cx.props.children.as_ref()
+                },
+                cx.props.with_nav.as_ref(),
+            )
         },
     ))
 }

--- a/kit/src/layout/topbar/mod.rs
+++ b/kit/src/layout/topbar/mod.rs
@@ -38,8 +38,8 @@ pub fn Topbar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             aria_label: "Topbar",
             (show_back_button(&cx)).then(|| rsx!(
                 Button {
-                    aria_label: "hamburger-button".into(),
-                    icon: icons::outline::Shape::Bars3,
+                    aria_label: "back-button".into(),
+                    icon: icons::outline::Shape::ChevronLeft,
                     onpress: move |_| emit(&cx),
                     appearance: Appearance::Secondary
                 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
Before, the hamburger that was added would collapse to a neat minimal view, per request that was removed so it collapses the sidebar entirely.


https://user-images.githubusercontent.com/2993032/230508452-0e0acf94-efd9-4a6c-8c03-30df4ff63ed5.mov



- 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

