### PR TITLE
chore(input): make username input not clear on enter when there is an error

### DIFF
--- a/ui/src/layouts/create_account.rs
+++ b/ui/src/layouts/create_account.rs
@@ -96,6 +96,7 @@ pub fn CreateAccountLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<Str
                 options: Options {
                     with_validation: Some(username_validation),
                     with_clear_btn: true,
+                    clear_on_submit: false,
                     ..Default::default()
                 }
                 onchange: |(val, is_valid): (String, bool)| {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
When creating a username with an invalid character, this prevents clearing when you hit enter. I kept adding a username I thought should be valid and hitting enter and missing the error.

https://user-images.githubusercontent.com/2993032/232122790-0537981a-4940-4580-b41e-281ccf8631cc.mov


- 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

