### PR TITLE
update(ui): add aria labels required for ui tests locators

### DIFF
--- a/kit/src/components/context_menu/mod.rs
+++ b/kit/src/components/context_menu/mod.rs
@@ -18,6 +18,7 @@ pub struct ItemProps<'a> {
     #[props(optional)]
     danger: Option<bool>,
     should_render: Option<bool>,
+    aria_label: Option<String>,
 }
 
 /// Tells the parent the menu was interacted with.
@@ -39,10 +40,12 @@ pub fn ContextItem<'a>(cx: Scope<'a, ItemProps<'a>>) -> Element<'a> {
     } else {
         "context-item"
     };
+
+    let aria_label = cx.props.aria_label.clone().unwrap_or_default();
     cx.render(rsx! {
         button {
             class: "{class}",
-            aria_label: "Context Item",
+            aria_label: "{aria_label}",
             onclick: move |e| emit(&cx, e),
             (cx.props.icon.is_some()).then(|| {
                 let icon = cx.props.icon.unwrap_or(icons::outline::Shape::Cog6Tooth);

--- a/kit/src/components/link_embed/mod.rs
+++ b/kit/src/components/link_embed/mod.rs
@@ -108,13 +108,16 @@ pub fn EmbedLinks(cx: Scope<LinkEmbedProps>) -> Element {
                     class: format_args!("link-embed-container {}", if cx.props.remote {"link-embed-remote"} else {""}),
                     div {
                         class: "link-embed",
+                        aria_label: "link-embed",
                         div {
                             class: "embed-icon",
+                            aria_label: "embed-icon",
                             img {
                                 src: "{meta.icon}"
                             },
                             a {
                                 class: "link-title",
+                                aria_label: "link-title",
                                 href: "{cx.props.link}",
                                 "{title}"
                             }
@@ -122,6 +125,7 @@ pub fn EmbedLinks(cx: Scope<LinkEmbedProps>) -> Element {
                         h2 {},
                         div {
                             class: "embed-details",
+                            aria_label: "embed-details",
                             p {
                                 "{desc}"
                             }

--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -144,7 +144,17 @@ pub fn Message<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     } else { "".into() }
                 )
             },
-            aria_label: "Message",
+            aria_label: {
+                format_args!(
+                    "{}-{}",
+                    if cx.props.order.is_some() {
+                        order.to_string()
+                    } else { "".into() },
+                    if is_remote {
+                        "remote"
+                    } else { "local" }
+                )
+            },
             white_space: "pre-wrap",
             (cx.props.with_content.is_some()).then(|| rsx! (
                     div {

--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -146,8 +146,7 @@ pub fn Message<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             },
             aria_label: {
                 format_args!(
-                    "{}-{}",
-                    cx.props.order.map(|o| o.to_string()).unwrap_or_default(),
+                    "message-{}",
                     if is_remote {
                         "remote"
                     } else { "local" }

--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -147,9 +147,7 @@ pub fn Message<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             aria_label: {
                 format_args!(
                     "{}-{}",
-                    if cx.props.order.is_some() {
-                        order.to_string()
-                    } else { "".into() },
+                    cx.props.order.map(|o| o.to_string()).unwrap_or_default(),
                     if is_remote {
                         "remote"
                     } else { "local" }

--- a/kit/src/components/message_group/mod.rs
+++ b/kit/src/components/message_group/mod.rs
@@ -24,7 +24,9 @@ pub fn MessageGroup<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     cx.render(rsx! (
         div {
             class: "message-group-wrap",
-            aria_label: "message-group-wrap",
+            aria_label: {
+                format_args!("message-group-wrap{}", if remote { "-remote" } else { "local" })
+            },
             remote.then(|| rsx!(
                 &cx.props.user_image
             ))

--- a/kit/src/components/message_group/mod.rs
+++ b/kit/src/components/message_group/mod.rs
@@ -25,7 +25,7 @@ pub fn MessageGroup<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
         div {
             class: "message-group-wrap",
             aria_label: {
-                format_args!("message-group-wrap{}", if remote { "-remote" } else { "local" })
+                format_args!("message-group-wrap-{}", if remote { "remote" } else { "local" })
             },
             remote.then(|| rsx!(
                 &cx.props.user_image

--- a/kit/src/components/message_typing/mod.rs
+++ b/kit/src/components/message_typing/mod.rs
@@ -15,6 +15,7 @@ pub fn MessageTyping<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             &cx.props.user_image,
             div {
                 class: "message-typing",
+                aria_label: "message-typing-indicator",
                 div { class: "dot dot-1" },
                 div { class: "dot dot-2" },
                 div { class: "dot dot-3" }

--- a/kit/src/components/toast/mod.rs
+++ b/kit/src/components/toast/mod.rs
@@ -54,8 +54,10 @@ pub fn Toast<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             )),
             div {
                 class: "toast-content",
+                aria_label: "toast-content",
                 Label {
                     text: title,
+                    aria_label: "toast-title".into(),
                 },
                 p {
                     "{content}",
@@ -65,6 +67,7 @@ pub fn Toast<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 icon: Icon::XMark,
                 appearance: Appearance::Secondary,
                 onpress: move |_| cx.props.on_close.call(cx.props.id),
+                aria_label: "close-toast".into(),
             }
         }
     ))

--- a/kit/src/elements/label/mod.rs
+++ b/kit/src/elements/label/mod.rs
@@ -13,10 +13,12 @@ pub struct Props {
     #[props(optional)]
     label_with_ellipsis: Option<LabelWithEllipsis>,
     text: String,
+    aria_label: Option<String>,
 }
 
 #[allow(non_snake_case)]
 pub fn Label(cx: Scope<Props>) -> Element {
+    let aria_label = cx.props.aria_label.clone().unwrap_or_default();
     let (apply_ellipsis, padding_right) =
         if let Some(label_with_ellipsis) = cx.props.label_with_ellipsis.clone() {
             (
@@ -29,6 +31,7 @@ pub fn Label(cx: Scope<Props>) -> Element {
 
     cx.render(rsx!(
         label {
+            aria_label: "{aria_label}",
             class: if apply_ellipsis {"wrap-text"} else {""},
             padding_right: "{padding_right}px",
             "{cx.props.text}"

--- a/kit/src/layout/chatbar/mod.rs
+++ b/kit/src/layout/chatbar/mod.rs
@@ -81,6 +81,7 @@ pub fn Reply<'a>(cx: Scope<'a, ReplyProps<'a>>) -> Element<'a> {
             aria_label: "inline-reply",
             Label {
                 text: cx.props.label.clone(),
+                aria_label: "inline-reply-header".into(),
             },
             Button {
                 small: true,

--- a/ui/src/components/chat/compose/messages.rs
+++ b/ui/src/components/chat/compose/messages.rs
@@ -295,6 +295,7 @@ pub fn get_messages(cx: Scope, data: Rc<super::ComposeData>) -> Element {
             div {
                 // key: "encrypted-notification-0001",
                 class: "msg-container-end",
+                aria_label: "messages-secured-alert",
                 IconElement {
                     icon:  Icon::LockClosed,
                 },
@@ -563,6 +564,7 @@ fn render_messages<'a>(cx: Scope<'a, MessagesProps<'a>>) -> Element<'a> {
             items: cx.render(rsx!(
                 ContextItem {
                     icon: Icon::ArrowLongLeft,
+                    aria_label: "messages-reply".into(),
                     text: get_local_text("messages.reply"),
                     onpress: move |_| {
                         state
@@ -572,6 +574,7 @@ fn render_messages<'a>(cx: Scope<'a, MessagesProps<'a>>) -> Element<'a> {
                 },
                 ContextItem {
                     icon: Icon::FaceSmile,
+                    aria_label: "messages-react".into(),
                     text: get_local_text("messages.react"),
                     onpress: move |_| {
                         state.write().ui.ignore_focus = true;
@@ -580,6 +583,7 @@ fn render_messages<'a>(cx: Scope<'a, MessagesProps<'a>>) -> Element<'a> {
                 },
                 ContextItem {
                     icon: Icon::Pencil,
+                    aria_label: "messages-edit".into(),
                     text: get_local_text("messages.edit"),
                     should_render: !cx.props.is_remote
                         && edit_msg.get().map(|id| id != _msg_uuid).unwrap_or(true),
@@ -590,6 +594,7 @@ fn render_messages<'a>(cx: Scope<'a, MessagesProps<'a>>) -> Element<'a> {
                 },
                 ContextItem {
                     icon: Icon::Pencil,
+                    aria_label: "messages-cancel-edit".into(),
                     text: get_local_text("messages.cancel-edit"),
                     should_render: !cx.props.is_remote
                         && edit_msg.get().map(|id| id == _msg_uuid).unwrap_or(false),
@@ -601,6 +606,7 @@ fn render_messages<'a>(cx: Scope<'a, MessagesProps<'a>>) -> Element<'a> {
                 ContextItem {
                     icon: Icon::Trash,
                     danger: true,
+                    aria_label: "messages-delete".into(),
                     text: get_local_text("uplink.delete"),
                     should_render: sender_is_self,
                     onpress: move |_| {

--- a/ui/src/components/chat/compose/quick_profile.rs
+++ b/ui/src/components/chat/compose/quick_profile.rs
@@ -262,6 +262,7 @@ pub fn QuickProfileContext<'a>(cx: Scope<'a, QuickProfileProps<'a>>) -> Element<
             if is_self {
                 rsx!(ContextItem {
                     icon: Icon::UserCircle,
+                    aria_label: "quick-profile-self-edit".into(),
                     text: get_local_text("quickprofile.self-edit"),
                     onpress: move |_| {
                         router.replace_route(UPLINK_ROUTES.settings, None, None);
@@ -280,6 +281,7 @@ pub fn QuickProfileContext<'a>(cx: Scope<'a, QuickProfileProps<'a>>) -> Element<
                             rsx!(
                                 ContextItem {
                                 icon: Icon::ChatBubbleBottomCenterText,
+                                aria_label: "quick-profile-message".into(),
                                 text: get_local_text("quickprofile.message"),
                                 onpress: move |_| {
                                     ch.send(QuickProfileCmd::CreateConversation(chat_of.clone(), identity.did_key()));
@@ -298,6 +300,7 @@ pub fn QuickProfileContext<'a>(cx: Scope<'a, QuickProfileProps<'a>>) -> Element<
                     rsx!(ContextItem {
                         icon: Icon::UserMinus,
                         text: get_local_text("quickprofile.friend-remove"),
+                        aria_label: "quick-profile-friend-remove".into(),
                         onpress: move |_| {
                             ch.send(QuickProfileCmd::RemoveFriend(remove_identity.did_key()));
                             ch.send(QuickProfileCmd::RemoveDirectConvs(remove_identity.did_key()));
@@ -306,6 +309,7 @@ pub fn QuickProfileContext<'a>(cx: Scope<'a, QuickProfileProps<'a>>) -> Element<
                 }
                 ContextItem {
                     icon: if blocked {Icon::UserBlocked} else {Icon::UserBlock},
+                    aria_label: if blocked {"quick-profile-unblock".into()} else {"quick-profile-block".into()},
                     text: if blocked {get_local_text("quickprofile.unblock")} else {get_local_text("quickprofile.block")},
                     onpress: move |_| {
                         if blocked {

--- a/ui/src/components/chat/sidebar.rs
+++ b/ui/src/components/chat/sidebar.rs
@@ -269,6 +269,7 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
                                     id: chat_id.to_string(),
                                     items: cx.render(rsx!(
                                         ContextItem {
+                                            aria_label: "favorites-chat".into(),
                                             icon: Icon::ChatBubbleBottomCenterText,
                                             text: get_local_text("uplink.chat"),
                                             onpress: move |_| {
@@ -282,6 +283,7 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
                                             }
                                         },
                                         ContextItem {
+                                            aria_label: "favorites-remove".into(),
                                             icon: Icon::HeartSlash,
                                             text: get_local_text("favorites.remove"),
                                             onpress: move |_| {
@@ -402,6 +404,7 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
                             items: cx.render(rsx!(
                                 ContextItem {
                                     icon: Icon::BellSlash,
+                                    aria_label: "chats-clear-unreads".into(),
                                     text: get_local_text("uplink.clear-unreads"),
                                     onpress: move |_| {
                                         state.write().mutate(Action::ClearUnreads(clear_unreads.id));
@@ -410,6 +413,7 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
                                 hr{ }
                                 ContextItem {
                                     icon: Icon::EyeSlash,
+                                    aria_label: "chats-hide-chat".into(),
                                     text: get_local_text("uplink.hide-chat"),
                                     onpress: move |_| {
                                         state.write().mutate(Action::RemoveFromSidebar(chat.id));
@@ -424,6 +428,9 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
                                             text: if is_group_conv && is_creator {get_local_text("uplink.delete-group-chat")} 
                                             else if is_group_conv && !is_creator  {get_local_text("uplink.leave-group")} 
                                             else {get_local_text("uplink.delete-conversation")},
+                                            aria_label: if is_group_conv && is_creator {"chats-delete-group".into()} 
+                                            else if is_group_conv && !is_creator {"chats-leave-group".into()}
+                                            else {"chats-delete-conversation".into()},
                                             onpress: move |_| {
                                                 ch.send(MessagesCommand::DeleteConversation { conv_id: chat.id });
                                             }

--- a/ui/src/components/friends/blocked/mod.rs
+++ b/ui/src/components/friends/blocked/mod.rs
@@ -77,6 +77,7 @@ pub fn BlockedUsers(cx: Scope) -> Element {
                             ContextItem {
                                 danger: true,
                                 icon: Icon::XMark,
+                                aria_label: "friends-unblock".into(),
                                 text: get_local_text("friends.unblock"),
                                 onpress: move |_| {
                                     if STATIC_ARGS.use_mock {

--- a/ui/src/components/friends/friend/mod.rs
+++ b/ui/src/components/friends/friend/mod.rs
@@ -61,21 +61,24 @@ pub fn Friend<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 class: "request-info",
                 aria_label: "Friend Info",
                 p {
+                    aria_label: "friend-username",
                     "{cx.props.username}",
                     (!state.read().ui.is_minimal_view()).then(|| rsx!(
                         span {
                             "#{cx.props.suffix}"
                         }
-                    ))
+                    )),
                 },
                 if relationship.friends() {
                    rsx!(p {
                         class: "status-message",
+                        aria_label: "status-message",
                         (!state.read().ui.is_minimal_view()).then(|| rsx!( "{status_message}" ))
                     })
                 } else  {
                     rsx!(Label {
                         // TODO: this is stubbed for now, wire up to the actual request time
+                        aria_label: "friendship-status".into(),
                         text: get_local_text(
                             if relationship.blocked() {
                                 "friends.blocked-desc"

--- a/ui/src/components/friends/friends_list/mod.rs
+++ b/ui/src/components/friends/friends_list/mod.rs
@@ -198,6 +198,7 @@ pub fn Friends(cx: Scope) -> Element {
                                         ContextItem {
                                             icon: Icon::ChatBubbleBottomCenterText,
                                             text: get_local_text("uplink.chat"),
+                                            aria_label: "friends-chat".into(),
                                             onpress: move |_| {
                                                 ch.send(ChanCmd::CreateConversation{recipient: context_friend.did_key(), chat: chat2.clone()});
                                             }
@@ -206,6 +207,7 @@ pub fn Friends(cx: Scope) -> Element {
                                             rsx!(ContextItem {
                                                 icon: if f {Icon::HeartSlash} else {Icon::Heart},
                                                 text: get_local_text(if f {"favorites.remove"} else {"favorites.favorites"}),
+                                                aria_label: if f {"favorites-remove".into()} else {"favorites-add".into()},
                                                 onpress: move |_| {
                                                     // can't favorite a non-existent conversation
                                                     // todo: don't even allow favoriting from the friends page unless there's a conversation
@@ -220,6 +222,7 @@ pub fn Friends(cx: Scope) -> Element {
                                             danger: true,
                                             icon: Icon::UserMinus,
                                             text: get_local_text("uplink.remove"),
+                                            aria_label: "friends-remove".into(),
                                             should_render: !remove_in_progress.current().contains(&remove_friend.did_key()),
                                             onpress: move |_| {
                                                 let did = remove_friend.did_key();
@@ -236,6 +239,7 @@ pub fn Friends(cx: Scope) -> Element {
                                             danger: true,
                                             icon: Icon::NoSymbol,
                                             text: get_local_text("friends.block"),
+                                            aria_label: "friends-block".into(),
                                             should_render: !block_in_progress.current().contains(&block_friend.did_key()),
                                             onpress: move |_| {
                                                 let did = block_friend.did_key();

--- a/ui/src/components/friends/incoming_requests/mod.rs
+++ b/ui/src/components/friends/incoming_requests/mod.rs
@@ -114,6 +114,7 @@ pub fn PendingFriends(cx: Scope) -> Element {
                                 danger: true,
                                 icon: Icon::Check,
                                 text: get_local_text("friends.accept"),
+                                aria_label: "friends-accept".into(),
                                 should_render: !any_button_disabled,
                                 onpress: move |_| {
                                     if STATIC_ARGS.use_mock {
@@ -127,6 +128,7 @@ pub fn PendingFriends(cx: Scope) -> Element {
                             ContextItem {
                                 danger: true,
                                 icon: Icon::XMark,
+                                aria_label: "friends-deny".into(),
                                 text: get_local_text("friends.deny"),
                                 should_render: !any_button_disabled,
                                 onpress: move |_| {

--- a/ui/src/components/friends/outgoing_requests/mod.rs
+++ b/ui/src/components/friends/outgoing_requests/mod.rs
@@ -71,6 +71,7 @@ pub fn OutgoingRequests(cx: Scope) -> Element {
                             ContextItem {
                                 danger: true,
                                 icon: Icon::XMark,
+                                aria_label: "friends-cancel".into(),
                                 text: get_local_text("friends.cancel"),
                                 should_render: !any_button_disabled,
                                 onpress: move |_| {

--- a/ui/src/components/settings/sub_pages/profile/mod.rs
+++ b/ui/src/components/settings/sub_pages/profile/mod.rs
@@ -173,6 +173,7 @@ pub fn ProfileSettings(cx: Scope) -> Element {
             (!show_welcome).then(|| rsx!(
                 div {
                     class: "new-profile-welcome",
+                    aria_label: "new-profile-welcome",
                     div {
                         class: "welcome",
                         img {
@@ -183,6 +184,7 @@ pub fn ProfileSettings(cx: Scope) -> Element {
                         class: "welcome-content",
                         Button {
                             text: get_local_text("uplink.dismiss"),
+                            aria_label: "welcome-message-dismiss".into(),
                             icon: Icon::XMark,
                             onpress: move |_| {
                                 state.write().ui.settings_welcome();
@@ -190,13 +192,16 @@ pub fn ProfileSettings(cx: Scope) -> Element {
                             }
                         },
                         Label {
+                            aria_label: "welcome-message".into(),
                             text: get_local_text("settings-profile.welcome")
                         },
                         p {
+                            aria_label: "welcome-message-desc",
                             get_local_text("settings-profile.welcome-desc")
                         }
                         br {},
                         p {
+                            aria_label: "welcome-message-cta",
                             get_local_text("settings-profile.welcome-cta")
                         }
                     }
@@ -213,6 +218,7 @@ pub fn ProfileSettings(cx: Scope) -> Element {
                         ContextItem {
                             icon: Icon::Trash,
                             text: get_local_text("settings-profile.clear-banner"),
+                            aria_label: "clear-banner".into(),
                             onpress: move |_| {
                                 ch.send(ChanCmd::Banner(String::from('\0')));
                             }
@@ -233,6 +239,7 @@ pub fn ProfileSettings(cx: Scope) -> Element {
                     items: cx.render(rsx!(
                         ContextItem {
                             icon: Icon::Trash,
+                            aria_label: "clear-avatar".into(),
                             text: get_local_text("settings-profile.clear-avatar"),
                             onpress: move |_| {
                                 ch.send(ChanCmd::Profile(String::from('\0')));

--- a/ui/src/layouts/storage.rs
+++ b/ui/src/layouts/storage.rs
@@ -645,6 +645,7 @@ pub fn FilesLayout(cx: Scope<Props>) -> Element {
                                     items: cx.render(rsx!(
                                         ContextItem {
                                             icon: Icon::Pencil,
+                                            aria_label: "folder-rename".into(),
                                             text: get_local_text("files.rename"),
                                             onpress: move |_| {
                                                 is_renaming_map.with_mut(|i| *i = Some(key));
@@ -654,6 +655,7 @@ pub fn FilesLayout(cx: Scope<Props>) -> Element {
                                         ContextItem {
                                             icon: Icon::Trash,
                                             danger: true,
+                                            aria_label: "folder-delete".into(),
                                             text: get_local_text("uplink.delete"),
                                             onpress: move |_| {
                                                 let item = Item::from(dir2.clone());
@@ -704,6 +706,7 @@ pub fn FilesLayout(cx: Scope<Props>) -> Element {
                                         items: cx.render(rsx!(
                                             ContextItem {
                                                 icon: Icon::Pencil,
+                                                aria_label: "files-rename".into(),
                                                 text: get_local_text("files.rename"),
                                                 onpress: move |_| {
                                                     is_renaming_map.with_mut(|i| *i = Some(key));
@@ -711,6 +714,7 @@ pub fn FilesLayout(cx: Scope<Props>) -> Element {
                                             },
                                             ContextItem {
                                                 icon: Icon::ArrowDownCircle,
+                                                aria_label: "files-download".into(),
                                                 text: get_local_text("files.download"),
                                                 onpress: move |_| {
                                                     let file_extension = std::path::Path::new(&file_name2)
@@ -734,6 +738,7 @@ pub fn FilesLayout(cx: Scope<Props>) -> Element {
                                             ContextItem {
                                                 icon: Icon::Trash,
                                                 danger: true,
+                                                aria_label: "files-delete".into(),
                                                 text: get_local_text("uplink.delete"),
                                                 onpress: move |_| {
                                                     let item = Item::from(file2.clone());

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -891,12 +891,14 @@ fn get_update_icon(cx: Scope) -> Element {
                 id: "update-available-menu".to_string(),
                 items: cx.render(rsx!(
                     ContextItem {
+                        aria_label: "update-menu-dismiss".into(),
                         text: get_local_text("uplink.update-menu-dismiss"),
                         onpress: move |_| {
                             state.write().mutate(Action::DismissUpdate);
                         }
                     },
                     ContextItem {
+                        aria_label: "update-menu-download".into(),
                         text: get_local_text("uplink.update-menu-download"),
                         onpress: move |_| {
                             download_state.write().stage = DownloadProgress::PickFolder;


### PR DESCRIPTION
### What this PR does 📖

- Add aria labels required to add/improve UI locators on appium tests
- Added aria labels for Context items
- Added aria labels for Chat elements, Your new profile modal, toast notifications and friends list elements, in order to improve UI location strategy on tests
- UI Tests are expected to fail on this PR since once that this PR is merged I will do the push the required updates on appium repo

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

