### PR TITLE
chore(appium): updates to appium workflow files

### DIFF
--- a/.github/workflows/ui-test-execution.yml
+++ b/.github/workflows/ui-test-execution.yml
@@ -45,6 +45,10 @@ jobs:
         with:
           repo-token: ${{env.GITHUB_TOKEN}}
 
+      - name: Patch makefile to remove --production-mode flag from make binary universal
+        run: |
+          perl -i -pe 's/--production-mode//g' Makefile
+
       - name: Run cargo update 🌐
         run: cargo update
 
@@ -109,7 +113,6 @@ jobs:
         working-directory: ./appium-tests/apps
         run: |
           unzip Uplink-Mac-Universal.zip
-          perl -i -pe 's/>ui</>uplink</g' ./Uplink.app/Contents/Info.plist
           cp -r ./Uplink.app /Applications/
           sudo xattr -r -d com.apple.quarantine /Applications/Uplink.app
 
@@ -133,6 +136,9 @@ jobs:
         with:
           junit_files: "./appium-tests/test-report/*.xml"
           check_name: "UI Automated Test Results on MacOS"
+          ignore_runs: true
+          job_summary: false
+          compare_to_earlier_commit: false
 
       - name: Upload Screenshots if tests failed 📷
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ui-test-execution.yml
+++ b/.github/workflows/ui-test-execution.yml
@@ -206,7 +206,6 @@ jobs:
         working-directory: ./appium-tests/apps
         run: |
           unzip Uplink-Mac-Universal.zip
-          perl -i -pe 's/>ui</>uplink</g' ./Uplink.app/Contents/Info.plist
           cp -r ./Uplink.app /Applications/
           sudo xattr -r -d com.apple.quarantine /Applications/Uplink.app
 

--- a/.github/workflows/ui-test-execution.yml
+++ b/.github/workflows/ui-test-execution.yml
@@ -45,10 +45,6 @@ jobs:
         with:
           repo-token: ${{env.GITHUB_TOKEN}}
 
-      - name: Patch makefile to remove --production-mode flag from make binary universal
-        run: |
-          perl -i -pe 's/--production-mode//g' Makefile
-
       - name: Run cargo update 🌐
         run: cargo update
 

--- a/.github/workflows/ui-test-windows.yml
+++ b/.github/workflows/ui-test-windows.yml
@@ -51,7 +51,7 @@ jobs:
         run: cargo clean
 
       - name: Build app 🖥️
-        run: cargo build --release
+        run: cargo build --package uplink -F production_mode
 
       - name: Upload Artifact ⬆️
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ui-test-windows.yml
+++ b/.github/workflows/ui-test-windows.yml
@@ -51,7 +51,7 @@ jobs:
         run: cargo clean
 
       - name: Build app 🖥️
-        run: cargo build --package uplink -F production_mode
+        run: cargo build --release --package uplink -F production_mode
 
       - name: Upload Artifact ⬆️
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ui-test-windows.yml
+++ b/.github/workflows/ui-test-windows.yml
@@ -110,6 +110,9 @@ jobs:
         with:
           junit_files: "./appium-tests/test-report/*.xml"
           check_name: "UI Automated Test Results on Windows"
+          ignore_runs: true
+          job_summary: false
+          compare_to_earlier_commit: false
 
       - name: Upload Screenshots if tests failed 📷
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
### What this PR does 📖

- Improvement 1 - The macos runner used on ui-test-execution pipeline is showing an OS update notification that was making the UI tests to fail when maximizing screen, so I am adding a step to dismiss this notification before running the tests
Improvement 2 - Remove the line patching the info.plist on ui-test-execution pipeline, since this one is no longer needed after the merge of https://github.com/Satellite-im/Uplink/pull/582
Improvement 3 - For the bot that comments the pull requests with the test results action (EnricoMi/publish-unit-test-result-action), now it will just paste the test results from the last commit and avoid comparing with previous commits. Also, now it won't paste the results into the job summary (somehow it was making adding the results into the cargo workflow job summary, instead of doing it in the job summary of the UI tests)

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

