### PR TITLE
fix(rendering): don't re-render every 5 seconds

### DIFF
--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -642,6 +642,7 @@ fn app(cx: Scope) -> Element {
                 if !state.read().has_toasts() {
                     continue;
                 }
+                log::trace!("decrement toasts");
                 state.write().decrement_toasts();
             }
         }
@@ -653,7 +654,10 @@ fn app(cx: Scope) -> Element {
         async move {
             loop {
                 sleep(Duration::from_secs(STATIC_ARGS.typing_indicator_timeout)).await;
-                state.write().clear_typing_indicator(Instant::now());
+                if state.write_silent().clear_typing_indicator(Instant::now()) {
+                    log::trace!("clear typing indicator");
+                    state.write();
+                }
             }
         }
     });
@@ -665,6 +669,7 @@ fn app(cx: Scope) -> Element {
             loop {
                 // simply triggering an update will refresh the message timestamps
                 sleep(Duration::from_secs(60)).await;
+                log::trace!("refresh timestamps");
                 state.write();
             }
         }

--- a/ui/src/window_manager/mod.rs
+++ b/ui/src/window_manager/mod.rs
@@ -18,7 +18,7 @@ pub struct WindowManagerCmdChannels {
     pub rx: WindowManagerCmdRx,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 #[allow(clippy::enum_variant_names)]
 pub enum WindowManagerCmd {
     ClosePopout,
@@ -32,6 +32,7 @@ pub async fn handle_cmd(
     cmd: WindowManagerCmd,
     desktop: DesktopContext,
 ) {
+    log::trace!("window manager command: {cmd:?}");
     match cmd {
         WindowManagerCmd::ClosePopout => {
             state.write().mutate(Action::ClearCallPopout(desktop));


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- the function to clear notifications returns a `bool` so you can use `write_silent()` and only update state if the typing indicator actually needs to be cleared. Not sure when `main.rs` stopped using that functionality, but this PR changes it back. 
- also add some more trace logs. 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

