### PR TITLE
fix(group): Fix clear button in group creation not resetting

### DIFF
--- a/kit/src/elements/input/mod.rs
+++ b/kit/src/elements/input/mod.rs
@@ -444,6 +444,7 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                             }
                             // re-focus the input after clearing it
                             eval(focus_script.clone());
+                            emit(&cx, String::new(), *valid.get());
                         },
                         IconElement {
                             icon: options.clear_btn_icon

--- a/ui/src/components/chat/create_group.rs
+++ b/ui/src/components/chat/create_group.rs
@@ -148,6 +148,7 @@ pub fn CreateGroup<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     options: Options {
                         with_clear_btn: true,
                         react_to_esc_key: true,
+                        clear_on_submit: false,
                         ..Options::default()
                     },
                     onchange: move |(v, _): (String, _)| {

--- a/ui/src/components/chat/edit_group.rs
+++ b/ui/src/components/chat/edit_group.rs
@@ -268,6 +268,7 @@ pub fn EditGroup<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     options: Options {
                         with_clear_btn: true,
                         react_to_esc_key: true,
+                        clear_on_submit: false,
                         ..Options::default()
                     },
                     onchange: move |(v, _): (String, _)| {


### PR DESCRIPTION
### What this PR does 📖

- Fix clear button on user filter in group creation not resetting the filter

### Which issue(s) this PR fixes 🔨

- Resolve #896