### PR TITLE
fix(themes): undo regression in themes

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -10,11 +10,15 @@ use clap::Parser;
 // export icons crate
 pub use icons;
 use once_cell::sync::Lazy;
+use state::{ui::Font, Theme};
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
+use titlecase::titlecase;
 use tokio::sync::Mutex;
+use walkdir::WalkDir;
+use warp::logging::tracing::log;
 use warp_runner::{WarpCmdChannels, WarpEventChannels};
 
 use fluent_templates::static_loader;
@@ -230,4 +234,96 @@ pub fn get_extensions_dir() -> anyhow::Result<PathBuf> {
     };
 
     Ok(extensions_path)
+}
+
+pub fn get_available_themes() -> Vec<Theme> {
+    let mut themes = vec![];
+
+    let mut add_to_themes = |themes_path: &PathBuf| {
+        log::debug!("add_to_themes: {}", themes_path.to_string_lossy());
+        for file in WalkDir::new(themes_path)
+            .into_iter()
+            .filter_map(|file| file.ok())
+        {
+            if file.metadata().map(|x| x.is_file()).unwrap_or(false) {
+                let theme_path = file.path().display().to_string();
+                let pretty_theme_str = get_pretty_name(&theme_path);
+                let pretty_theme_str = titlecase(&pretty_theme_str);
+
+                let styles = std::fs::read_to_string(&theme_path).unwrap_or_default();
+
+                let theme = Theme {
+                    filename: theme_path.to_owned(),
+                    name: pretty_theme_str.to_owned(),
+                    styles,
+                };
+                if !themes.contains(&theme) {
+                    themes.push(theme);
+                }
+            }
+        }
+    };
+    add_to_themes(&STATIC_ARGS.themes_path);
+    if let Ok(p) = get_extras_dir() {
+        add_to_themes(&p.join("themes"));
+    }
+
+    themes.sort_by_key(|theme| theme.name.clone());
+    themes.dedup();
+
+    themes
+}
+
+fn get_pretty_name<S: AsRef<str>>(name: S) -> String {
+    let path = Path::new(name.as_ref());
+    let last = path
+        .file_name()
+        .and_then(|p| Path::new(p).file_stem())
+        .unwrap_or_default();
+    last.to_string_lossy().into()
+}
+
+pub fn get_available_fonts() -> Vec<Font> {
+    let mut fonts = vec![];
+
+    for file in WalkDir::new(&STATIC_ARGS.fonts_path)
+        .into_iter()
+        .filter_map(|file| file.ok())
+    {
+        if file.metadata().map(|x| x.is_file()).unwrap_or(false) {
+            let file_osstr = file.file_name();
+            let mut pretty_name: String = file_osstr.to_str().unwrap_or_default().into();
+            pretty_name = pretty_name
+                .replace(['_', '-'], " ")
+                .split('.')
+                .next()
+                .unwrap()
+                .into();
+
+            let font = Font {
+                name: pretty_name,
+                path: file.path().to_str().unwrap_or_default().into(),
+            };
+
+            fonts.push(font);
+        }
+    }
+
+    fonts
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_get_pretty_name1() {
+        if cfg!(windows) {
+            let r = get_pretty_name("c:\\pretty\\name2.scss");
+            assert_eq!(r, String::from("name2"));
+        } else {
+            let r = get_pretty_name("pretty/name1.scss");
+            assert_eq!(r, String::from("name1"));
+        }
+    }
 }

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -23,7 +23,7 @@ pub use ui::{Theme, ToastNotification, UI};
 use warp::multipass::identity::Platform;
 use warp::raygun::{ConversationType, Reaction};
 
-use crate::STATIC_ARGS;
+use crate::{get_available_themes, STATIC_ARGS};
 
 use crate::{
     testing::mock::generate_mock,
@@ -526,6 +526,16 @@ impl State {
                 }
             }
         };
