### PR TITLE
feat(logger): Add min height for debug logger

### DIFF
--- a/ui/src/components/debug_logger/script.js
+++ b/ui/src/components/debug_logger/script.js
@@ -12,6 +12,8 @@ interact(".resize-vert-top")
         // translate when resizing from top edge
         y += event.deltaRect.top
         target.style.transform = "translate(" + x + "px," + y + "px)"
+        // limit to the headers size
+        target.style.minHeight = target.getElementsByClassName("header")[0].clientHeight  + "px"
       },
     },
   })


### PR DESCRIPTION
### What this PR does 📖

- Adds a minimum height for debug logger making it impossible to hide it completely. There will always be a bit left of the logger to make it able to expand again after collapsing

### Which issue(s) this PR fixes 🔨

- Resolve #901