### PR TITLE
chore(updater): minor updates to notification for update

### DIFF
--- a/.github/workflows/build-dmg-universal.yml
+++ b/.github/workflows/build-dmg-universal.yml
@@ -81,10 +81,12 @@ jobs:
         with:
           name: Uplink Universal Mac App
           path: |
+            target/release/macos/Uplink.dmg
             Uplink-Mac-Universal.zip
             Uplink-Mac-Universal.zip.sha256.txt
       - name: Copy file to release
         uses: softprops/action-gh-release@v1
         with:
           files: |
+            target/release/macos/Uplink.dmg
             Uplink-Mac-Universal.zip

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -151,7 +151,7 @@ impl State {
                     .insert(Uuid::new_v4(), notification);
             }
             Action::DismissUpdate => {
-                self.settings.update_dismissed = self.settings.update_available.take();
+                self.settings.update_dismissed = self.settings.update_available.clone();
                 self.ui
                     .notifications
                     .decrement(notifications::NotificationKind::Settings, 1);

--- a/ui/extra/themes/polar.scss
+++ b/ui/extra/themes/polar.scss
@@ -12,8 +12,8 @@
     --primary-dark: #3c61bf;
     --primary-light: #84a5f9;
 
-    --secondary: #191b20;
-    --secondary-light: #2d3139;
+    --secondary: #44475a;
+    --secondary-light: #6a6c6e;
     --secondary-dark: #191b20;
 
     --background: #16171d;

--- a/ui/src/components/settings/styles.scss
+++ b/ui/src/components/settings/styles.scss
@@ -81,3 +81,7 @@
     }
   }
 }
+
+.settings-control .btn-wrap:nth-of-type(2) {
+  padding-left: 1rem;
+}

