### PR TITLE
fix(state): Reload theme from disc during start

### DIFF
--- a/ui/src/components/chat/compose.rs
+++ b/ui/src/components/chat/compose.rs
@@ -452,8 +452,8 @@ fn get_messages(cx: Scope, data: Rc<ComposeData>) -> Element {
         use_ref(cx, || None);
 
     let quick_profile_uuid = &*cx.use_hook(|| Uuid::new_v4().to_string());
-    let identity_profile = use_state(cx, || Identity::default());
-    let update_script = use_state(cx, || String::new());
+    let identity_profile = use_state(cx, Identity::default);
+    let update_script = use_state(cx, String::new);
 
     if let Some((id, m)) = newely_fetched_messages.write_silent().take() {
         if m.is_empty() {
@@ -1477,6 +1477,7 @@ pub struct QuickProfileProps<'a> {
     children: Element<'a>,
 }
 
+#[allow(clippy::large_enum_variant)]
 enum QuickProfileCmd {
     CreateConversation(Option<Chat>, DID),
     RemoveFriend(DID),
@@ -1501,7 +1502,7 @@ pub fn QuickProfileContext<'a>(cx: Scope<'a, QuickProfileProps<'a>>) -> Element<
 
     let chat_is_current = match state.read().get_active_chat() {
         Some(c) => match &chat_of {
-            Some(cO) => c.eq(&cO),
+            Some(cO) => c.eq(cO),
             None => false,
         },
         None => false,
@@ -1667,7 +1668,7 @@ pub fn QuickProfileContext<'a>(cx: Scope<'a, QuickProfileProps<'a>>) -> Element<
                 }
             }
             identity.status_message().and_then(|s|{
-                cx.render(rsx!(            
+                cx.render(rsx!(
                     hr{},
                     div {
                         id: "profile-status",

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -55,6 +55,7 @@ use crate::layouts::unlock::UnlockLayout;
 use crate::utils::auto_updater::{
     get_download_dest, DownloadProgress, DownloadState, SoftwareDownloadCmd, SoftwareUpdateCmd,
 };
+use crate::utils::get_available_themes;
 use crate::window_manager::WindowManagerCmdChannels;
 use crate::{components::chat::RouteInfo, layouts::chat::ChatLayout};
 use common::{
@@ -409,6 +410,20 @@ pub fn app_bootstrap(cx: Scope, identity: multipass::identity::Identity) -> Elem
         assert!(state.chats().initialized);
     } else {
         state.set_own_identity(identity.clone().into());
+    }
+
+    // Reload theme from file if present
+    let themes = get_available_themes();
+    let theme = themes.iter().find(|t| {
+        state
+            .ui
+            .theme
+            .as_ref()
+            .map(|theme| theme.eq(t))
+            .unwrap_or_default()
+    });
+    if let Some(t) = theme {
+        state.set_theme(Some(t.clone()));
     }
 
     // set the window to the normal size.


### PR DESCRIPTION
### What this PR does 📖

- Currently the theme gets saved as a whole (name + style string) in the state and the app will use that value ignoring file changes unless one refreshes the theme in the settings page.
  This change makes it during start it will try to also read from the file and apply it.

### Which issue(s) this PR fixes 🔨

- Resolve #639