### PR TITLE
chore(cargo): Update dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.20",
+ "time 0.3.21",
 ]
 
 [[package]]
@@ -318,7 +318,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.20",
+ "time 0.3.21",
 ]
 
 [[package]]
@@ -2398,18 +2398,18 @@ dependencies = [
 
 [[package]]
 name = "enumset"
-version = "1.0.13"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b025475ad197bd8b4a9bdce339216b6cf3bd568bf2e107c286b51613f0b3cf"
+checksum = "27f1d44683938f1f2dbb59932a7e164a21928b0a4b23ca6f9059649ae4725b2e"
 dependencies = [
  "enumset_derive",
 ]
 
 [[package]]
 name = "enumset_derive"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c2852ff17a4c9a2bb2abbca3074737919cb05dc24b0a8ca9498081a7033dd6"
+checksum = "93b15496585fddd368466056b314fbb7e826a9ef1cf17b563d30dd2665846be2"
 dependencies = [
  "darling 0.20.1",
  "proc-macro2",
@@ -4214,9 +4214,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "68c16e1bfd491478ab155fd8b4896b86f9ede344949b641e61501e07c2b8b4d5"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -4373,9 +4373,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libdbus-sys"
@@ -5264,7 +5264,7 @@ dependencies = [
  "dirs-next",
  "objc-foundation",
  "objc_id",
- "time 0.3.20",
+ "time 0.3.21",
 ]
 
 [[package]]
@@ -6732,9 +6732,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
@@ -6871,7 +6871,7 @@ checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.20",
+ "time 0.3.21",
  "x509-parser 0.13.2",
  "yasna",
 ]
@@ -6884,7 +6884,7 @@ checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.20",
+ "time 0.3.21",
  "yasna",
 ]
 
@@ -7694,9 +7694,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c2bb1a323307527314a36bfb73f24febb08ce2b8a554bf4ffd6f51ad15198c"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.6",
  "keccak",
