### PR TITLE
fix(notification): Move notification into separate thread

### DIFF
--- a/common/src/notifications.rs
+++ b/common/src/notifications.rs
@@ -16,7 +16,7 @@ pub fn push_notification(
             .body(&content)
             .timeout(timeout)
             .show();
-        
+
         if let Some(sound) = notification_sound {
             Play(sound);
         }

--- a/common/src/notifications.rs
+++ b/common/src/notifications.rs
@@ -9,16 +9,18 @@ pub fn push_notification(
     notification_sound: Option<Sounds>,
     timeout: notify_rust::Timeout,
 ) {
-    let summary = format!("Uplink - {title}");
-    let _n = Notification::new()
-        .summary(summary.as_ref())
-        .body(&content)
-        .timeout(timeout)
-        .show();
-
-    if let Some(sound) = notification_sound {
-        Play(sound);
-    }
+    std::thread::spawn(move || {
+        let summary = format!("Uplink - {title}");
+        let _n = Notification::new()
+            .summary(summary.as_ref())
+            .body(&content)
+            .timeout(timeout)
+            .show();
+        
+        if let Some(sound) = notification_sound {
+            Play(sound);
+        }
+    });
 }
 
 pub fn set_badge(count: u32) -> Result<(), String> {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Move notification into separate thread

### Which issue(s) this PR fixes 🔨

- N/A

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
During testing for a separate PR, I begun to notice that messaging and other task performed were being blocked for a short duration. After investigating, it was determined that `Notification` was blocking, which would only be noticeable if there is an issue with the system notification handler, or if it has trouble communicating to one. Even without any issues, this function should be move into a separate thread due to its blocking nature to the thread. 
