### PR TITLE
chore(windows): add signing task to windows action

### DIFF
--- a/.github/workflows/build-release-windows.yml
+++ b/.github/workflows/build-release-windows.yml
@@ -13,7 +13,8 @@ env:
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on:
+      labels: windows-latest-8-cores
 
     permissions:
       contents: write
@@ -49,6 +50,16 @@ jobs:
       
       - name: Build Installer 
         run: cargo wix --package uplink --no-build --nocapture
+        
+      - name: Sign Windows Installer
+        uses: dlemstra/code-sign-action@v1
+        with:
+          certificate: '${{ secrets.WINDOWS_CERTIFICATE }}'
+          password: '${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}'
+          folder: 'target/wix'
+          recursive: true
+          files: |
+            target/wix/*.msi
 
       - name: Github Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
This signs the windows app as part of the tag/release process

I forked the repo so I could make releases without setting off the update notification here. Check:

https://github.com/Satellite-im/Uplink-build-testing/releases/tag/0.0.2

We can delete that repo after this goes in.
- 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

