### PR TITLE
fix(EditMsg): Fix jump line when enter on edit msg

### DIFF
--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -222,10 +222,16 @@ struct EditProps<'a> {
 #[allow(non_snake_case)]
 fn EditMsg<'a>(cx: Scope<'a, EditProps<'a>>) -> Element<'a> {
     log::trace!("rendering EditMsg");
+    let mut input = cx.props.text.clone();
+    let length = input.len();
+    if input.ends_with('\n') {
+        input.truncate(length - 1);
+    }
+
     cx.render(rsx!(textarea::Input {
         id: cx.props.id.clone(),
         ignore_focus: false,
-        value: cx.props.text.clone(),
+        value: input,
         onchange: move |_| {},
         onreturn: move |(s, is_valid, _): (String, bool, _)| {
             if is_valid && !s.is_empty() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
### 1. Fix jump line when enter on edit msg


https://user-images.githubusercontent.com/63157656/236274441-2a7ab9c6-6ea0-48de-9dbf-3a35f0ed930d.mov




- 

### Which issue(s) this PR fixes 🔨

- Resolve #768 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