@@ -8145,9 +8145,9 @@ dependencies = [
 
 [[package]]
 name = "system-deps"
-version = "6.0.5"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fe581ad25d11420b873cf9aedaca0419c2b411487b134d4d21065f3d092055"
+checksum = "e5fa6fb9ee296c0dc2df41a656ca7948546d061958115ddb0bcaae43ad0d17d2"
 dependencies = [
  "cfg-expr 0.15.1",
  "heck 0.4.1",
@@ -8338,9 +8338,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
  "itoa 1.0.6",
  "serde",
@@ -8350,15 +8350,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
 dependencies = [
  "time-core",
 ]
@@ -9033,7 +9033,7 @@ dependencies = [
 [[package]]
 name = "warp"
 version = "0.1.0"
-source = "git+https://github.com/Satellite-im/Warp?rev=80db12ece1d30ae5096cca1fca12a487e1e552f3#80db12ece1d30ae5096cca1fca12a487e1e552f3"
+source = "git+https://github.com/Satellite-im/Warp?rev=5f8c84ccc6dc683ab5b31cb6d122f57601b0e814#5f8c84ccc6dc683ab5b31cb6d122f57601b0e814"
 dependencies = [
  "aes-gcm 0.10.1",
  "anyhow",
@@ -9093,7 +9093,7 @@ dependencies = [
 [[package]]
 name = "warp-derive"
 version = "0.1.0"
-source = "git+https://github.com/Satellite-im/Warp?rev=80db12ece1d30ae5096cca1fca12a487e1e552f3#80db12ece1d30ae5096cca1fca12a487e1e552f3"
+source = "git+https://github.com/Satellite-im/Warp?rev=5f8c84ccc6dc683ab5b31cb6d122f57601b0e814#5f8c84ccc6dc683ab5b31cb6d122f57601b0e814"
 dependencies = [
  "paste",
  "quote",
@@ -9103,7 +9103,7 @@ dependencies = [
 [[package]]
 name = "warp-fs-ipfs"
 version = "0.1.0"
-source = "git+https://github.com/Satellite-im/Warp?rev=80db12ece1d30ae5096cca1fca12a487e1e552f3#80db12ece1d30ae5096cca1fca12a487e1e552f3"
+source = "git+https://github.com/Satellite-im/Warp?rev=5f8c84ccc6dc683ab5b31cb6d122f57601b0e814#5f8c84ccc6dc683ab5b31cb6d122f57601b0e814"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -9124,7 +9124,7 @@ dependencies = [
 [[package]]
 name = "warp-mp-ipfs"
 version = "0.1.0"
-source = "git+https://github.com/Satellite-im/Warp?rev=80db12ece1d30ae5096cca1fca12a487e1e552f3#80db12ece1d30ae5096cca1fca12a487e1e552f3"
+source = "git+https://github.com/Satellite-im/Warp?rev=5f8c84ccc6dc683ab5b31cb6d122f57601b0e814#5f8c84ccc6dc683ab5b31cb6d122f57601b0e814"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -9147,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "warp-rg-ipfs"
 version = "0.1.0"
-source = "git+https://github.com/Satellite-im/Warp?rev=80db12ece1d30ae5096cca1fca12a487e1e552f3#80db12ece1d30ae5096cca1fca12a487e1e552f3"
+source = "git+https://github.com/Satellite-im/Warp?rev=5f8c84ccc6dc683ab5b31cb6d122f57601b0e814#5f8c84ccc6dc683ab5b31cb6d122f57601b0e814"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -9189,9 +9189,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "5b6cb788c4e39112fbe1822277ef6fb3c55cd86b95cb3d3c4c1c9597e4ac74b4"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -9199,24 +9199,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "35e522ed4105a9d626d885b35d62501b30d9666283a5c8be12c14a8bdafe7822"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.34"
+version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+checksum = "083abe15c5d88556b77bdf7aef403625be9e327ad37c62c4e4129af740168163"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -9226,9 +9226,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "358a79a0cb89d21db8120cbfb91392335913e4890665b1a7981d9e956903b434"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9236,22 +9236,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "4783ce29f09b9d93134d41297aded3a712b7b979e9c6f28c32cb88c973a94869"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "a901d592cafaa4d711bc324edfaff879ac700b19c3dfd60058d2b445be2691eb"
 
 [[package]]
 name = "wasm-streams"
@@ -9283,9 +9283,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "16b5f940c7edfdc6d12126d98c9ef4d1b3d470011c47c76a6581df47ad9ba721"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9407,7 +9407,7 @@ dependencies = [
  "sha2 0.10.6",
  "stun",
  "thiserror",
- "time 0.3.20",
+ "time 0.3.21",
  "tokio",
  "turn",
  "url",
@@ -10199,7 +10199,7 @@ dependencies = [
  "ring",
  "rusticata-macros",
  "thiserror",
- "time 0.3.20",
+ "time 0.3.21",
 ]
 
 [[package]]
@@ -10217,14 +10217,14 @@ dependencies = [
  "oid-registry 0.6.1",
  "rusticata-macros",
  "thiserror",
- "time 0.3.20",
+ "time 0.3.21",
 ]
 
 [[package]]
 name = "xml-rs"
-version = "0.8.5"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374b609fb36c36ce3501094dc0548f7df5d8d102224b65bc59812e4a5425d571"
+checksum = "c1fcc45bb67e8bd9c33ada4b861bccfe2506e726169f7c1081b95841b3758eb3"
 
 [[package]]
 name = "xml5ever"
@@ -10266,7 +10266,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
- "time 0.3.20",
+ "time 0.3.21",
 ]
 
 [[package]]
@@ -10291,9 +10291,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0445d0fbc924bb93539b4316c11afb121ea39296f99a3c4c9edad09e3658cdef"
+checksum = "7e92305c174683d78035cbf1b70e18db6329cc0f1b9cae0a52ca90bf5bfe7125"
 dependencies = [
  "aes 0.7.5",
  "byteorder",
@@ -10305,7 +10305,7 @@ dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
  "sha1 0.10.5",
- "time 0.3.20",
+ "time 0.3.21",
  "zstd",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,10 +44,10 @@ humansize = "2.1.3"
 window-vibrancy = "0.3.2"
 uuid = { version = "1", features = ["serde", "v4"] }
 libloading = "0.7.4"
-warp = { git = "https://github.com/Satellite-im/Warp", rev = "80db12ece1d30ae5096cca1fca12a487e1e552f3" }
-warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "80db12ece1d30ae5096cca1fca12a487e1e552f3" }
-warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "80db12ece1d30ae5096cca1fca12a487e1e552f3" }
-warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "80db12ece1d30ae5096cca1fca12a487e1e552f3" }
+warp = { git = "https://github.com/Satellite-im/Warp", rev = "5f8c84ccc6dc683ab5b31cb6d122f57601b0e814" }
+warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "5f8c84ccc6dc683ab5b31cb6d122f57601b0e814" }
+warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "5f8c84ccc6dc683ab5b31cb6d122f57601b0e814" }
+warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "5f8c84ccc6dc683ab5b31cb6d122f57601b0e814" }
 rfd = "0.11.3"
 mime = "0.3.16"
 serde = "1.0"

--- a/common/src/warp_runner/manager/commands/constellation_commands.rs
+++ b/common/src/warp_runner/manager/commands/constellation_commands.rs
@@ -397,10 +397,7 @@ async fn upload_files(
             Some(filename.clone()),
         )));
 
-        match warp_storage
-            .put(&filename, &local_path)
-            .await
-        {
+        match warp_storage.put(&filename, &local_path).await {
             Ok(mut upload_progress) => {
                 let mut previous_percentage: usize = 0;
                 let mut upload_process_started = false;

--- a/common/src/warp_runner/manager/commands/constellation_commands.rs
+++ b/common/src/warp_runner/manager/commands/constellation_commands.rs
@@ -13,7 +13,6 @@ use mime::*;
 use once_cell::sync::Lazy;
 use tempfile::TempDir;
 use tokio::sync::mpsc;
-use tokio_util::io::ReaderStream;
 
 use crate::{state::storage::Storage as uplink_storage, IMAGE_EXTENSIONS, VIDEO_FILE_EXTENSIONS};
 use crate::{warp_runner::Storage as warp_storage, DOC_EXTENSIONS};
@@ -397,28 +396,9 @@ async fn upload_files(
         let _ = tx.send(FileTransferProgress::Step(FileTransferStep::DuplicateName(
             Some(filename.clone()),
         )));
-        let tokio_file = match tokio::fs::File::open(&local_path).await {
-            Ok(file) => file,
-            Err(error) => {
-                log::error!("Error on get tokio file, cancelling upload action, error: {error}");
-                continue;
-            }
-        };
-
-        let total_size_for_stream = match tokio_file.metadata().await {
-            Ok(data) => Some(data.len() as usize),
-            Err(error) => {
-                log::error!("Error getting metadata: {:?}", error);
-                None
-            }
-        };
-
-        let file_stream = ReaderStream::new(tokio_file)
-            .filter_map(|x| async { x.ok() })
-            .map(|x| x.into());
 
         match warp_storage
-            .put_stream(&filename, total_size_for_stream, file_stream.boxed())
+            .put(&filename, &local_path)
             .await
         {
             Ok(mut upload_progress) => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Add limits on names for files and directories (limit is set to 256)
- Adds `Constellation::max_size` and `Constellation_current_size` to give the amount of data stored and the max allowed
- Switch from using `Constellation::put_stream` to `Constellation::put`
- Minor Optimizations

### Which issue(s) this PR fixes 🔨

- N/A

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️
Should not have any major changes that require testing

### Additional comments 🎤
- The limit for the names of the files or directories are a hard cap (keeping in compatibility with most major OS max name limits). Uplink still has it capped off at 64 characters, which is fine. If there are any interactions with `Directory` or `File` when setting or renaming and the name hits the limit, it will only use the first 256 characters. 
- Sending/receiving friend request with this PR to/from a prior commit will not work, however this does not require a new account.