### PR TITLE
chore(appium): accounts as temp artifacts on appium workflows

### DIFF
--- a/.github/workflows/ui-test-execution.yml
+++ b/.github/workflows/ui-test-execution.yml
@@ -156,6 +156,13 @@ jobs:
         with:
           file-name: "desktop.jpg"
 
+      - name: Upload Test User Accounts Created ⬆️
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: appium-test-accounts
+          path: ./appium-tests/tests/fixtures/users/
+
   test-chats:
     if: ${{ always() }}
     needs: test
@@ -179,6 +186,12 @@ jobs:
         with:
           repository: Satellite-im/testing-uplink
           path: "./appium-tests"
+
+      - name: Download Test User Accounts 🗳️
+        uses: actions/download-artifact@v3
+        with:
+          name: appium-test-accounts
+          path: ./appium-tests/tests/fixtures/users/
 
       - name: Setup Node.js 🔨
         uses: actions/setup-node@v3
@@ -234,3 +247,9 @@ jobs:
         with:
           name: appium-log-${{ matrix.user }}
           path: ./appium-tests/appium.log
+
+      - name: Delete Chat Users Accounts
+        if: always()
+        uses: geekyeggo/delete-artifact@v2
+        with:
+          name: appium-test-accounts


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Chats Tests from Appium Repo were modified in order to use test accounts created during test runs, instead of reusing the same test accounts.  The purpose of this was to add tests for friend request process on both sides and avoid using the same accounts by multiple test workflows running at the same time
- Due to this change, Uplink repo ui test execution workflow needs to be updated to upload accounts created as artifacts, then to download these in the chats job, and finally to delete these artifacts

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

