### PR TITLE
fix(overlays): temporary fix for windows overlay bug

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -9,6 +9,8 @@ jobs:
     name: Cargo Checks
     runs-on: ubuntu-latest
     steps:
+      - name: Get new package info
+        run: sudo apt-get update
       - name: Install libwebkit2gtk
         run: sudo apt-get install -y build-essential pkg-config libssl-dev libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev librust-alsa-sys-dev --fix-missing
       - name: Install Protoc

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install libwebkit2gtk
-        run: sudo apt-get install -y build-essential pkg-config libssl-dev libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev librust-alsa-sys-dev
+        run: sudo apt-get install -y build-essential pkg-config libssl-dev libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev librust-alsa-sys-dev --fix-missing
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
       - name: Checkout sources

--- a/ui/src/components/settings/sub_pages/general.rs
+++ b/ui/src/components/settings/sub_pages/general.rs
@@ -37,10 +37,10 @@ pub fn GeneralSettings(cx: Scope) -> Element {
                 section_description: get_local_text("settings-general.overlay-description"),
                 Switch {
                     // TODO: This overlay causes a crash in windows
-                    disabled: if cfg!(target_os = "windows") {true } else {false},
-                    active: if cfg!(target_os = "windows") {false } else {state.read().configuration.general.enable_overlay},
+                    disabled: cfg!(target_os = "windows"),
+                    active: cfg!(not(target_os = "windows")) && state.read().configuration.general.enable_overlay,
                     onflipped: move |e| {
-                        state.write().mutate(Action::Config(ConfigAction::SetOverlayEnabled(if cfg!(target_os = "windows") {false } else {e})));
+                        state.write().mutate(Action::Config(ConfigAction::SetOverlayEnabled(cfg!(not(target_os = "windows")) && e )));
                         state.write().mutate(Action::SetOverlay(e));
                     }
                 }

--- a/ui/src/components/settings/sub_pages/general.rs
+++ b/ui/src/components/settings/sub_pages/general.rs
@@ -36,9 +36,11 @@ pub fn GeneralSettings(cx: Scope) -> Element {
                 section_label: get_local_text("settings-general.overlay"),
                 section_description: get_local_text("settings-general.overlay-description"),
                 Switch {
-                    active: state.read().configuration.general.enable_overlay,
+                    // TODO: This overlay causes a crash in windows
+                    disabled: if cfg!(target_os = "windows") {true } else {false},
+                    active: if cfg!(target_os = "windows") {false } else {state.read().configuration.general.enable_overlay},
                     onflipped: move |e| {
-                        state.write().mutate(Action::Config(ConfigAction::SetOverlayEnabled(e)));
+                        state.write().mutate(Action::Config(ConfigAction::SetOverlayEnabled(if cfg!(target_os = "windows") {false } else {e})));
                         state.write().mutate(Action::SetOverlay(e));
                     }
                 }

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -409,10 +409,13 @@ pub fn app_bootstrap(cx: Scope, identity: multipass::identity::Identity) -> Elem
     }
 
     let desktop = use_window(cx);
-    if state.configuration.general.enable_overlay {
-        let overlay_test = VirtualDom::new(OverlayDom);
-        let window = desktop.new_window(overlay_test, make_config());
-        state.ui.overlays.push(window);
+    // TODO: This overlay needs to be fixed in windows
+    if cfg!(not(target_os = "windows")) {
+        if state.configuration.general.enable_overlay {
+            let overlay_test = VirtualDom::new(OverlayDom);
+            let window = desktop.new_window(overlay_test, make_config());
+            state.ui.overlays.push(window);
+        }
     }
 
     let size = desktop.webview.inner_size();

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -410,12 +410,10 @@ pub fn app_bootstrap(cx: Scope, identity: multipass::identity::Identity) -> Elem
 
     let desktop = use_window(cx);
     // TODO: This overlay needs to be fixed in windows
-    if cfg!(not(target_os = "windows")) {
-        if state.configuration.general.enable_overlay {
-            let overlay_test = VirtualDom::new(OverlayDom);
-            let window = desktop.new_window(overlay_test, make_config());
-            state.ui.overlays.push(window);
-        }
+    if cfg!(not(target_os = "windows")) && state.configuration.general.enable_overlay {
+        let overlay_test = VirtualDom::new(OverlayDom);
+        let window = desktop.new_window(overlay_test, make_config());
+        state.ui.overlays.push(window);
     }
 
     let size = desktop.webview.inner_size();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
This disables the overlay which was causing windows sign in to fail just on windows.

We will need to go in and fix this when we get video/calling in for the overlay widget but for now this quick fix should be ok

Here is a test build:
https://drive.google.com/file/d/1IB2B31LjPrGnStIBHk-5I5wDR9ZOCfyi/view?usp=sharing
- 

### Which issue(s) this PR fixes 🔨

- Resolve #804 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

