### PR TITLE
fix(state): Lang & theme fix during load

### DIFF
--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -9,7 +9,9 @@ pub mod scope_ids;
 pub mod settings;
 pub mod storage;
 pub mod ui;
+pub mod utils;
 
+use crate::language::change_language;
 // export specific structs which the UI expects. these structs used to be in src/state.rs, before state.rs was turned into the `state` folder
 use crate::{language::get_local_text, warp_runner::ui_adapter};
 pub use action::Action;
@@ -49,6 +51,7 @@ use warp::{
 
 use self::storage::Storage;
 use self::ui::{Call, Font, Layout};
+use self::utils::get_available_themes;
 
 // todo: create an Identity cache and only store UUID in state.friends and state.chats
 // store the following information in the cache: key: DID, value: { Identity, HashSet<UUID of conversations this identity is participating in> }
@@ -534,7 +537,21 @@ impl State {
         if state.settings.font_scale() == 0.0 {
             state.settings.set_font_scale(1.0);
         }
-
+        // Reload themes from disc
+        let themes = get_available_themes();
+        let theme = themes.iter().find(|t| {
+            state
+                .ui
+                .theme
+                .as_ref()
+                .map(|theme| theme.eq(t))
+                .unwrap_or_default()
+        });
+        if let Some(t) = theme {
+            state.set_theme(Some(t.clone()));
+        }
+        let user_lang_saved = state.settings.language.clone();
+        change_language(user_lang_saved);
         state
     }
     fn load_mock() -> Self {

--- a/common/src/state/utils.rs
+++ b/common/src/state/utils.rs
@@ -1,0 +1,104 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use titlecase::titlecase;
+use walkdir::WalkDir;
+use warp::logging::tracing::log;
+
+use crate::{get_extras_dir, STATIC_ARGS};
+
+use super::{ui::Font, Theme};
+
+pub fn get_available_themes() -> Vec<Theme> {
+    let mut themes = vec![];
+
+    let mut add_to_themes = |themes_path: &PathBuf| {
+        log::debug!("add_to_themes: {}", themes_path.to_string_lossy());
+        for file in WalkDir::new(themes_path)
+            .into_iter()
+            .filter_map(|file| file.ok())
+        {
+            if file.metadata().map(|x| x.is_file()).unwrap_or(false) {
+                let theme_path = file.path().display().to_string();
+                let pretty_theme_str = get_pretty_name(&theme_path);
+                let pretty_theme_str = titlecase(&pretty_theme_str);
+
+                let styles = fs::read_to_string(&theme_path).unwrap_or_default();
+
+                let theme = Theme {
+                    filename: theme_path.to_owned(),
+                    name: pretty_theme_str.to_owned(),
+                    styles,
+                };
+                if !themes.contains(&theme) {
+                    themes.push(theme);
+                }
+            }
+        }
+    };
+    add_to_themes(&STATIC_ARGS.themes_path);
+    if let Ok(p) = get_extras_dir() {
+        add_to_themes(&p.join("themes"));
+    }
+
+    themes.sort_by_key(|theme| theme.name.clone());
+    themes.dedup();
+
+    themes
+}
+
+fn get_pretty_name<S: AsRef<str>>(name: S) -> String {
+    let path = Path::new(name.as_ref());
+    let last = path
+        .file_name()
+        .and_then(|p| Path::new(p).file_stem())
+        .unwrap_or_default();
+    last.to_string_lossy().into()
+}
+
+pub fn get_available_fonts() -> Vec<Font> {
+    let mut fonts = vec![];
+
+    for file in WalkDir::new(&STATIC_ARGS.fonts_path)
+        .into_iter()
+        .filter_map(|file| file.ok())
+    {
+        if file.metadata().map(|x| x.is_file()).unwrap_or(false) {
+            let file_osstr = file.file_name();
+            let mut pretty_name: String = file_osstr.to_str().unwrap_or_default().into();
+            pretty_name = pretty_name
+                .replace(['_', '-'], " ")
+                .split('.')
+                .next()
+                .unwrap()
+                .into();
+
+            let font = Font {
+                name: pretty_name,
+                path: file.path().to_str().unwrap_or_default().into(),
+            };
+
+            fonts.push(font);
+        }
+    }
+
+    fonts
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_get_pretty_name1() {
+        if cfg!(windows) {
+            let r = get_pretty_name("c:\\pretty\\name2.scss");
+            assert_eq!(r, String::from("name2"));
+        } else {
+            let r = get_pretty_name("pretty/name1.scss");
+            assert_eq!(r, String::from("name1"));
+        }
+    }
+}

--- a/ui/src/components/chat/compose/mod.rs
+++ b/ui/src/components/chat/compose/mod.rs
@@ -5,7 +5,7 @@ mod quick_profile;
 use std::{path::PathBuf, rc::Rc};
 
 #[cfg(target_os = "windows")]
-use std::{time::Duration};
+use std::time::Duration;
 
 use dioxus::prelude::*;
 
@@ -34,7 +34,7 @@ use std::time::Duration;
 use tokio::time::sleep;
 
 use uuid::Uuid;
-use warp::{logging::tracing::log, raygun::ConversationType, crypto::DID};
+use warp::{crypto::DID, logging::tracing::log, raygun::ConversationType};
 use wry::webview::FileDropEvent;
 
 use crate::{
@@ -157,11 +157,11 @@ pub fn Compose(cx: Scope) -> Element {
                     state.write().mutate(Action::SidebarHidden(!current));
                 },
                 controls: cx.render(rsx!(get_controls{
-                    data: data2, 
+                    data: data2,
                     show_edit_group: show_edit_group.clone(),
                 })),
                 get_topbar_children {
-                    data: data.clone(), 
+                    data: data.clone(),
                     show_edit_group: show_edit_group.clone(),
                 }
             },
@@ -264,11 +264,14 @@ fn get_controls(cx: Scope<ComposeProps>) -> Element {
     let desktop = use_window(cx);
     let data = &cx.props.data;
     let active_chat = data.as_ref().map(|x| &x.active_chat);
-    let favorite = data.as_ref().map(|d: &Rc<ComposeData>| d.is_favorite).unwrap_or_default();
+    let favorite = data
+        .as_ref()
+        .map(|d: &Rc<ComposeData>| d.is_favorite)
+        .unwrap_or_default();
     let (conversation_type, creator) = if let Some(chat) = active_chat.as_ref() {
         (chat.conversation_type, chat.creator.clone())
     } else {
-       ( ConversationType::Direct, None)
+        (ConversationType::Direct, None)
     };
     let edit_group_activated = show_edit_group
         .get()
@@ -308,7 +311,7 @@ fn get_controls(cx: Scope<ComposeProps>) -> Element {
                             show_edit_group.set(Some(chat.id));
                         }
                     }
-                    
+
                 }
             })
         }

