### PR TITLE
add(aria): add aria labels for ui elements

### DIFF
--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -230,6 +230,7 @@ pub fn Message<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
         },
         div {
             class: "{reactions_class}",
+            aria_label: "message-reaction-container",
             cx.props.reactions.iter().map(|reaction| {
                 let reaction_count = reaction.reaction_count;
                 let emoji = &reaction.emoji;
@@ -242,6 +243,14 @@ pub fn Message<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                             format_args!("emoji-reaction {}", if reaction.self_reacted {
                             "emoji-reaction-self"
                         } else { "" }),
+                        aria_label: {
+                            format_args!(
+                                "emoji-reaction-{}",
+                                if reaction.self_reacted {
+                                    "self"
+                                } else { "remote" }
+                            )
+                        },
                         onclick: move |_| {
                             cx.props.on_click_reaction.call(emoji.clone());
                         },

--- a/kit/src/components/slide_selector/mod.rs
+++ b/kit/src/components/slide_selector/mod.rs
@@ -43,6 +43,7 @@ where
         class: "slide-selector",
         aria_label: "slide-selector",
         Button {
+            aria_label: "slide-selector-minus".into(),
             icon: if buttons_format == ButtonsFormat::PlusAndMinus {Shape::Minus} else {Shape::ArrowLeft},
             disabled: *index.get() == 0,
             onpress: move |_| {
@@ -57,10 +58,12 @@ where
             },
         },
         span {
+            aria_label: "slide-selector-value",
             class: "slide-selector__value",
             "{converted_display}",
         },
         Button {
+            aria_label: "slide-selector-plus".into(),
             icon: if buttons_format == ButtonsFormat::PlusAndMinus {Shape::Plus} else {Shape::ArrowRight},
             disabled: *index.get() >= (cx.props.values.len() - 1),
             onpress: move |_| {

--- a/kit/src/components/user/mod.rs
+++ b/kit/src/components/user/mod.rs
@@ -81,10 +81,12 @@ pub fn User<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                             aria_label: "User Badge",
                             span {
                                 class: "badge-prefix",
+                                aria_label: "badge-prefix",
                                 "{time_ago}"
                             }
                             span {
                                 class: "badge-count",
+                                aria_label: "badge-count",
                                 "{badge}"
                             }
                         }

--- a/kit/src/components/user_image/mod.rs
+++ b/kit/src/components/user_image/mod.rs
@@ -74,11 +74,13 @@ pub fn UserImage<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     aria_label: "User Image",
                     div {
                         class: "image",
+                        aria_label: "user-image-profile",
                         style: "background-image: url('{image_data}');"
                     },
                     typing.then(|| rsx!(
                         div {
                             class: "profile-typing",
+                            aria_label: "profile-typing",
                             div { class: "dot dot-1" },
                             div { class: "dot dot-2" },
                             div { class: "dot dot-3" }

--- a/kit/src/components/user_image_group/mod.rs
+++ b/kit/src/components/user_image_group/mod.rs
@@ -75,6 +75,7 @@ pub fn UserImageGroup<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     },
                     cx.props.with_username.as_ref().map(|username| rsx!(
                         Label {
+                            aria_label: username.into(),
                             text: username.to_string()
                         }
                     ))

--- a/native_extensions/emoji_selector/src/lib.rs
+++ b/native_extensions/emoji_selector/src/lib.rs
@@ -144,6 +144,7 @@ fn render_selector<'a>(
                     }
                 },
                 id: "emoji_selector",
+                aria_label: "emoji-selector",
                 tabindex: "0",
                 onblur: |_| {
                     #[cfg(target_os = "macos")] 
@@ -172,9 +173,11 @@ fn render_selector<'a>(
                             }
                             div {
                                 class: "emojis-container",
+                                aria_label: "emojis-container",
                                 group.emojis().map(|emoji| {
                                     rsx!(
                                         div {
+                                            aria_label: "emoji",
                                             class: "emoji",
                                             onclick: move |_| {
                                                 // If we're on an active chat, append the emoji to the end of the chat message.

--- a/ui/src/components/chat/compose/messages.rs
+++ b/ui/src/components/chat/compose/messages.rs
@@ -800,6 +800,7 @@ fn render_message<'a>(cx: Scope<'a, MessageProps<'a>>) -> Element<'a> {
             rsx!(
                 div {
                     id: "add-message-reaction",
+                    aria_label: "add-message-reaction",
                     class: "{reactions_class} pointer",
                     tabindex: "0",
                     onmouseleave: |_| {
@@ -815,6 +816,7 @@ fn render_message<'a>(cx: Scope<'a, MessageProps<'a>>) -> Element<'a> {
                     reactions.iter().cloned().map(|reaction| {
                         rsx!(
                             div {
+                                aria_label: "{reaction}",
                                 onclick: move |_|  {
                                     reacting_to.set(None);
                                     state.write().ui.ignore_focus = false;

--- a/ui/src/components/chat/create_group.rs
+++ b/ui/src/components/chat/create_group.rs
@@ -107,10 +107,12 @@ pub fn CreateGroup<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             aria_label: "Create Group",
             div {
                 id: "create-group-name",
+                aria_label: "create-group-name",
                 class: "create-group-name",
                 div {
                     align_items: "start",
                     Label {
+                        aria_label: "group-name-label".into(),
                         text: get_local_text("messages.group-name"),
                     },
                 }
@@ -134,13 +136,14 @@ pub fn CreateGroup<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             div {
                 class: "search-input",
                 Label {
+                    aria_label: "users-label".into(),
                     text: "Users".into(),
                 },
                 Input {
                     // todo: filter friends on input
                     placeholder: get_local_text("uplink.search-placeholder"),
                     disabled: false,
-                    aria_label: "chat-search-input".into(),
+                    aria_label: "friend-search-input".into(),
                     icon: Icon::MagnifyingGlass,
                     options: Options {
                         with_clear_btn: true,
@@ -196,6 +199,7 @@ fn render_friends(cx: Scope<FriendsProps>) -> Element {
     cx.render(rsx!(
         div {
             class: "friend-list vertically-scrollable",
+            aria_label: "friends-list",
             cx.props.friends.iter().map(
                 |(letter, sorted_friends)| {
                     let group_letter = letter.to_string();

--- a/ui/src/components/chat/edit_group.rs
+++ b/ui/src/components/chat/edit_group.rs
@@ -221,6 +221,7 @@ pub fn EditGroup<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 class: "edit-group-name", 
                 Label {
                     text: get_local_text("messages.group-name"),
+                    aria_label: "group-name-label".into(),
                 },
                 Input {
                         placeholder:  get_local_text("messages.group-name"),
@@ -262,7 +263,7 @@ pub fn EditGroup<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     // todo: filter friends on input
                     placeholder: get_local_text("uplink.search-placeholder"),
                     disabled: false,
-                    aria_label: "chat-search-input".into(),
+                    aria_label: "friend-search-input".into(),
                     icon: Icon::MagnifyingGlass,
                     options: Options {
                         with_clear_btn: true,
@@ -284,6 +285,7 @@ pub fn EditGroup<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     div {
                         key: "add-button",
                         Button {
+                            aria_label: "add-button".into(),
                             text: get_local_text("uplink.add"),
                             appearance: Appearance::Primary,
                             onpress: move |e| {
@@ -299,6 +301,7 @@ pub fn EditGroup<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     div {
                         key: "remove-button",
                         Button {
+                            aria_label: "remove-button".into(),
                             text: get_local_text("uplink.remove"),
                             appearance: Appearance::Primary,
                             onpress: move |e| {
@@ -326,6 +329,7 @@ fn render_friends(cx: Scope<FriendsProps>) -> Element {
     cx.render(rsx!(
         div {
             class: "friend-list vertically-scrollable",
+            aria_label: "friends-list",
             cx.props.friends.iter().map(
                 |(letter, sorted_friends)| {
                     let group_letter = letter.to_string();
@@ -333,6 +337,7 @@ fn render_friends(cx: Scope<FriendsProps>) -> Element {
                         div {
                             key: "friend-group-{group_letter}",
                             class: "friend-group",
+                            aria_label: "friend-group",
                             sorted_friends.iter().filter(|friend| {
                                 let name = friend.username();
                                 if name.len() < name_prefix.len() {
@@ -403,6 +408,7 @@ fn render_friend(cx: Scope<FriendProps>) -> Element {
                     onclick: move |_| {
                         update_fn();
                     },
+                    aria_label: "friend-username",
                     cx.props.friend.username(),
                 },
             },

--- a/ui/src/components/chat/group_users.rs
+++ b/ui/src/components/chat/group_users.rs
@@ -54,6 +54,7 @@ pub fn GroupUsers(cx: Scope<Props>) -> Element {
             div {
                 class: "search-input",
                 Label {
+                    aria_label: "number-of-participants".into(),
                     text: format!("{} {}", _friends_in_group.len(),  get_local_text(
                         if _friends_in_group.len() > 1 {
                             "messages.participants"
@@ -66,7 +67,7 @@ pub fn GroupUsers(cx: Scope<Props>) -> Element {
                     // todo: filter friends on input
                     placeholder: get_local_text("uplink.search-placeholder"),
                     disabled: false,
-                    aria_label: "chat-search-input".into(),
+                    aria_label: "friend-search-input".into(),
                     icon: Icon::MagnifyingGlass,
                     options: Options {
                         with_clear_btn: true,
@@ -100,6 +101,7 @@ fn render_friends(cx: Scope<FriendsProps>) -> Element {
     cx.render(rsx!(
         div {
             class: "friend-list vertically-scrollable",
+            aria_label: "friends-list",
             cx.props.friends.iter().map(
                 |(letter, sorted_friends)| {
                     let group_letter = letter.to_string();
@@ -145,6 +147,7 @@ fn render_friend(cx: Scope<FriendProps>) -> Element {
             div {
                 class: "flex-1",
                 p {
+                    aria_label: "friend-username",
                     cx.props.friend.username(),
                 },
             },

--- a/ui/src/components/chat/sidebar.rs
+++ b/ui/src/components/chat/sidebar.rs
@@ -253,6 +253,7 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
                     aria_label: "Favorites",
                     Label {
                         text: get_local_text("favorites.favorites"),
+                        aria_label: "favorites-label".into(),
                     },
                     div {
                         class: "vertically-scrollable",
@@ -323,6 +324,7 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
                         class: "sidebar-chats-header",
                         Label {
                             text: get_local_text("uplink.chats"),
+                            aria_label: "chats-label".into(),
                         },
                         Button {
                             appearance: if *show_create_group.get() { Appearance::Primary } else { Appearance::Secondary },

--- a/ui/src/components/chat/welcome/mod.rs
+++ b/ui/src/components/chat/welcome/mod.rs
@@ -38,6 +38,7 @@ pub fn Welcome(cx: Scope) -> Element {
                 }
                 img {
                     class: "image",
+                    aria_label: "welcome-image",
                     src:"{image_path}"
                 },
                 p {

--- a/ui/src/components/debug_logger/mod.rs
+++ b/ui/src/components/debug_logger/mod.rs
@@ -43,6 +43,7 @@ pub fn DebugLogger(cx: Scope) -> Element {
                 aria_label: "debug-logger-header",
                 Label {
                     text: "Logger".into()
+                    aria_label: "logger-label".into()
                 }
             },
             div {

--- a/ui/src/components/friends/add.rs
+++ b/ui/src/components/friends/add.rs
@@ -165,6 +165,7 @@ pub fn AddFriend(cx: Scope) -> Element {
             class: "add-friend",
             Label {
                 text: get_local_text("friends.add"),
+                aria_label: "add-friend-label".into(),
             },
             div {
                 class: "body",

--- a/ui/src/components/friends/blocked/mod.rs
+++ b/ui/src/components/friends/blocked/mod.rs
@@ -60,6 +60,7 @@ pub fn BlockedUsers(cx: Scope) -> Element {
             aria_label: "Blocked List",
             Label {
                 text: get_local_text("friends.blocked"),
+                aria_label: "blocked-list-label".into(),
             },
             block_list.into_iter().map(|blocked_user| {
                 let did = blocked_user.did_key();

--- a/ui/src/components/friends/friends_list/mod.rs
+++ b/ui/src/components/friends/friends_list/mod.rs
@@ -165,6 +165,7 @@ pub fn Friends(cx: Scope) -> Element {
             aria_label: "Friends List",
             Label {
                 text: get_local_text("friends.friends"),
+                aria_label: "friends-list-label".into(),
             },
             friends.into_iter().map(|(letter, sorted_friends)| {
                 let group_letter = letter.to_string();
@@ -173,6 +174,7 @@ pub fn Friends(cx: Scope) -> Element {
                         key: "friend-group-{group_letter}",
                         Label {
                             text: letter.into(),
+                            aria_label: letter.into()
                         },
                         sorted_friends.into_iter().map(|friend| {
                             let did = friend.did_key();

--- a/ui/src/components/friends/incoming_requests/mod.rs
+++ b/ui/src/components/friends/incoming_requests/mod.rs
@@ -89,6 +89,7 @@ pub fn PendingFriends(cx: Scope) -> Element {
             aria_label: "Incoming Requests List",
             Label {
                 text: get_local_text("friends.incoming_requests"),
+                aria_label: "incoming-list-label".into(),
             },
             friends_list.into_iter().map(|friend| {
                 let friend = Rc::new(friend);

--- a/ui/src/components/friends/outgoing_requests/mod.rs
+++ b/ui/src/components/friends/outgoing_requests/mod.rs
@@ -56,6 +56,7 @@ pub fn OutgoingRequests(cx: Scope) -> Element {
             aria_label: "Outgoing Requests List",
             Label {
                 text: get_local_text("friends.outgoing_requests"),
+                aria_label: "outgoing-list-label".into(),
             },
             friends_list.into_iter().map(|friend| {
                 let did = friend.did_key();

--- a/ui/src/components/settings/mod.rs
+++ b/ui/src/components/settings/mod.rs
@@ -23,8 +23,10 @@ pub fn SettingSection<'a>(cx: Scope<'a, SectionProps<'a>>) -> Element<'a> {
                 aria_label: "settings-info",
                 Label {
                     text: cx.props.section_label.clone(),
+                    aria_label: cx.props.section_label.clone().into(),
                 },
                 p {
+                    aria_label: "settings-info-description",
                     "{cx.props.section_description}"
                 }
             },

--- a/ui/src/components/settings/mod.rs
+++ b/ui/src/components/settings/mod.rs
@@ -23,10 +23,8 @@ pub fn SettingSection<'a>(cx: Scope<'a, SectionProps<'a>>) -> Element<'a> {
                 aria_label: "settings-info",
                 Label {
                     text: cx.props.section_label.clone(),
-                    aria_label: cx.props.section_label.clone()
                 },
                 p {
-                    aria_label: "settings-info-description",
                     "{cx.props.section_description}"
                 }
             },

--- a/ui/src/components/settings/mod.rs
+++ b/ui/src/components/settings/mod.rs
@@ -23,7 +23,7 @@ pub fn SettingSection<'a>(cx: Scope<'a, SectionProps<'a>>) -> Element<'a> {
                 aria_label: "settings-info",
                 Label {
                     text: cx.props.section_label.clone(),
-                    aria_label: cx.props.section_label.clone().into(),
+                    aria_label: cx.props.section_label.clone()
                 },
                 p {
                     aria_label: "settings-info-description",

--- a/ui/src/components/settings/sub_pages/profile/mod.rs
+++ b/ui/src/components/settings/sub_pages/profile/mod.rs
@@ -270,6 +270,7 @@ pub fn ProfileSettings(cx: Scope) -> Element {
                     class: "content-item",
                     Label {
                         text: get_local_text("uplink.username"),
+                        aria_label: "profile-username-label".into(),
                     },
                     div {
                         class: "profile-group-username",
@@ -294,6 +295,7 @@ pub fn ProfileSettings(cx: Scope) -> Element {
                             class: "profile-id-btn",
                             Button {
                                 appearance: Appearance::SecondaryLess,
+                                aria_label: "copy-id-button".into(),
                                 text: did_short.to_string(),
                                 tooltip: cx.render(rsx!(
                                     Tooltip{
@@ -320,6 +322,7 @@ pub fn ProfileSettings(cx: Scope) -> Element {
                     class: "content-item",
                     Label {
                         text: get_local_text("uplink.status"),
+                        aria_label: "profile-status-label".into(),
                     },
                     Input {
                         placeholder: get_local_text("uplink.status"),

--- a/ui/src/extension_browser/mod.rs
+++ b/ui/src/extension_browser/mod.rs
@@ -54,8 +54,10 @@ pub fn Explore(cx: Scope) -> Element {
     cx.render(rsx! (
         div {
             class: "extensions-explore",
+            aria_label: "extensions-explore",
             span {
                 class: "banner",
+                aria_label: "extensions-explore-banner",
                 get_local_text("settings-extensions.banner")
             },
             Input {
@@ -136,6 +138,7 @@ pub fn ExtensionsBrowser(cx: Scope) -> Element {
     cx.render(rsx!(
         div {
             id: "extensions-browser",
+            aria_label: "extensions-browser",
             Nav {
                 active: routes[0].clone(),
                 bubble: true,

--- a/ui/src/layouts/storage/mod.rs
+++ b/ui/src/layouts/storage/mod.rs
@@ -236,6 +236,7 @@ pub fn FilesLayout(cx: Scope<Props>) -> Element {
                             rsx!(
                                 p {
                                     class: "free-space",
+                                    aria_label: "free-space-max-size",
                                     format!("{}", get_local_text("files.storage-max-size")),
                                     span {
                                         class: "count",
@@ -244,6 +245,7 @@ pub fn FilesLayout(cx: Scope<Props>) -> Element {
                                 },
                                 p {
                                     class: "free-space",
+                                    aria_label: "free-space-current-size",
                                     format!("{}", get_local_text("files.storage-current-size")),
                                     span {
                                         class: "count",
@@ -278,6 +280,7 @@ pub fn FilesLayout(cx: Scope<Props>) -> Element {
                                     icon: Icon::Home,
                                 },
                                 p {
+                                    aria_label: "home-dir",
                                     "{home_text}",
                                 }
                             })
@@ -290,6 +293,7 @@ pub fn FilesLayout(cx: Scope<Props>) -> Element {
                                 },
                                 aria_label: "crumb",
                                 p {
+                                    aria_label: "{folder_name_formatted}",
                                     "{folder_name_formatted}"
                                 }
                             },)


### PR DESCRIPTION
### What this PR does 📖

- Adding aria labels for several UI elements, which are missing now and required to keep building/improving tests, mostly on group chats, settings, sidebar, reactions and files storage texts
- Changing the aria label for user/friend input from "chat-search-input" to "friend-search-input"

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

