### PR TITLE
fix(notification): Fix alerts not decreasing with deleted messages

### DIFF
--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -433,6 +433,10 @@ impl State {
                 if let Some(chat) = self.chats.all.get_mut(&conversation_id) {
                     chat.messages.retain(|msg| msg.inner.id() != message_id);
                 }
+                self.mutate(Action::RemoveNotification(
+                    notifications::NotificationKind::Message,
+                    1,
+                ));
             }
             MessageEvent::MessageReactionAdded { message } => {
                 self.update_message(message);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Fixes alert bubble not decreasing when a message has been deleted before viewing

### Which issue(s) this PR fixes 🔨

- Resolve #841