### PR TITLE
fix(chat): Add padding to msg end

### DIFF
--- a/ui/src/components/chat/style.scss
+++ b/ui/src/components/chat/style.scss
@@ -242,6 +242,7 @@
     display: inline-flex;
     flex-direction: row;
     justify-content: center;
+    padding: var(--padding-less);
   }
 
   .message-group {


### PR DESCRIPTION
### What this PR does 📖

- Adds padding to p2p text at beginning of the chat

### Which issue(s) this PR fixes 🔨

- Resolve #823