--- a/ui/src/components/chat/edit_group.rs
+++ b/ui/src/components/chat/edit_group.rs
@@ -111,7 +111,7 @@ pub fn EditGroup<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
         }
     });
 
-    let add_friends_with_sidebar =  rsx!(div {
+    let add_friends_with_sidebar = rsx!(div {
         id: "edit-group-add-friends-button-with_sidebar",
         key: "edit-group-add-friends-button-with_sidebar",
         Button {
@@ -129,7 +129,7 @@ pub fn EditGroup<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
         }
     });
 
-    let add_friends_without_sidebar =  rsx!(div {
+    let add_friends_without_sidebar = rsx!(div {
         id: "edit-group-add-friends-button-without-sidebar",
         width: "38px",
         key: "edit-group-add-friends-button-without-sidebar",
@@ -148,7 +148,7 @@ pub fn EditGroup<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
         }
     });
 
-    let remove_friends_with_sidebar =  rsx!(div {
+    let remove_friends_with_sidebar = rsx!(div {
         id: "edit-group-remove_friends_with_sidebar",
         key: "edit-group-remove_friends_with_sidebar",
         Button {
@@ -166,7 +166,7 @@ pub fn EditGroup<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
         }
     });
 
-    let remove_friends_without_sidebar =  rsx!(div {
+    let remove_friends_without_sidebar = rsx!(div {
         id: "edit-group-remove-friends-without-sidebar",
         width: "38px",
         key: "edit-group-remove-friends-without-sidebar",
@@ -196,7 +196,7 @@ pub fn EditGroup<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                        rsx! {
                         add_friends_without_sidebar,
                         remove_friends_without_sidebar,
-                       } 
+                       }
                     } else {
                         rsx! {
                             add_friends_with_sidebar,
@@ -230,7 +230,7 @@ pub fn EditGroup<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     name_prefix: friend_prefix.clone(),
                     selected_friends: selected_friends.clone()
                 },
-            }            
+            }
             if *edit_group_action.current() == EditGroupAction::Add {
                 rsx!(
                     div {

--- a/ui/src/components/settings/sub_pages/general.rs
+++ b/ui/src/components/settings/sub_pages/general.rs
@@ -1,12 +1,12 @@
 use common::language::{change_language, get_available_languages, get_local_text};
+use common::state::utils::{get_available_fonts, get_available_themes};
 use common::state::{action::ConfigAction, Action, State};
 use dioxus::prelude::*;
 use kit::components::slide_selector::{ButtonsFormat, SlideSelector};
 use kit::elements::{select::Select, switch::Switch};
 use warp::logging::tracing::log;
 
-use crate::utils::get_available_fonts;
-use crate::{components::settings::SettingSection, utils::get_available_themes};
+use crate::components::settings::SettingSection;
 
 #[allow(non_snake_case)]
 pub fn GeneralSettings(cx: Scope) -> Element {

--- a/ui/src/layouts/file_preview.rs
+++ b/ui/src/layouts/file_preview.rs
@@ -59,16 +59,17 @@ pub fn get_file_format(file_name: String) -> FileFormat {
 #[inline_props]
 #[allow(non_snake_case)]
 pub fn FilePreview(cx: Scope, file: File, _drop_handler: WindowDropHandler) -> Element {
+    let state = use_shared_state::<State>(cx)?;
     let file_format = get_file_format(file.name());
     let file_name = file.name();
     let thumbnail = file.thumbnail();
     let has_thumbnail = !file.thumbnail().is_empty();
     let desktop = use_window(cx);
-    let mut css_style = update_theme_colors();
+    let mut css_style = update_theme_colors(state);
     let update_state: &UseRef<Option<()>> = use_ref(cx, || Some(()));
 
     if update_state.read().is_some() {
-        css_style = update_theme_colors();
+        css_style = update_theme_colors(state);
         *update_state.write_silent() = None;
     }
 
@@ -248,9 +249,9 @@ fn resize_window(
     Some(())
 }
 
-fn update_theme_colors() -> String {
-    let state = State::load();
+fn update_theme_colors(state: UseSharedState<State>) -> String {
     let mut css_style = state
+        .read()
         .ui
         .theme
         .as_ref()

--- a/ui/src/layouts/unlock.rs
+++ b/ui/src/layouts/unlock.rs
@@ -54,7 +54,7 @@ pub fn UnlockLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -
     let account_exists: &UseState<Option<bool>> = use_state(cx, || None);
     let cmd_in_progress = use_state(cx, || false);
 
-    let state = use_state(cx, State::load);
+    let state = use_shared_state::<State>(cx)?;
 
     // this will be needed later
     use_future(cx, (), |_| {
@@ -156,7 +156,7 @@ pub fn UnlockLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -
         .unwrap_or_default();
 
     cx.render(rsx!(
-        style {update_theme_colors(&state.current())},
+        style {update_theme_colors(&state.read())},
         div {
             id: "unlock-layout",
             aria_label: "unlock-layout",
@@ -188,7 +188,7 @@ pub fn UnlockLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -
                             with_validation: Some(pin_validation),
                             with_clear_btn: true,
                             with_label: if STATIC_ARGS.cache_path.exists()
-                            {Some(get_welcome_message(&state.current()))}
+                            {Some(get_welcome_message(&state.read()))}
                             else
                                 {Some(get_local_text("unlock.create-password"))}, // TODO: Implement this.
                             ellipsis_on_label: Some(LabelWithEllipsis {

--- a/ui/src/layouts/unlock.rs
+++ b/ui/src/layouts/unlock.rs
@@ -54,7 +54,7 @@ pub fn UnlockLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -
     let account_exists: &UseState<Option<bool>> = use_state(cx, || None);
     let cmd_in_progress = use_state(cx, || false);
 
-    let state = use_shared_state::<State>(cx)?;
+    let state = use_state(cx, State::load);
 
     // this will be needed later
     use_future(cx, (), |_| {
@@ -156,7 +156,7 @@ pub fn UnlockLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -
         .unwrap_or_default();
 
     cx.render(rsx!(
-        style {update_theme_colors(&state.read())},
+        style {update_theme_colors(&state.current())},
         div {
             id: "unlock-layout",
             aria_label: "unlock-layout",
@@ -188,7 +188,7 @@ pub fn UnlockLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -
                             with_validation: Some(pin_validation),
                             with_clear_btn: true,
                             with_label: if STATIC_ARGS.cache_path.exists()
-                            {Some(get_welcome_message(&state.read()))}
+                            {Some(get_welcome_message(&state.current()))}
                             else
                                 {Some(get_local_text("unlock.create-password"))}, // TODO: Implement this.
                             ellipsis_on_label: Some(LabelWithEllipsis {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -305,7 +305,6 @@ fn bootstrap(cx: Scope) -> Element {
 fn auth_page_manager(cx: Scope) -> Element {
     let page = use_state(cx, || AuthPages::Unlock);
     let pin = use_ref(cx, String::new);
-    use_shared_state_provider(cx, || State::load());
     cx.render(rsx!(match &*page.current() {
         AuthPages::Success(ident) => rsx!(app_bootstrap {
             identity: ident.clone()
@@ -423,8 +422,7 @@ fn get_extensions() -> Result<HashMap<String, UplinkExtension>, Box<dyn std::err
 #[inline_props]
 pub fn app_bootstrap(cx: Scope, identity: multipass::identity::Identity) -> Element {
     log::trace!("rendering app_bootstrap");
-    let shared_state = use_shared_state::<State>(cx)?;
-    let mut state = shared_state.write_silent();
+    let mut state = State::load();
 
     if STATIC_ARGS.use_mock {
         assert!(state.friends().initialized);
@@ -450,6 +448,7 @@ pub fn app_bootstrap(cx: Scope, identity: multipass::identity::Identity) -> Elem
     };
     state.ui.metadata = window_meta;
 
+    use_shared_state_provider(cx, || state);
     use_shared_state_provider(cx, DownloadState::default);
 
     cx.render(rsx!(crate::app {}))

--- a/ui/src/utils/mod.rs
+++ b/ui/src/utils/mod.rs
@@ -1,18 +1,8 @@
-use common::{
-    get_extras_dir,
-    state::{self, ui::Font, Theme},
-    STATIC_ARGS,
-};
+use common::{state, STATIC_ARGS};
 use filetime::FileTime;
 use warp::logging::tracing::log;
 
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
-use titlecase::titlecase;
-
-use walkdir::WalkDir;
+use std::{fs, path::Path};
 
 use kit::User as UserInfo;
 
@@ -21,82 +11,6 @@ use crate::{window_manager::WindowManagerCmd, WINDOW_CMD_CH};
 pub mod auto_updater;
 pub mod format_timestamp;
 pub mod lifecycle;
-
-pub fn get_available_themes() -> Vec<Theme> {
-    let mut themes = vec![];
-
-    let mut add_to_themes = |themes_path: &PathBuf| {
-        log::debug!("add_to_themes: {}", themes_path.to_string_lossy());
-        for file in WalkDir::new(themes_path)
-            .into_iter()
-            .filter_map(|file| file.ok())
-        {
-            if file.metadata().map(|x| x.is_file()).unwrap_or(false) {
-                let theme_path = file.path().display().to_string();
-                let pretty_theme_str = get_pretty_name(&theme_path);
-                let pretty_theme_str = titlecase(&pretty_theme_str);
-
-                let styles = fs::read_to_string(&theme_path).unwrap_or_default();
-
-                let theme = Theme {
-                    filename: theme_path.to_owned(),
-                    name: pretty_theme_str.to_owned(),
-                    styles,
-                };
-                if !themes.contains(&theme) {
-                    themes.push(theme);
-                }
-            }
-        }
-    };
-    add_to_themes(&STATIC_ARGS.themes_path);
-    if let Ok(p) = get_extras_dir() {
-        add_to_themes(&p.join("themes"));
-    }
-
-    themes.sort_by_key(|theme| theme.name.clone());
-    themes.dedup();
-
-    themes
-}
-
-pub fn get_available_fonts() -> Vec<Font> {
-    let mut fonts = vec![];
-
-    for file in WalkDir::new(&STATIC_ARGS.fonts_path)
-        .into_iter()
-        .filter_map(|file| file.ok())
-    {
-        if file.metadata().map(|x| x.is_file()).unwrap_or(false) {
-            let file_osstr = file.file_name();
-            let mut pretty_name: String = file_osstr.to_str().unwrap_or_default().into();
-            pretty_name = pretty_name
-                .replace(['_', '-'], " ")
-                .split('.')
-                .next()
-                .unwrap()
-                .into();
-
-            let font = Font {
-                name: pretty_name,
-                path: file.path().to_str().unwrap_or_default().into(),
-            };
-
-            fonts.push(font);
-        }
-    }
-
-    fonts
-}
-
-fn get_pretty_name<S: AsRef<str>>(name: S) -> String {
-    let path = Path::new(name.as_ref());
-    let last = path
-        .file_name()
-        .and_then(|p| Path::new(p).file_stem())
-        .unwrap_or_default();
-    last.to_string_lossy().into()
-}
 
 pub fn unzip_prism_langs() {
     if !STATIC_ARGS.production_mode || !cfg!(target_os = "windows") {
@@ -235,22 +149,6 @@ impl Drop for WindowDropHandler {
         let cmd_tx = WINDOW_CMD_CH.tx.clone();
         if let Err(_e) = cmd_tx.send(self.cmd) {
             // todo: log error
-        }
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_get_pretty_name1() {
-        if cfg!(windows) {
-            let r = get_pretty_name("c:\\pretty\\name2.scss");
-            assert_eq!(r, String::from("name2"));
-        } else {
-            let r = get_pretty_name("pretty/name1.scss");
-            assert_eq!(r, String::from("name1"));
         }
     }
 }


### PR DESCRIPTION
### What this PR does 📖

- undo regression caused by #630. making themes not reload again
- make `State::load` also handle language loading which fixes the loging page not respecting language

### Which issue(s) this PR fixes 🔨

- Resolve #647

