### PR TITLE
chore(cargo): Set rust version to 1.68

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ codegen-units = 1
 
 [workspace.package]
 version = "0.1.0"
+rust-version = "1.68"
 
 [workspace.dependencies]
 dioxus = { git = "https://github.com/DioxusLabs/dioxus", rev = "d521da1991719760e271457dfe4f9ddf281afbb3" }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "common"
 version.workspace = true
+rust-version.workspace = true
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/icons/Cargo.toml
+++ b/icons/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "icons"
+rust-version.workspace = true
 version.workspace = true
 edition = "2021"
 

--- a/kit/Cargo.toml
+++ b/kit/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "kit"
+rust-version.workspace = true
 version.workspace = true
 edition = "2021"
 

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "uplink"
+rust-version.workspace = true
 version.workspace = true
 edition = "2021"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Sets the min rust version in `Cargo.toml` to prevent building with earlier versions of rust that may not be compatible with underlining dependencies.

### Which issue(s) this PR fixes 🔨

- N/A

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️
No change in code.

### Additional comments 🎤

