### PR TITLE
chore(appium): build only for x86_64 target on appium workflow

### DIFF
--- a/.github/workflows/ui-test-execution.yml
+++ b/.github/workflows/ui-test-execution.yml
@@ -40,6 +40,9 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: "10.13"
         run: |
           rustup target add x86_64-apple-darwin aarch64-apple-darwin
+          
+      - name: Remove aarch64 target from Makefile make app on this workflow
+        run: perl -i -pe 's/MACOSX_DEPLOYMENT_TARGET="10.11" cargo build --release --target=aarch64-apple-darwin -F production_mode//g' Makefile
 
       - name: Run cargo update 🌐
         run: cargo update

--- a/.github/workflows/ui-test-windows.yml
+++ b/.github/workflows/ui-test-windows.yml
@@ -34,9 +34,6 @@ jobs:
         with:
           repo-token: ${{env.GITHUB_TOKEN}}
 
-      - name: Remove aarch64 target from Makefile make app on this workflow
-        run: perl -i -pe 's/MACOSX_DEPLOYMENT_TARGET="10.11" cargo build --release --target=aarch64-apple-darwin -F production_mode//g' Makefile
-
       - name: Run cargo update 🌐
         run: cargo update
 

--- a/.github/workflows/ui-test-windows.yml
+++ b/.github/workflows/ui-test-windows.yml
@@ -34,6 +34,9 @@ jobs:
         with:
           repo-token: ${{env.GITHUB_TOKEN}}
 
+      - name: Remove aarch64 target from Makefile make app on this workflow
+        run: perl -i -pe 's/MACOSX_DEPLOYMENT_TARGET="10.11" cargo build --release --target=aarch64-apple-darwin -F production_mode//g' Makefile
+
       - name: Run cargo update 🌐
         run: cargo update
 


### PR DESCRIPTION
### What this PR does 📖

- Removing target x86_64 on appium workflow buildstep by updating the makefile under workflow execution
- This should help to reduce the build time on the workflow. Change is not committed to the makefile file and only applied under workflow execution

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

