### PR TITLE
chore(appium): change resolution on appium windows runner

### DIFF
--- a/.github/workflows/ui-test-windows.yml
+++ b/.github/workflows/ui-test-windows.yml
@@ -74,6 +74,10 @@ jobs:
           repository: Satellite-im/testing-uplink
           path: "./appium-tests"
 
+      - name: Change resolution on Windows Runner
+        run: Set-DisplayResolution -Width 1920 -Height 1080 -Force
+        shell: powershell
+
       - name: Setup Node.js 🔨
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
### What this PR does 📖

- Added step to change resolution in the Windows Github Runner when executing the appium tests
- This step can help reduce failures on windows test executions since GH assign by default a slow resolution to the runner

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

