### PR TITLE
chore(titlebar): Titlebar updates

### DIFF
--- a/kit/src/components/mod.rs
+++ b/kit/src/components/mod.rs
@@ -19,3 +19,5 @@ pub mod message_typing;
 pub mod file_embed;
 
 pub mod context_menu;
+
+pub mod topbar_controls;

--- a/kit/src/components/mod.rs
+++ b/kit/src/components/mod.rs
@@ -19,5 +19,4 @@ pub mod message_typing;
 pub mod file_embed;
 
 pub mod context_menu;
-
 pub mod topbar_controls;

--- a/kit/src/components/topbar_controls/mod.rs
+++ b/kit/src/components/topbar_controls/mod.rs
@@ -6,7 +6,6 @@ use dioxus_desktop::use_window;
 #[allow(non_snake_case)]
 pub fn Topbar_Controls(cx: Scope) -> Element {
     let desktop = use_window(cx);
-    // #[cfg(not(target_os = "macos"))]
     cx.render(rsx!(
         div {
             class: "controls",

--- a/kit/src/components/topbar_controls/mod.rs
+++ b/kit/src/components/topbar_controls/mod.rs
@@ -1,0 +1,39 @@
+use crate::elements::{button::Button, Appearance};
+use common::icons::outline::Shape as Icon;
+use dioxus::prelude::*;
+use dioxus_desktop::use_window;
+
+#[allow(non_snake_case)]
+pub fn Topbar_Controls(cx: Scope) -> Element {
+    let desktop = use_window(cx);
+    // #[cfg(not(target_os = "macos"))]
+    cx.render(rsx!(
+        div {
+            class: "controls",
+            Button {
+                aria_label: "minimize-button".into(),
+                icon: Icon::Minus,
+                appearance: Appearance::Transparent,
+                onpress: move |_| {
+                    desktop.set_minimized(true);
+                }
+            },
+            Button {
+                aria_label: "square-button".into(),
+                icon: Icon::Square2Stack,
+                appearance: Appearance::Transparent,
+                onpress: move |_| {
+                    desktop.set_maximized(!desktop.is_maximized());
+                }
+            },
+            Button {
+                aria_label: "close-button".into(),
+                icon: Icon::XMark,
+                appearance: Appearance::Transparent,
+                onpress: move |_| {
+                    desktop.close();
+                }
+            },
+        }
+    ))
+}

--- a/ui/src/components/mod.rs
+++ b/ui/src/components/mod.rs
@@ -5,3 +5,4 @@ pub mod friends;
 pub mod media;
 pub mod settings;
 pub mod toast;
+pub mod topbar;

--- a/ui/src/components/topbar/mod.rs
+++ b/ui/src/components/topbar/mod.rs
@@ -1,0 +1,1 @@
+pub mod release_info;

--- a/ui/src/components/topbar/release_info/mod.rs
+++ b/ui/src/components/topbar/release_info/mod.rs
@@ -6,9 +6,16 @@ use dioxus::prelude::*;
 #[allow(non_snake_case)]
 pub fn Release_Info(cx: Scope) -> Element {
     let pre_release_text = get_local_text("uplink.pre-release");
+
+    #[cfg(target_os = "macos")]
+    let left_padding = true;
+
     cx.render(rsx!(
         div {
             id: "pre-release",
+            class : {
+                if left_padding == true {"topbar-item mac-spacer"}  else {"topbar-item"}
+            },
             aria_label: "pre-release",
             IconElement {
                 icon: Icon::Beaker,

--- a/ui/src/components/topbar/release_info/mod.rs
+++ b/ui/src/components/topbar/release_info/mod.rs
@@ -1,0 +1,27 @@
+use common::icons::outline::Shape as Icon;
+use common::icons::Icon as IconElement;
+use common::language::get_local_text;
+use dioxus::prelude::*;
+
+#[allow(non_snake_case)]
+pub fn Release_Info(cx: Scope) -> Element {
+    let pre_release_text = get_local_text("uplink.pre-release");
+    cx.render(rsx!(
+        div {
+            id: "pre-release",
+            aria_label: "pre-release",
+            IconElement {
+                icon: Icon::Beaker,
+            },
+            p {
+                div {
+                    onclick: move |_| {
+                        let _ = open::that("https://issues.satellite.im");
+                    },
+                    "{pre_release_text}"
+                }
+
+            }
+        },
+    ))
+}

--- a/ui/src/components/topbar/release_info/style.scss
+++ b/ui/src/components/topbar/release_info/style.scss
@@ -1,0 +1,19 @@
+#pre-release {
+    cursor: default;
+    p {
+      color: var(--warning-light);
+      font-size: var(--text-size-less);
+      cursor: pointer;
+    }
+    svg {
+      fill: transparent;
+      stroke: var(--warning-light);
+      height: var(--text-size-less);
+      align-self: center;
+      width: var(--text-size-less);
+    }
+  }
+
+.mac-spacer {
+    margin-left: 4rem;
+}

--- a/ui/src/layouts/file_preview.rs
+++ b/ui/src/layouts/file_preview.rs
@@ -17,6 +17,8 @@ use warp::constellation::file::File;
 use dioxus_desktop::wry::application::event::Event as WryEvent;
 use dioxus_desktop::{use_window, use_wry_event_handler, DesktopContext, LogicalSize};
 use image::io::Reader as ImageReader;
+#[cfg(not(target_os = "macos"))]
+use kit::components::topbar_controls::Topbar_Controls;
 use kit::elements::file::get_file_extension;
 use kit::STYLE as UIKIT_STYLES;
 use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
@@ -135,35 +137,7 @@ pub fn FilePreview(cx: Scope, file: File, _drop_handler: WindowDropHandler) -> E
 
     #[cfg(not(target_os = "macos"))]
     {
-        controls = cx.render(rsx!(
-            div {
-                class: "controls",
-                Button {
-                    aria_label: "minimize-button".into(),
-                    icon: Icon::Minus,
-                    appearance: Appearance::Transparent,
-                    onpress: move |_| {
-                        desktop.set_minimized(true);
-                    }
-                },
-                Button {
-                    aria_label: "square-button".into(),
-                    icon: Icon::Square2Stack,
-                    appearance: Appearance::Transparent,
-                    onpress: move |_| {
-                        desktop.set_maximized(!desktop.is_maximized());
-                    }
-                },
-                Button {
-                    aria_label: "close-button".into(),
-                    icon: Icon::XMark,
-                    appearance: Appearance::Transparent,
-                    onpress: move |_| {
-                        desktop.close();
-                    }
-                },
-            }
-        ))
+        controls = Topbar_Controls();
     }
 
     cx.render(rsx! (

--- a/ui/src/layouts/file_preview.rs
+++ b/ui/src/layouts/file_preview.rs
@@ -1,17 +1,11 @@
 use std::io::Cursor;
 
-#[cfg(not(target_os = "macos"))]
-use common::icons::outline::Shape as Icon;
 use common::{
     language::get_local_text, state::State, DOC_EXTENSIONS, IMAGE_EXTENSIONS, STATIC_ARGS,
     VIDEO_FILE_EXTENSIONS,
 };
 use dioxus::prelude::*;
 use dioxus_desktop::tao::event::WindowEvent;
-#[cfg(not(target_os = "macos"))]
-use kit::elements::button::Button;
-#[cfg(not(target_os = "macos"))]
-use kit::elements::Appearance;
 use warp::constellation::file::File;
 
 use dioxus_desktop::wry::application::event::Event as WryEvent;
@@ -137,7 +131,7 @@ pub fn FilePreview(cx: Scope, file: File, _drop_handler: WindowDropHandler) -> E
 
     #[cfg(not(target_os = "macos"))]
     {
-        controls = Topbar_Controls();
+        controls = cx.render(rsx!(Topbar_Controls {}));
     }
 
     cx.render(rsx! (

--- a/ui/src/layouts/file_preview.rs
+++ b/ui/src/layouts/file_preview.rs
@@ -8,6 +8,7 @@ use dioxus::prelude::*;
 use dioxus_desktop::tao::event::WindowEvent;
 use warp::constellation::file::File;
 
+use crate::components::topbar::release_info::Release_Info;
 use dioxus_desktop::wry::application::event::Event as WryEvent;
 use dioxus_desktop::{use_window, use_wry_event_handler, DesktopContext, LogicalSize};
 use image::io::Reader as ImageReader;
@@ -18,7 +19,7 @@ use kit::STYLE as UIKIT_STYLES;
 use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
 use std::sync::mpsc::channel;
 
-use crate::{get_pre_release_message, utils::WindowDropHandler, APP_STYLE};
+use crate::{utils::WindowDropHandler, APP_STYLE};
 
 const CSS_STYLE: &str = include_str!("./style.scss");
 
@@ -146,7 +147,7 @@ pub fn FilePreview(cx: Scope, file: File, _drop_handler: WindowDropHandler) -> E
                 },
                 controls,
             }
-            get_pre_release_message{},
+            Release_Info{},
             div {
                 {
                 if file_format != FileFormat::Other && has_thumbnail {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -47,6 +47,7 @@ use dioxus_desktop::wry::application::event::Event as WryEvent;
 
 use crate::components::debug_logger::DebugLogger;
 use crate::components::toast::Toast;
+use crate::components::topbar::release_info::Release_Info;
 use crate::layouts::create_account::CreateAccountLayout;
 use crate::layouts::friends::FriendsLayout;
 use crate::layouts::loading::LoadingLayout;
@@ -491,7 +492,7 @@ fn app(cx: Scope) -> Element {
                 get_titlebar{},
                 get_toasts{},
                 get_call_dialog{},
-                get_pre_release_message{},
+                Release_Info{},
                 get_router{},
                 get_logger{},
             }
@@ -987,28 +988,6 @@ fn app(cx: Scope) -> Element {
     cx.render(main_element)
 }
 
-fn get_pre_release_message(_cx: Scope) -> Element {
-    let pre_release_text = get_local_text("uplink.pre-release");
-    _cx.render(rsx!(
-        div {
-            id: "pre-release",
-            aria_label: "pre-release",
-            IconElement {
-                icon: Icon::Beaker,
-            },
-            p {
-                div {
-                    onclick: move |_| {
-                        let _ = open::that("https://issues.satellite.im");
-                    },
-                    "{pre_release_text}"
-                }
-
-            }
-        },
-    ))
-}
-
 fn get_update_icon(cx: Scope) -> Element {
     log::trace!("rendering get_update_icon");
     let state = use_shared_state::<State>(cx)?;
@@ -1219,7 +1198,6 @@ fn get_titlebar(cx: Scope) -> Element {
                     }
                 }
             )),
-
             controls,
 
         },

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -324,7 +324,7 @@ fn auth_wrapper(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -> El
 
     #[cfg(not(target_os = "macos"))]
     {
-        controls = Topbar_Controls();
+        controls = cx.render(rsx!(Topbar_Controls {}));
     }
 
     cx.render(rsx! (
@@ -1156,7 +1156,7 @@ fn get_titlebar(cx: Scope) -> Element {
 
     #[cfg(not(target_os = "macos"))]
     {
-        controls = Topbar_Controls();
+        controls = cx.render(rsx!(Topbar_Controls {}));
     }
 
     cx.render(rsx!(

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -22,7 +22,6 @@ use kit::components::nav::Route as UIRoute;
 use kit::components::topbar_controls::Topbar_Controls;
 use kit::elements::button::Button;
 use kit::elements::Appearance;
-use kit::layout::topbar::Topbar;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use once_cell::sync::Lazy;
 use overlay::{make_config, OverlayDom};

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -264,7 +264,8 @@ pub fn get_window_builder(with_predefined_size: bool) -> WindowBuilder {
             .with_transparent(true)
             .with_fullsize_content_view(true)
             .with_menu(main_menu)
-            .with_titlebar_transparent(true);
+            .with_titlebar_transparent(true)
+            .with_title("")
         // .with_movable_by_window_background(true)
     }
 
@@ -616,11 +617,6 @@ fn app(cx: Scope) -> Element {
                 //    size,
                 //    size.width < 1200
                 //);
-                if desktop.outer_size().width < 575 {
-                    desktop.set_title("");
-                } else {
-                    desktop.set_title("Uplink");
-                }
 
                 match inner.try_borrow_mut() {
                     Ok(state) => {
@@ -1046,8 +1042,7 @@ fn get_update_icon(cx: Scope) -> Element {
                         }
                     },
                     IconElement {
-                        icon: common::icons::solid::Shape::ArrowDown,
-                        fill: "green",
+                        icon: common::icons::solid::Shape::ArrowDownCircle,
                     },
                     "{update_msg}",
                 }
@@ -1055,12 +1050,14 @@ fn get_update_icon(cx: Scope) -> Element {
         )),
         DownloadProgress::Pending => cx.render(rsx!(div {
             id: "update-available",
+            class: "topbar-item",
             aria_label: "update-available",
             "{downloading_msg}"
         })),
         DownloadProgress::Finished => {
             cx.render(rsx!(div {
                 id: "update-available",
+                class: "topbar-item",
                 aria_label: "update-available",
                 onclick: move |_| {
                     // be sure to update this before closing the app
@@ -1140,6 +1137,7 @@ fn get_titlebar(cx: Scope) -> Element {
         div {
             id: "titlebar",
             onmousedown: move |_| { desktop.drag(); },
+            cx.render(rsx!(Release_Info{})),
             get_update_icon{},
             // Only display this if developer mode is enabled.
             (config.developer.developer_mode).then(|| rsx!(
@@ -1197,9 +1195,7 @@ fn get_titlebar(cx: Scope) -> Element {
                     }
                 }
             )),
-            cx.render(rsx!(Release_Info{})),
             controls,
-
         },
     ))
 }

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -492,7 +492,6 @@ fn app(cx: Scope) -> Element {
                 get_titlebar{},
                 get_toasts{},
                 get_call_dialog{},
-                Release_Info{},
                 get_router{},
                 get_logger{},
             }
@@ -1198,6 +1197,7 @@ fn get_titlebar(cx: Scope) -> Element {
                     }
                 }
             )),
+            cx.render(rsx!(Release_Info{})),
             controls,
 
         },

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -18,8 +18,11 @@ use futures::channel::oneshot;
 use futures::StreamExt;
 use kit::components::context_menu::{ContextItem, ContextMenu};
 use kit::components::nav::Route as UIRoute;
+#[cfg(not(target_os = "macos"))]
+use kit::components::topbar_controls::Topbar_Controls;
 use kit::elements::button::Button;
 use kit::elements::Appearance;
+use kit::layout::topbar::Topbar;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use once_cell::sync::Lazy;
 use overlay::{make_config, OverlayDom};
@@ -321,35 +324,7 @@ fn auth_wrapper(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -> El
 
     #[cfg(not(target_os = "macos"))]
     {
-        controls = cx.render(rsx!(
-            div {
-                class: "controls",
-                Button {
-                    aria_label: "minimize-button".into(),
-                    icon: Icon::Minus,
-                    appearance: Appearance::Transparent,
-                    onpress: move |_| {
-                        desktop.set_minimized(true);
-                    }
-                },
-                Button {
-                    aria_label: "square-button".into(),
-                    icon: Icon::Square2Stack,
-                    appearance: Appearance::Transparent,
-                    onpress: move |_| {
-                        desktop.set_maximized(!desktop.is_maximized());
-                    }
-                },
-                Button {
-                    aria_label: "close-button".into(),
-                    icon: Icon::XMark,
-                    appearance: Appearance::Transparent,
-                    onpress: move |_| {
-                        desktop.close();
-                    }
-                },
-            }
-        ))
+        controls = Topbar_Controls();
     }
 
     cx.render(rsx! (
@@ -1181,35 +1156,7 @@ fn get_titlebar(cx: Scope) -> Element {
 
     #[cfg(not(target_os = "macos"))]
     {
-        controls = cx.render(rsx!(
-            div {
-                class: "controls",
-                Button {
-                    aria_label: "minimize-button".into(),
-                    icon: Icon::Minus,
-                    appearance: Appearance::Transparent,
-                    onpress: move |_| {
-                        desktop.set_minimized(true);
-                    }
-                },
-                Button {
-                    aria_label: "square-button".into(),
-                    icon: Icon::Square2Stack,
-                    appearance: Appearance::Transparent,
-                    onpress: move |_| {
-                        desktop.set_maximized(!desktop.is_maximized());
-                    }
-                },
-                Button {
-                    aria_label: "close-button".into(),
-                    icon: Icon::XMark,
-                    appearance: Appearance::Transparent,
-                    onpress: move |_| {
-                        desktop.close();
-                    }
-                },
-            }
-        ))
+        controls = Topbar_Controls();
     }
 
     cx.render(rsx!(

--- a/ui/src/style.scss
+++ b/ui/src/style.scss
@@ -33,7 +33,7 @@ body {
   background-color: var(--background);
   border-bottom: 1px solid var(--border-color);
   display: inline-flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   user-select: none;
   cursor: pointer;
   min-height: 1.6rem;
@@ -59,35 +59,16 @@ body {
   color: var(--warning-light);
   font-size: var(--text-size-less);
   cursor: pointer;
+  
 }
 
-#pre-release {
-  position: fixed;
-  top: 0.14rem;
-  margin-left: 4rem; // TODO: only do this on mac
-  left: var(--gap);
-  background-color: var(--secondary-dark);
-  border-radius: var(--border-radius-less);
-  display: inline-flex;
-  gap: var(--gap-less);
-  align-content: center;
-  justify-content: center;
-  width: fit-content;
-  padding: var(--gap-less);
-  user-select: none;
-  cursor: default;
-  p {
-    color: var(--warning-light);
-    font-size: var(--text-size-less);
-    cursor: pointer;
-  }
-  svg {
-    fill: transparent;
-    stroke: var(--warning-light);
-    height: var(--text-size-less);
-    align-self: center;
-    width: var(--text-size-less);
-  }
+#update-available > svg {
+  fill: var(--warning-light);
+  height: 16px;
+}
+
+#update-available-menu {
+  margin-right: var(--gap-less);
 }
 
 #main {
@@ -150,4 +131,15 @@ body {
   width: 100%;
   height: 2rem;
   z-index: 1;
+}
+
+.topbar-item {
+  background-color: var(--secondary-dark);
+  border-radius: var(--border-radius-less);
+  display: inline-flex;
+  gap: var(--gap-less);
+  width: fit-content;
+  padding: var(--gap-less);
+  user-select: none;
+  margin-right: var(--gap-less);
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- We were re-using the same windows-controls component in three places. I moved it to kit.
- Moved the pre-release component to it's own component in ui/src (since it is application specific) and loaded it back in main, and loaded it into the titlebar instead of, hierarchically the same level as titlebar, and removed fixed positioning
- I cleaned up the CSS a little; mac override for a css class in titlebar (to accommodate for the mac windows-controls) and removed things we didnt need.
- removed the 'Uplink" title text. It just got in the way and made that section of the title hard to grab/move

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

