### PR TITLE
chore(appium): build only for x86_64 target on appium workflow - revert

### DIFF
--- a/.github/workflows/ui-test-execution.yml
+++ b/.github/workflows/ui-test-execution.yml
@@ -40,9 +40,6 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: "10.13"
         run: |
           rustup target add x86_64-apple-darwin aarch64-apple-darwin
-          
-      - name: Remove aarch64 target from Makefile make app on this workflow
-        run: perl -i -pe 's/MACOSX_DEPLOYMENT_TARGET="10.11" cargo build --release --target=aarch64-apple-darwin -F production_mode//g' Makefile
 
       - name: Run cargo update 🌐
         run: cargo update


### PR DESCRIPTION
Reverts Satellite-im/Uplink#770

After speaking with Luis, we are gonna revert this change because the artifact wasn't compiled properly.
