### PR TITLE
fix(files): Fix path decoding issue on linux for file dragging

### DIFF
--- a/ui/src/layouts/storage/functions.rs
+++ b/ui/src/layouts/storage/functions.rs
@@ -161,7 +161,9 @@ pub fn verify_if_there_are_valid_paths(files_local_path: &Vec<PathBuf>) -> bool 
     if files_local_path.is_empty() {
         false
     } else {
-        files_local_path.first().map_or(false, |path| path.exists())
+        decoded_pathbufs(files_local_path.clone())
+            .first()
+            .map_or(false, |path| path.exists())
     }
 }
 


### PR DESCRIPTION
### What this PR does 📖

- Fixes the file verification for drag and drop not taking decoding into consideration. Noticeable on linux when you try to e.g. drag and drop a file with whitespace.