### PR TITLE
fix(logger): Hide logger when loading app

### DIFF
--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1071,6 +1071,10 @@ pub fn get_download_modal<'a>(
 fn get_logger(cx: Scope) -> Element {
     let state = use_shared_state::<State>(cx)?;
 
+    if !state.read().initialized {
+        return cx.render(rsx!(()));
+    }
+
     cx.render(rsx!(state
         .read()
         .configuration


### PR DESCRIPTION
### What this PR does 📖

- Hides the logger when the app is still loading

### Which issue(s) this PR fixes 🔨

- Resolve #902