### PR TITLE
chore(appium): update appium workflow to use toolchain 1.68.2

### DIFF
--- a/.github/workflows/ui-test-execution.yml
+++ b/.github/workflows/ui-test-execution.yml
@@ -21,24 +21,14 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up cargo cache 🛠️
-        uses: actions/cache@v3
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+        uses: Swatinem/rust-cache@v2
 
       - name: Install Rust 💿
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
-          profile: minimal
+          toolchain: 1.68.2
           override: true
+          components: rustfmt, clippy
 
       - name: Install Protobuf 💿
         uses: arduino/setup-protoc@v1
@@ -48,11 +38,7 @@ jobs:
       - name: Run cargo update 🌐
         run: cargo update
 
-      - name: Run cargo clean 🧹
-        run: cargo clean
-
       - name: Build executable 🖥️
-        continue-on-error: true
         run: make dmg
 
       - name: Create ZIP archive 🗳️

--- a/.github/workflows/ui-test-windows.yml
+++ b/.github/workflows/ui-test-windows.yml
@@ -20,22 +20,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up cargo cache 🛠️
-        uses: actions/cache@v3
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+        uses: Swatinem/rust-cache@v2
 
       - name: Install Rust 💿
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.68.2
           override: true
           components: rustfmt, clippy
 
@@ -46,9 +36,6 @@ jobs:
 
       - name: Run cargo update 🌐
         run: cargo update
-
-      - name: Run cargo clean 🧹
-        run: cargo clean
 
       - name: Build app 🖥️
         run: cargo build --release --package uplink -F production_mode


### PR DESCRIPTION
### What this PR does 📖

- Appium workflow for MacOS is failing on the build job because the install rust step needs to be updated to  use toolchain: 1.68.2 (which is the one that is setup on the build dmg workflow now)
- Applying this change and other minor improvements to appium workflows, which fixes the build job

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

