### PR TITLE
update(controls): removed state from kit component

### DIFF
--- a/kit/src/components/topbar_controls/mod.rs
+++ b/kit/src/components/topbar_controls/mod.rs
@@ -1,14 +1,10 @@
 use crate::elements::{button::Button, Appearance};
-use common::{
-    icons::outline::Shape as Icon,
-    state::{Action, State},
-};
+use common::icons::outline::Shape as Icon;
 use dioxus::prelude::*;
 use dioxus_desktop::use_window;
 
 #[allow(non_snake_case)]
 pub fn Topbar_Controls(cx: Scope) -> Element {
-    let state = use_shared_state::<State>(cx)?;
     let desktop = use_window(cx);
     if cfg!(not(target_os = "macos")) {
         cx.render(rsx!(
@@ -35,9 +31,6 @@ pub fn Topbar_Controls(cx: Scope) -> Element {
                     icon: Icon::XMark,
                     appearance: Appearance::Transparent,
                     onpress: move |_| {
-                        state
-                        .write()
-                            .mutate(Action::ClearAllPopoutWindows(desktop.clone()));
                         desktop.close();
                     }
                 },

--- a/ui/extra/themes/lunar-eclipse.css
+++ b/ui/extra/themes/lunar-eclipse.css
@@ -461,7 +461,6 @@ body {
     width: unset;
     padding: var(--padding-more);
     border-radius: var(--border-radius-more);
-    height: fit-content;
 } 
 
 #unlock-layout .idle {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

This adds the topbar controls back in linux and windows. The PR to move the preview to a modal instead of a new window means we can take state out of the kit topbar controls. State was not available until unlocked, causing it to fail/be missing when the component was rendered before

Also minor CSS update to the lunar eclipse theme so the cat gif didn't cover the minimize button.

before
![image](https://github.com/Satellite-im/Uplink/assets/2993032/db111ad3-1246-4beb-9e8f-78b50cdd259e)


now
![image](https://github.com/Satellite-im/Uplink/assets/2993032/c47a1b66-7da9-4769-b41c-58c15f50b243)


### Which issue(s) this PR fixes 🔨

- Resolve #765 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

