### PR TITLE
fix(emoji): Fix wrong emoji icon

### DIFF
--- a/native_extensions/emoji_selector/src/lib.rs
+++ b/native_extensions/emoji_selector/src/lib.rs
@@ -38,7 +38,7 @@ fn build_nav(cx: Scope) -> Element<'a> {
         Route {
             to: "Smileys & Emotion",
             name: group_to_str(Group::SmileysAndEmotion),
-            icon: Icon::Flag,
+            icon: Icon::FaceSmile,
             with_badge: None,
             loading: None,
         },


### PR DESCRIPTION
### What this PR does 📖

- Fixes faces section using flag icon instead of face icon

### Which issue(s) this PR fixes 🔨

- Resolve #883 