### PR TITLE
fix(friend): Improved some friend request things

### DIFF
--- a/common/locales/en-US/main.ftl
+++ b/common/locales/en-US/main.ftl
@@ -74,6 +74,7 @@ friends = Friends
     .new_request = New friend request.
     .copied-did = Copied ID to clipboard!
     .unblock = Unblock
+    .request-exist = Friend request is already pending!
 
 files = Files
     .files = Files

--- a/common/src/warp_runner/manager/commands/multipass_commands.rs
+++ b/common/src/warp_runner/manager/commands/multipass_commands.rs
@@ -17,7 +17,7 @@ use warp::{
 };
 
 use crate::{
-    state::{self, friends, Identity},
+    state::{self, friends},
     warp_runner::{ui_adapter::dids_to_identity, Account},
 };
 
@@ -37,7 +37,6 @@ pub enum MultiPassCmd {
     #[display(fmt = "RequestFriend {{ request: {id} }} ")]
     RequestFriend {
         id: String,
-        outgoing_requests: Vec<Identity>,
         rsp: oneshot::Sender<Result<(), warp::error::Error>>,
     },
     #[display(fmt = "InitializeFriends")]
@@ -123,11 +122,7 @@ pub async fn handle_multipass_cmd(cmd: MultiPassCmd, warp: &mut super::super::Wa
         MultiPassCmd::CreateIdentity { .. } | MultiPassCmd::TryLogIn { .. } => {
             // do nothing and drop the rsp channel
         }
-        MultiPassCmd::RequestFriend {
-            id,
-            outgoing_requests,
-            rsp,
-        } => {
+        MultiPassCmd::RequestFriend { id, rsp } => {
             // First attempt using a did
             let did = match DID::from_str(id.as_str()) {
                 Ok(did) => did,
@@ -165,15 +160,6 @@ pub async fn handle_multipass_cmd(cmd: MultiPassCmd, warp: &mut super::super::Wa
                     }
                 }
             };
-            // If request already exist return
-            if outgoing_requests
-                .into_iter()
-                .find(|id| id.did_key().eq(&did))
-                .is_some()
-            {
-                let _ = rsp.send(Result::Err(Error::FriendRequestExist));
-                return;
-            }
             let r = warp.multipass.send_request(&did).await;
             let _ = rsp.send(r);
         }

--- a/common/src/warp_runner/manager/commands/multipass_commands.rs
+++ b/common/src/warp_runner/manager/commands/multipass_commands.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use derive_more::Display;
+
 use futures::channel::oneshot;
 use warp::{
     crypto::DID,
@@ -16,7 +17,7 @@ use warp::{
 };
 
 use crate::{
-    state::{self, friends},
+    state::{self, friends, Identity},
     warp_runner::{ui_adapter::dids_to_identity, Account},
 };
 
@@ -36,6 +37,7 @@ pub enum MultiPassCmd {
     #[display(fmt = "RequestFriend {{ request: {id} }} ")]
     RequestFriend {
         id: String,
+        outgoing_requests: Vec<Identity>,
         rsp: oneshot::Sender<Result<(), warp::error::Error>>,
     },
     #[display(fmt = "InitializeFriends")]
@@ -121,7 +123,11 @@ pub async fn handle_multipass_cmd(cmd: MultiPassCmd, warp: &mut super::super::Wa
         MultiPassCmd::CreateIdentity { .. } | MultiPassCmd::TryLogIn { .. } => {
             // do nothing and drop the rsp channel
         }
-        MultiPassCmd::RequestFriend { id, rsp } => {
+        MultiPassCmd::RequestFriend {
+            id,
+            outgoing_requests,
+            rsp,
+        } => {
             // First attempt using a did
             let did = match DID::from_str(id.as_str()) {
                 Ok(did) => did,
@@ -159,6 +165,15 @@ pub async fn handle_multipass_cmd(cmd: MultiPassCmd, warp: &mut super::super::Wa
                     }
                 }
             };
+            // If request already exist return
+            if outgoing_requests
+                .into_iter()
+                .find(|id| id.did_key().eq(&did))
+                .is_some()
+            {
+                let _ = rsp.send(Result::Err(Error::FriendRequestExist));
+                return;
+            }
             let r = warp.multipass.send_request(&did).await;
             let _ = rsp.send(r);
         }

--- a/ui/src/components/friends/add.rs
+++ b/ui/src/components/friends/add.rs
@@ -157,7 +157,7 @@ pub fn AddFriend(cx: Scope) -> Element {
             Ok(x) => x,
             Err(e) => {
                 log::error!("failed to turn did to string: {e}");
-                return false;
+                return true;
             }
         };
         if outgoing_requests
@@ -166,9 +166,9 @@ pub fn AddFriend(cx: Scope) -> Element {
         {
             error_toast.set(Some(get_local_text("friends.request-exist")));
             log::warn!("duplicate friend request");
-            return false;
+            return true;
         }
-        true
+        false
     };
 
     cx.render(rsx!(

--- a/ui/src/components/friends/add.rs
+++ b/ui/src/components/friends/add.rs
@@ -164,6 +164,7 @@ pub fn AddFriend(cx: Scope) -> Element {
             .into_iter()
             .any(|id| id.did_key().eq(&did))
         {
+            error_toast.set(Some(get_local_text("friends.request-exist")));
             log::warn!("duplicate friend request");
             return false;
         }


### PR DESCRIPTION
### What this PR does 📖

- Properly reset things when a friend request is send. E.g. disable the "Add" button
- Also check first if there already is a request for the given input outgoing before sending the request.

### Which issue(s) this PR fixes 🔨

- Resolve #554

