### PR TITLE
update(topbarcontrols): Move topbar controls to own component

### DIFF
--- a/kit/src/components/mod.rs
+++ b/kit/src/components/mod.rs
@@ -19,3 +19,5 @@ pub mod message_typing;
 pub mod file_embed;
 
 pub mod context_menu;
+
+pub mod topbar_controls;

--- a/kit/src/components/mod.rs
+++ b/kit/src/components/mod.rs
@@ -19,5 +19,4 @@ pub mod message_typing;
 pub mod file_embed;
 
 pub mod context_menu;
-
 pub mod topbar_controls;

--- a/kit/src/components/topbar_controls/mod.rs
+++ b/kit/src/components/topbar_controls/mod.rs
@@ -6,7 +6,6 @@ use dioxus_desktop::use_window;
 #[allow(non_snake_case)]
 pub fn Topbar_Controls(cx: Scope) -> Element {
     let desktop = use_window(cx);
-    // #[cfg(not(target_os = "macos"))]
     cx.render(rsx!(
         div {
             class: "controls",

--- a/kit/src/components/topbar_controls/mod.rs
+++ b/kit/src/components/topbar_controls/mod.rs
@@ -1,0 +1,39 @@
+use crate::elements::{button::Button, Appearance};
+use common::icons::outline::Shape as Icon;
+use dioxus::prelude::*;
+use dioxus_desktop::use_window;
+
+#[allow(non_snake_case)]
+pub fn Topbar_Controls(cx: Scope) -> Element {
+    let desktop = use_window(cx);
+    // #[cfg(not(target_os = "macos"))]
+    cx.render(rsx!(
+        div {
+            class: "controls",
+            Button {
+                aria_label: "minimize-button".into(),
+                icon: Icon::Minus,
+                appearance: Appearance::Transparent,
+                onpress: move |_| {
+                    desktop.set_minimized(true);
+                }
+            },
+            Button {
+                aria_label: "square-button".into(),
+                icon: Icon::Square2Stack,
+                appearance: Appearance::Transparent,
+                onpress: move |_| {
+                    desktop.set_maximized(!desktop.is_maximized());
+                }
+            },
+            Button {
+                aria_label: "close-button".into(),
+                icon: Icon::XMark,
+                appearance: Appearance::Transparent,
+                onpress: move |_| {
+                    desktop.close();
+                }
+            },
+        }
+    ))
+}

--- a/ui/src/layouts/file_preview.rs
+++ b/ui/src/layouts/file_preview.rs
@@ -17,6 +17,8 @@ use warp::constellation::file::File;
 use dioxus_desktop::wry::application::event::Event as WryEvent;
 use dioxus_desktop::{use_window, use_wry_event_handler, DesktopContext, LogicalSize};
 use image::io::Reader as ImageReader;
+#[cfg(not(target_os = "macos"))]
+use kit::components::topbar_controls::Topbar_Controls;
 use kit::elements::file::get_file_extension;
 use kit::STYLE as UIKIT_STYLES;
 use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
@@ -135,35 +137,7 @@ pub fn FilePreview(cx: Scope, file: File, _drop_handler: WindowDropHandler) -> E
 
     #[cfg(not(target_os = "macos"))]
     {
-        controls = cx.render(rsx!(
-            div {
-                class: "controls",
-                Button {
-                    aria_label: "minimize-button".into(),
-                    icon: Icon::Minus,
-                    appearance: Appearance::Transparent,
-                    onpress: move |_| {
-                        desktop.set_minimized(true);
-                    }
-                },
-                Button {
-                    aria_label: "square-button".into(),
-                    icon: Icon::Square2Stack,
-                    appearance: Appearance::Transparent,
-                    onpress: move |_| {
-                        desktop.set_maximized(!desktop.is_maximized());
-                    }
-                },
-                Button {
-                    aria_label: "close-button".into(),
-                    icon: Icon::XMark,
-                    appearance: Appearance::Transparent,
-                    onpress: move |_| {
-                        desktop.close();
-                    }
-                },
-            }
-        ))
+        controls = Topbar_Controls();
     }
 
     cx.render(rsx! (

--- a/ui/src/layouts/file_preview.rs
+++ b/ui/src/layouts/file_preview.rs
@@ -1,17 +1,11 @@
 use std::io::Cursor;
 
-#[cfg(not(target_os = "macos"))]
-use common::icons::outline::Shape as Icon;
 use common::{
     language::get_local_text, state::State, DOC_EXTENSIONS, IMAGE_EXTENSIONS, STATIC_ARGS,
     VIDEO_FILE_EXTENSIONS,
 };
 use dioxus::prelude::*;
 use dioxus_desktop::tao::event::WindowEvent;
-#[cfg(not(target_os = "macos"))]
-use kit::elements::button::Button;
-#[cfg(not(target_os = "macos"))]
-use kit::elements::Appearance;
 use warp::constellation::file::File;
 
 use dioxus_desktop::wry::application::event::Event as WryEvent;
@@ -137,7 +131,7 @@ pub fn FilePreview(cx: Scope, file: File, _drop_handler: WindowDropHandler) -> E
 
     #[cfg(not(target_os = "macos"))]
     {
-        controls = Topbar_Controls();
+        controls = cx.render(rsx!(Topbar_Controls {}));
     }
 
     cx.render(rsx! (

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -324,7 +324,7 @@ fn auth_wrapper(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -> El
 
     #[cfg(not(target_os = "macos"))]
     {
-        controls = Topbar_Controls();
+        controls = cx.render(rsx!(Topbar_Controls {}));
     }
 
     cx.render(rsx! (
@@ -1156,7 +1156,7 @@ fn get_titlebar(cx: Scope) -> Element {
 
     #[cfg(not(target_os = "macos"))]
     {
-        controls = Topbar_Controls();
+        controls = cx.render(rsx!(Topbar_Controls {}));
     }
 
     cx.render(rsx!(

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -22,7 +22,6 @@ use kit::components::nav::Route as UIRoute;
 use kit::components::topbar_controls::Topbar_Controls;
 use kit::elements::button::Button;
 use kit::elements::Appearance;
-use kit::layout::topbar::Topbar;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use once_cell::sync::Lazy;
 use overlay::{make_config, OverlayDom};

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -18,8 +18,11 @@ use futures::channel::oneshot;
 use futures::StreamExt;
 use kit::components::context_menu::{ContextItem, ContextMenu};
 use kit::components::nav::Route as UIRoute;
+#[cfg(not(target_os = "macos"))]
+use kit::components::topbar_controls::Topbar_Controls;
 use kit::elements::button::Button;
 use kit::elements::Appearance;
+use kit::layout::topbar::Topbar;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use once_cell::sync::Lazy;
 use overlay::{make_config, OverlayDom};
@@ -321,35 +324,7 @@ fn auth_wrapper(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -> El
 
     #[cfg(not(target_os = "macos"))]
     {
-        controls = cx.render(rsx!(
-            div {
-                class: "controls",
-                Button {
-                    aria_label: "minimize-button".into(),
-                    icon: Icon::Minus,
-                    appearance: Appearance::Transparent,
-                    onpress: move |_| {
-                        desktop.set_minimized(true);
-                    }
-                },
-                Button {
-                    aria_label: "square-button".into(),
-                    icon: Icon::Square2Stack,
-                    appearance: Appearance::Transparent,
-                    onpress: move |_| {
-                        desktop.set_maximized(!desktop.is_maximized());
-                    }
-                },
-                Button {
-                    aria_label: "close-button".into(),
-                    icon: Icon::XMark,
-                    appearance: Appearance::Transparent,
-                    onpress: move |_| {
-                        desktop.close();
-                    }
-                },
-            }
-        ))
+        controls = Topbar_Controls();
     }
 
     cx.render(rsx! (
@@ -1181,35 +1156,7 @@ fn get_titlebar(cx: Scope) -> Element {
 
     #[cfg(not(target_os = "macos"))]
     {
-        controls = cx.render(rsx!(
-            div {
-                class: "controls",
-                Button {
-                    aria_label: "minimize-button".into(),
-                    icon: Icon::Minus,
-                    appearance: Appearance::Transparent,
-                    onpress: move |_| {
-                        desktop.set_minimized(true);
-                    }
-                },
-                Button {
-                    aria_label: "square-button".into(),
-                    icon: Icon::Square2Stack,
-                    appearance: Appearance::Transparent,
-                    onpress: move |_| {
-                        desktop.set_maximized(!desktop.is_maximized());
-                    }
-                },
-                Button {
-                    aria_label: "close-button".into(),
-                    icon: Icon::XMark,
-                    appearance: Appearance::Transparent,
-                    onpress: move |_| {
-                        desktop.close();
-                    }
-                },
-            }
-        ))
+        controls = Topbar_Controls();
     }
 
     cx.render(rsx!(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

We were re-using the same component in three places. I moved it to kit. I wanted to do this small PR first to make sure I was doing it right, so I could put the other topbar items in a reusable component/not add more to ui/sr/main.rs

### Which issue(s) this PR fixes 🔨

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

@phillsatellite this shouldn't appear any different - you should see the custom topbar (minimize, expand window, close) in windows and linux on the right side, but not in mac on the main window, login window, and the file preview.

### Additional comments 🎤

