### PR TITLE
fix(friends): add loading screen after login

### DIFF
--- a/ui/src/layouts/loading.rs
+++ b/ui/src/layouts/loading.rs
@@ -1,0 +1,24 @@
+use common::{state::State, STATIC_ARGS};
+use dioxus::prelude::*;
+use dioxus_router::use_router;
+
+use crate::UPLINK_ROUTES;
+
+#[allow(non_snake_case)]
+pub fn LoadingLayout(cx: Scope) -> Element {
+    let state = use_shared_state::<State>(cx)?;
+    let router = use_router(cx);
+    if state.read().chats().initialized && state.read().friends().initialized {
+        router.replace_route(UPLINK_ROUTES.chat, None, None);
+    }
+    let img_path = STATIC_ARGS
+        .extras_path
+        .join("assets")
+        .join("img")
+        .join("uplink.gif");
+    let img_path = img_path.to_string_lossy().to_string();
+    cx.render(rsx!(img {
+        style: "width: 100%",
+        src: "{img_path}"
+    }))
+}

--- a/ui/src/layouts/mod.rs
+++ b/ui/src/layouts/mod.rs
@@ -2,6 +2,7 @@ pub mod chat;
 pub mod create_account;
 pub mod file_preview;
 pub mod friends;
+pub mod loading;
 pub mod settings;
 pub mod storage;
 pub mod unlock;

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -47,6 +47,7 @@ use crate::components::debug_logger::DebugLogger;
 use crate::components::toast::Toast;
 use crate::layouts::create_account::CreateAccountLayout;
 use crate::layouts::friends::FriendsLayout;
+use crate::layouts::loading::LoadingLayout;
 use crate::layouts::settings::SettingsLayout;
 use crate::layouts::storage::{FilesLayout, DRAG_EVENT};
 use crate::layouts::unlock::UnlockLayout;
@@ -85,6 +86,7 @@ pub static WINDOW_CMD_CH: Lazy<WindowManagerCmdChannels> = Lazy::new(|| {
 });
 
 pub struct UplinkRoutes<'a> {
+    pub loading: &'a str,
     pub chat: &'a str,
     pub friends: &'a str,
     pub files: &'a str,
@@ -92,7 +94,8 @@ pub struct UplinkRoutes<'a> {
 }
 
 pub static UPLINK_ROUTES: UplinkRoutes = UplinkRoutes {
-    chat: "/",
+    loading: "/",
+    chat: "/chat",
     friends: "/friends",
     files: "/files",
     settings: "/settings",
@@ -1336,6 +1339,10 @@ fn get_router(cx: Scope) -> Element {
 
     cx.render(rsx!(
         Router {
+            Route {
+                to: UPLINK_ROUTES.loading,
+                LoadingLayout{}
+            },
             Route {
                 to: UPLINK_ROUTES.chat,
                 ChatLayout {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- one can use the buttons to add/remove/chat with friends while uplink is loading data from warp. To prevent this, port the loading screen over from the last version of uplink. 
- note that this is a little different than what the ticket asked for. if this solution is unacceptable, i'm fine with abandoning this PR. 

### Which issue(s) this PR fixes 🔨

- Resolve #419 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

