### PR TITLE
feat(update): display toast after checking for updates

### DIFF
--- a/common/locales/en-US/main.ftl
+++ b/common/locales/en-US/main.ftl
@@ -250,6 +250,7 @@ settings-about = About Settings
     .open-website-description = Opens our website in your default web browser.
     .open-codebase = Open Source Code
     .open-codebase-description = Opens the codebase in your default web browser.
+    .no-update-available = Your software is up to date!
 
 media-player = Media Player 
     .enable-camera = Enable Camera 

--- a/common/locales/en-US/main.ftl
+++ b/common/locales/en-US/main.ftl
@@ -251,7 +251,7 @@ settings-about = About Settings
     .open-codebase = Open Source Code
     .open-codebase-description = Opens the codebase in your default web browser.
     .no-update-available = Your software is up to date!
-    .update-check-error = There was an error checking for the update. Please report this!
+    .update-check-error = Failed to fetch update. Please check your internet connection.
     
 media-player = Media Player 
     .enable-camera = Enable Camera 

--- a/common/locales/en-US/main.ftl
+++ b/common/locales/en-US/main.ftl
@@ -251,7 +251,8 @@ settings-about = About Settings
     .open-codebase = Open Source Code
     .open-codebase-description = Opens the codebase in your default web browser.
     .no-update-available = Your software is up to date!
-
+    .update-check-error = There was an error checking for the update. Please report this!
+    
 media-player = Media Player 
     .enable-camera = Enable Camera 
     .fullscreen = Fullscreen

--- a/ui/src/components/settings/sub_pages/about.rs
+++ b/ui/src/components/settings/sub_pages/about.rs
@@ -47,6 +47,14 @@ pub fn AboutPage(cx: Scope) -> Element {
                         download_available.set(opt);
                     }
                     Err(e) => {
+                        state.write().mutate(Action::AddToastNotification(
+                            ToastNotification::init(
+                                "".into(),
+                                get_local_text("settings-about.update-check-error"),
+                                None,
+                                4,
+                            ),
+                        ));
                         log::error!("failed to check for updates: {e}");
                     }
                 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- on the about page, after checking for updates, if no update is available, communicate this to the user with a toast

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

