### PR TITLE
fix(dmg): put the codesign steps back in the makefile

### DIFF
--- a/.github/workflows/build-dmg-universal.yml
+++ b/.github/workflows/build-dmg-universal.yml
@@ -52,7 +52,6 @@ jobs:
           security find-identity -p codesigning -v
           security list-keychains
           make dmg-universal
-          /usr/bin/codesign -vvv --deep --entitlements ui/extra/entitlements.plist --strict --options=runtime --force target/release/macos/Uplink.dmg
       - name: "Notarize executable"
         env:
           PROD_MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.MACOS_NOTARIZATION_APPLE_ID }}

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ $(TARGET)-universal:
 	@lipo target/{x86_64,aarch64}-apple-darwin/release/$(TARGET) -create -output $(APP_BINARY)
 	@lipo target/{x86_64,aarch64}-apple-darwin/release/libclear_all.dylib -create -output $(RELEASE_DIR)/libclear_all.dylib
 	@lipo target/{x86_64,aarch64}-apple-darwin/release/libemoji_selector.dylib -create -output $(RELEASE_DIR)/libemoji_selector.dylib
-# /usr/bin/codesign -vvv --deep --entitlements $(ASSETS_DIR)/entitlements.plist --strict --options=runtime --force -s $(SIGNING_KEY) $(APP_BINARY)
+	/usr/bin/codesign -vvv --deep --entitlements $(ASSETS_DIR)/entitlements.plist --strict --options=runtime --force $(APP_BINARY)
 
 app: $(APP_NAME)-native ## Create a Uplink.app
 app-universal: $(APP_NAME)-universal ## Create a universal Uplink.app
@@ -69,7 +69,7 @@ $(DMG_NAME)-%: $(APP_NAME)-%
 		-srcfolder $(APP_DIR) \
 		-ov -format UDZO
 	@echo "Packed '$(APP_NAME)' in '$(APP_DIR)'"
-# /usr/bin/codesign -vvv --deep --entitlements $(ASSETS_DIR)/entitlements.plist --strict --options=runtime --force -s $(SIGNING_KEY) $(DMG_DIR)/$(DMG_NAME)
+	/usr/bin/codesign -vvv --deep --entitlements $(ASSETS_DIR)/entitlements.plist --strict --options=runtime --force $(DMG_DIR)/$(DMG_NAME)
 
 install: $(INSTALL)-native ## Mount disk image
 install-universal: $(INSTALL)-native ## Mount universal disk image


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- try to fix this:
![image](https://user-images.githubusercontent.com/8636602/235208692-06803b96-5ebc-485e-a372-d7fe1a88c4d3.png)

the Makefile used to use `codesign` at multiple steps. maybe it's required to sign both the binary and the dmg. 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