+
+        // if a theme has changed, there may be a difference between the css saved in State and what's on Disk.
+        // correct that here.
+        let themes = get_available_themes();
+        if let Some(theme_name) = state.ui.theme.as_ref().map(|x| &x.name) {
+            if let Some(theme) = themes.iter().find(|t| &t.name == theme_name) {
+                state.set_theme(Some(theme.clone()));
+            }
+        }
+
         // not sure how these defaulted to true, but this should serve as additional
         // protection in the future
         state.friends.initialized = false;

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -531,9 +531,7 @@ impl State {
         // correct that here.
         let themes = get_available_themes();
         if let Some(theme_name) = state.ui.theme.as_ref().map(|x| &x.name) {
-            if let Some(theme) = themes.iter().find(|t| &t.name == theme_name) {
-                state.set_theme(Some(theme.clone()));
-            }
+            state.set_theme(themes.iter().find(|t| &t.name == theme_name).cloned());
         }
 
         // not sure how these defaulted to true, but this should serve as additional

--- a/ui/src/components/settings/sub_pages/general.rs
+++ b/ui/src/components/settings/sub_pages/general.rs
@@ -5,16 +5,15 @@ use kit::components::slide_selector::{ButtonsFormat, SlideSelector};
 use kit::elements::{select::Select, switch::Switch};
 use warp::logging::tracing::log;
 
-use crate::utils::get_available_fonts;
-use crate::{components::settings::SettingSection, utils::get_available_themes};
+use crate::components::settings::SettingSection;
 
 #[allow(non_snake_case)]
 pub fn GeneralSettings(cx: Scope) -> Element {
     let state = use_shared_state::<State>(cx)?;
     let initial_lang_value = state.read().settings.language.clone();
 
-    let themes_fut = use_future(cx, (), |_| async move { get_available_themes() });
-    let font_fut = use_future(cx, (), |_| async move { get_available_fonts() });
+    let themes_fut = use_future(cx, (), |_| async move { common::get_available_themes() });
+    let font_fut = use_future(cx, (), |_| async move { common::get_available_fonts() });
 
     log::trace!("General settings page rendered.");
 

--- a/ui/src/utils/mod.rs
+++ b/ui/src/utils/mod.rs
@@ -1,18 +1,11 @@
 use common::{
-    get_extras_dir,
-    state::{self, ui::Font, Theme},
+    state::{self},
     STATIC_ARGS,
 };
 use filetime::FileTime;
 use warp::logging::tracing::log;
 
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
-use titlecase::titlecase;
-
-use walkdir::WalkDir;
+use std::{fs, path::Path};
 
 use kit::User as UserInfo;
 
@@ -21,82 +14,6 @@ use crate::{window_manager::WindowManagerCmd, WINDOW_CMD_CH};
 pub mod auto_updater;
 pub mod format_timestamp;
 pub mod lifecycle;
-
-pub fn get_available_themes() -> Vec<Theme> {
-    let mut themes = vec![];
-
-    let mut add_to_themes = |themes_path: &PathBuf| {
-        log::debug!("add_to_themes: {}", themes_path.to_string_lossy());
-        for file in WalkDir::new(themes_path)
-            .into_iter()
-            .filter_map(|file| file.ok())
-        {
-            if file.metadata().map(|x| x.is_file()).unwrap_or(false) {
-                let theme_path = file.path().display().to_string();
-                let pretty_theme_str = get_pretty_name(&theme_path);
-                let pretty_theme_str = titlecase(&pretty_theme_str);
-
-                let styles = fs::read_to_string(&theme_path).unwrap_or_default();
-
-                let theme = Theme {
-                    filename: theme_path.to_owned(),
-                    name: pretty_theme_str.to_owned(),
-                    styles,
-                };
-                if !themes.contains(&theme) {
-                    themes.push(theme);
-                }
-            }
-        }
-    };
-    add_to_themes(&STATIC_ARGS.themes_path);
-    if let Ok(p) = get_extras_dir() {
-        add_to_themes(&p.join("themes"));
-    }
-
-    themes.sort_by_key(|theme| theme.name.clone());
-    themes.dedup();
-
-    themes
-}
-
-pub fn get_available_fonts() -> Vec<Font> {
-    let mut fonts = vec![];
-
-    for file in WalkDir::new(&STATIC_ARGS.fonts_path)
-        .into_iter()
-        .filter_map(|file| file.ok())
-    {
-        if file.metadata().map(|x| x.is_file()).unwrap_or(false) {
-            let file_osstr = file.file_name();
-            let mut pretty_name: String = file_osstr.to_str().unwrap_or_default().into();
-            pretty_name = pretty_name
-                .replace(['_', '-'], " ")
-                .split('.')
-                .next()
-                .unwrap()
-                .into();
-
-            let font = Font {
-                name: pretty_name,
-                path: file.path().to_str().unwrap_or_default().into(),
-            };
-
-            fonts.push(font);
-        }
-    }
-
-    fonts
-}
-
-fn get_pretty_name<S: AsRef<str>>(name: S) -> String {
-    let path = Path::new(name.as_ref());
-    let last = path
-        .file_name()
-        .and_then(|p| Path::new(p).file_stem())
-        .unwrap_or_default();
-    last.to_string_lossy().into()
-}
 
 pub fn unzip_prism_langs() {
     if !STATIC_ARGS.production_mode || !cfg!(target_os = "windows") {
@@ -235,22 +152,6 @@ impl Drop for WindowDropHandler {
         let cmd_tx = WINDOW_CMD_CH.tx.clone();
         if let Err(_e) = cmd_tx.send(self.cmd) {
             // todo: log error
-        }
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_get_pretty_name1() {
-        if cfg!(windows) {
-            let r = get_pretty_name("c:\\pretty\\name2.scss");
-            assert_eq!(r, String::from("name2"));
-        } else {
-            let r = get_pretty_name("pretty/name1.scss");
-            assert_eq!(r, String::from("name1"));
         }
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- undo regression caused by https://github.com/Satellite-im/Uplink/pull/630
- themes should be reloaded from disk on startup
- not sure if the theme should be cleared from State if the theme file is deleted, but I added that too. 

![image](https://user-images.githubusercontent.com/8636602/233175813-22012af3-78a5-470c-ab2a-7a6b1286cea9.png)


### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

