### PR TITLE
fix(logger): Hide logger when loading app

### DIFF
--- a/kit/src/elements/input/mod.rs
+++ b/kit/src/elements/input/mod.rs
@@ -390,7 +390,6 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     onblur: move |_| {
                         if onblur_active {
                             emit_return(&cx, val.read().to_string(), *valid.current(), Code::Enter);
-                            valid.set(false);
                             if options.clear_on_submit {
                                 reset_fn();
                             }
@@ -415,17 +414,11 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     onkeyup: move |evt| {
                         if evt.code() == Code::Enter || evt.code() == Code::NumpadEnter {
                             emit_return(&cx, val.read().to_string(), *valid.current(), evt.code());
-                            if *valid.current() {
-                                 valid.set(false);
-                            }
                             if options.clear_on_submit {
                                 reset_fn();
                             }
                         } else if options.react_to_esc_key && evt.code() == Code::Escape {
                             emit_return(&cx, "".to_owned(), min_length == 0, evt.code());
-                            if *valid.current() {
-                                valid.set(false);
-                           }
                             if options.clear_on_submit {
                                 reset_fn();
                            }

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1070,6 +1070,9 @@ pub fn get_download_modal<'a>(
 
 fn get_logger(cx: Scope) -> Element {
     let state = use_shared_state::<State>(cx)?;
+    if !state.read().initialized {
+        return cx.render(rsx!(()));
+    }
 
     cx.render(rsx!(state
         .read()


### PR DESCRIPTION
### What this PR does 📖

- Hides the logger when the app is still loading

### Which issue(s) this PR fixes 🔨

- Resolve #902