--- a/ui/src/components/settings/sub_pages/about.rs
+++ b/ui/src/components/settings/sub_pages/about.rs
@@ -87,17 +87,32 @@ pub fn AboutPage(cx: Scope) -> Element {
         }
         _ => match stage {
             DownloadProgress::Idle => {
-                rsx!(Button {
-                    key: "btn-idle",
-                    text: get_local_text("uplink.download-update"),
-                    loading: *update_button_loading.current(),
-                    aria_label: "check-for-updates-button".into(),
-                    appearance: Appearance::Secondary,
-                    icon: Icon::ArrowDown,
-                    onpress: move |_| {
-                        download_state.write().stage = DownloadProgress::PickFolder;
+                rsx!(
+                    Button {
+                        key: "btn-idle",
+                        text: get_local_text("uplink.download-update"),
+                        loading: *update_button_loading.current(),
+                        aria_label: "check-for-updates-button".into(),
+                        appearance: Appearance::Secondary,
+                        icon: Icon::ArrowDown,
+                        onpress: move |_| {
+                            download_state.write().stage = DownloadProgress::PickFolder;
+                        }
+                    },
+                    if state.read().settings.update_dismissed
+                        != state.read().settings.update_available
+                    {
+                        rsx!(Button {
+                            aria_label: "update-menu-dismiss".into(),
+                            text: get_local_text("uplink.update-menu-dismiss"),
+                            appearance: Appearance::Secondary,
+                            icon: Icon::XCircle,
+                            onpress: move |_| {
+                                state.write().mutate(Action::DismissUpdate);
+                            }
+                        })
                     }
-                })
+                )
             }
             DownloadProgress::PickFolder => rsx!(get_download_modal {
                 on_dismiss: move |_| {

--- a/ui/src/components/topbar/release_info/mod.rs
+++ b/ui/src/components/topbar/release_info/mod.rs
@@ -10,7 +10,7 @@ pub fn Release_Info(cx: Scope) -> Element {
     cx.render(rsx!(
         div {
             id: "pre-release",
-            class : if cfg!(target_os = "macos") {"topbar-item mac-spacer"}  else {"topbar-item"},
+            class : if cfg!(target_os = "macos") {"topbar-item mac-spacer topbar-item-background"}  else {"topbar-item topbar-item-background"},
             aria_label: "pre-release",
             IconElement {
                 icon: Icon::Beaker,

--- a/ui/src/style.scss
+++ b/ui/src/style.scss
@@ -141,18 +141,16 @@ body {
 }
 
 .topbar-item {
-  background-color: var(--secondary-dark);
   border-radius: var(--border-radius-less);
   display: inline-flex;
   gap: var(--gap-less);
   width: fit-content;
   padding: var(--gap-less);
   user-select: none;
-  margin-right: var(--gap-less);
 }
 
-.inline-controls {
-  display: inline-flex;
+.topbar-item-background {
+  background-color: var(--secondary-dark);
 }
 
 .disable-select {

--- a/ui/src/utils/auto_updater.rs
+++ b/ui/src/utils/auto_updater.rs
@@ -67,9 +67,10 @@ pub fn get_download_dest() -> Option<PathBuf> {
 }
 
 pub async fn check_for_release() -> anyhow::Result<Option<GitHubRelease>> {
-    let latest_release =
-        get_github_release("https://api.github.com/repos/Satellite-im/Uplink/releases/latest")
-            .await?;
+    let latest_release = get_github_release(
+        "https://api.github.com/repos/Satellite-im/test-builds-uplink/releases/latest",
+    )
+    .await?;
 
     // ensure installer is released - .deb, .msi, or .dpkg
     let extension = if cfg!(target_os = "windows") {
@@ -101,9 +102,10 @@ pub async fn download_update(
     binary_dest: PathBuf,
     ch: mpsc::UnboundedSender<f32>,
 ) -> anyhow::Result<String> {
-    let latest_release =
-        get_github_release("https://api.github.com/repos/Satellite-im/Uplink/releases/latest")
-            .await?;
+    let latest_release = get_github_release(
+        "https://api.github.com/repos/Satellite-im/test-builds-uplink/releases/latest",
+    )
+    .await?;
     let find_asset = |name: &str| {
         latest_release
             .assets

--- a/ui/src/utils/auto_updater.rs
+++ b/ui/src/utils/auto_updater.rs
@@ -67,10 +67,9 @@ pub fn get_download_dest() -> Option<PathBuf> {
 }
 
 pub async fn check_for_release() -> anyhow::Result<Option<GitHubRelease>> {
-    let latest_release = get_github_release(
-        "https://api.github.com/repos/Satellite-im/test-builds-uplink/releases/latest",
-    )
-    .await?;
+    let latest_release =
+        get_github_release("https://api.github.com/repos/Satellite-im/Uplink/releases/latest")
+            .await?;
 
     // ensure installer is released - .deb, .msi, or .dpkg
     let extension = if cfg!(target_os = "windows") {
@@ -102,10 +101,9 @@ pub async fn download_update(
     binary_dest: PathBuf,
     ch: mpsc::UnboundedSender<f32>,
 ) -> anyhow::Result<String> {
-    let latest_release = get_github_release(
-        "https://api.github.com/repos/Satellite-im/test-builds-uplink/releases/latest",
-    )
-    .await?;
+    let latest_release =
+        get_github_release("https://api.github.com/repos/Satellite-im/Uplink/releases/latest")
+            .await?;
     let find_asset = |name: &str| {
         latest_release
             .assets


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Added the dmg upload to the make dmg action (updater was looking for DMG that didn't get added to release)
- Changed updater to not take  updated version (sets update_available to null when taking) so that way we could see what the available update is, and which update was dismissed, so we know not to ask again until the next update version)
- change to polar theme, the secondary colors not light enough to see a difference in the background
- changed update in header to use the same class as other topbar controls, so it was centered vertically better
- added dismiss button in the Settings > About that only shows if the update is not dismissed already.


### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

To test:
Update the version `version = "0.1.5"` to something older in the Cargo.toml

This will make your local version think it is out of date. Now you can run this and it should see your version is out of date with the github version (which is 0.1.5).

If you open your state file in a text editor: (on mac, `~/.uplink/.user.state.json`
You will see the keys for `update_available` and `update_dismissed`

If update_available is different from the version in cargo, and the dismissed version is not the same as update_available, you will see the notice
if update_availabe = update_dismissed, no notice int he top


### Additional comments 🎤

