### PR TITLE
chore(appium): continue next steps on building app

### DIFF
--- a/.github/workflows/ui-test-execution.yml
+++ b/.github/workflows/ui-test-execution.yml
@@ -40,6 +40,7 @@ jobs:
 
       - name: Build executable 🖥️
         run: make dmg
+        continue-on-error: true
 
       - name: Create ZIP archive 🗳️
         run: |

--- a/.github/workflows/ui-test-windows.yml
+++ b/.github/workflows/ui-test-windows.yml
@@ -39,6 +39,7 @@ jobs:
 
       - name: Build app 🖥️
         run: cargo build --release --package uplink -F production_mode
+        continue-on-error: true
 
       - name: Upload Artifact ⬆️
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
### What this PR does 📖

- Adding continue-on-error: true on build steps from ui automated tests workflows, to avoid that the workflow stops when receiving this error on build step, even when the app build was created 

![image](https://user-images.githubusercontent.com/35935591/235226336-15f77f35-58b8-4d84-8408-6c51c2a576ca.png)

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

