### PR TITLE
fix(chat): Fix contents not wrapped in top bar

### DIFF
--- a/ui/src/components/chat/style.scss
+++ b/ui/src/components/chat/style.scss
@@ -296,6 +296,7 @@
   -webkit-line-clamp: 1; /* number of lines to show */
   line-clamp: 1;
   -webkit-box-orient: vertical;
+  word-wrap: anywhere;
 }
 
 #favorites {


### PR DESCRIPTION
### What this PR does 📖

- Fixes content in topbar not getting wrapped which fixes long status getting cutoff

### Which issue(s) this PR fixes 🔨

- Resolve #884 