### PR TITLE
fix(workflow): linux and mac build scripts

### DIFF
--- a/.github/workflows/build-dmg-universal.yml
+++ b/.github/workflows/build-dmg-universal.yml
@@ -52,6 +52,7 @@ jobs:
           security find-identity -p codesigning -v
           security list-keychains
           make dmg-universal
+          /usr/bin/codesign -vvv --deep --entitlements ui/extra/entitlements.plist --strict --options=runtime --force target/release/macos/Uplink.dmg
       - name: "Notarize executable"
         env:
           PROD_MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.MACOS_NOTARIZATION_APPLE_ID }}

--- a/.github/workflows/build-release-linux.yml
+++ b/.github/workflows/build-release-linux.yml
@@ -26,7 +26,7 @@ jobs:
           toolchain: 1.68.2
           override: true
       - run: cargo build --release -F production_mode
-      - run: ./build_linux_installer uplink ${{ github.ref_name }} amd64
+      - run: bash build_linux_installer.sh uplink ${{ github.ref_name }} amd64
 
       - name: Github Release
         uses: softprops/action-gh-release@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,7 +1339,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "base64 0.20.0",
@@ -2485,7 +2485,7 @@ dependencies = [
 
 [[package]]
 name = "extensions"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "derive_more",
  "dioxus",
@@ -3744,7 +3744,7 @@ dependencies = [
 
 [[package]]
 name = "icons"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dioxus",
  "dioxus-html",
@@ -4209,7 +4209,7 @@ dependencies = [
 
 [[package]]
 name = "kit"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "common",
@@ -8820,7 +8820,7 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "uplink"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ opt-level = 3
 codegen-units = 1
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 rust-version = "1.68"
 
 [workspace.dependencies]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 TARGET = uplink
 
-SIGNING_KEY = LOCAL
 ASSETS_DIR = ui/extra
 RELEASE_DIR = target/release
 
@@ -33,12 +32,8 @@ $(TARGET)-universal:
 	MACOSX_DEPLOYMENT_TARGET="10.11" cargo build --release --target=x86_64-apple-darwin -F production_mode
 	MACOSX_DEPLOYMENT_TARGET="10.11" cargo build --release --target=aarch64-apple-darwin -F production_mode
 	@lipo target/{x86_64,aarch64}-apple-darwin/release/$(TARGET) -create -output $(APP_BINARY)
-	/usr/bin/codesign -vvv --deep --entitlements $(ASSETS_DIR)/entitlements.plist --strict --options=runtime --force -s $(SIGNING_KEY) $(APP_BINARY)
-ifeq ($(SIGNING_KEY),LOCAL)
-	@echo "Local Build, no signing"
-else
-	/usr/bin/codesign -vvv --deep --entitlements $(ASSETS_DIR)/entitlements.plist --strict --options=runtime --force -s $(SIGNING_KEY) $(APP_BINARY)
-endif
+# /usr/bin/codesign -vvv --deep --entitlements $(ASSETS_DIR)/entitlements.plist --strict --options=runtime --force -s $(SIGNING_KEY) $(APP_BINARY)
+
 app: $(APP_NAME)-native ## Create a Uplink.app
 app-universal: $(APP_NAME)-universal ## Create a universal Uplink.app
 $(APP_NAME)-%: $(TARGET)-%
@@ -59,12 +54,8 @@ $(APP_NAME)-%: $(TARGET)-%
 
 	mkdir -p $(APP_DIR)/$(APP_NAME)/Contents/Resources/extensions
 	cp -r $(RELEASE_DIR)/*.dylib $(APP_DIR)/$(APP_NAME)/Contents/Resources/extensions
+# /usr/bin/codesign -vvv --deep --entitlements $(ASSETS_DIR)/entitlements.plist --strict --options=runtime --force -s $(SIGNING_KEY) $(APP_DIR)/$(APP_NAME)
 
-ifeq ($(SIGNING_KEY),LOCAL)
-	@echo "Local Build, no signing"
-else
-	/usr/bin/codesign -vvv --deep --entitlements $(ASSETS_DIR)/entitlements.plist --strict --options=runtime --force -s $(SIGNING_KEY) $(APP_DIR)/$(APP_NAME)
-endif
 dmg: $(DMG_NAME)-native ## Create a Uplink.dmg
 dmg-universal: $(DMG_NAME)-universal ## Create a universal Uplink.dmg
 $(DMG_NAME)-%: $(APP_NAME)-%
@@ -76,12 +67,8 @@ $(DMG_NAME)-%: $(APP_NAME)-%
 		-srcfolder $(APP_DIR) \
 		-ov -format UDZO
 	@echo "Packed '$(APP_NAME)' in '$(APP_DIR)'"
+# /usr/bin/codesign -vvv --deep --entitlements $(ASSETS_DIR)/entitlements.plist --strict --options=runtime --force -s $(SIGNING_KEY) $(DMG_DIR)/$(DMG_NAME)
 
-ifeq ($(SIGNING_KEY),LOCAL)
-	@echo "Local Build, no signing"
-else
-	/usr/bin/codesign -vvv --deep --entitlements $(ASSETS_DIR)/entitlements.plist --strict --options=runtime --force -s $(SIGNING_KEY) $(DMG_DIR)/$(DMG_NAME)
-endif
 install: $(INSTALL)-native ## Mount disk image
 install-universal: $(INSTALL)-native ## Mount universal disk image
 $(INSTALL)-%: $(DMG_NAME)-%


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- I think the Linux workflow failed because of a missing file extension for `build_linux_installer.sh`
- the Mac workflow failed because the Makefile tried to codesign with the wrong key. Hopefully moving this step out of the makefile and into the github workflow, and removing the `-s` option (for signing key) fixes it. 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

