### PR TITLE
fix(unreads): fix count of unread messages for simple cases

### DIFF
--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -467,16 +467,26 @@ impl State {
             MessageEvent::Deleted {
                 conversation_id,
                 message_id,
-                message_time,
             } => {
                 // can't have 2 mutable borrows
                 let mut should_decrement_notifications = false;
                 if let Some(chat) = self.chats.all.get_mut(&conversation_id) {
-                    chat.messages.retain(|msg| msg.inner.id() != message_id);
-                    if chat.is_msg_unread(message_time) {
-                        chat.unreads = chat.unreads.saturating_sub(1);
-                        should_decrement_notifications = true;
+                    // can't fetch the deleted message from RayGun because it no longer exists there.
+                    // Not going to ask that the RayGun event be updated at this time because having this
+                    // information doesn't guarantee we can determine if the deleted message was unread.
+                    // Knowing this basically requires that RayGun  or warp_runner knows how many
+                    // unread messages there are. But that information is in State.
+                    if let Some(msg) = chat
+                        .messages
+                        .iter()
+                        .find(|msg| msg.inner.id() == message_id)
+                    {
+                        if chat.is_msg_unread(msg.inner.date()) {
+                            chat.unreads = chat.unreads.saturating_sub(1);
+                            should_decrement_notifications = true;
+                        }
                     }
+                    chat.messages.retain(|msg| msg.inner.id() != message_id);
                 }
 
                 if should_decrement_notifications {

--- a/common/src/warp_runner/ui_adapter/message_event.rs
+++ b/common/src/warp_runner/ui_adapter/message_event.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use derive_more::Display;
 use uuid::Uuid;
 use warp::{
@@ -35,7 +34,6 @@ pub enum MessageEvent {
     Deleted {
         conversation_id: Uuid,
         message_id: Uuid,
-        message_time: DateTime<Utc>,
     },
     #[display(fmt = "MessageReactionAdded")]
     MessageReactionAdded { message: warp::raygun::Message },
@@ -94,14 +92,10 @@ pub async fn convert_message_event(
         MessageEventKind::MessageDeleted {
             conversation_id,
             message_id,
-        } => {
-            let message = messaging.get_message(conversation_id, message_id).await?;
-            MessageEvent::Deleted {
-                conversation_id,
-                message_id,
-                message_time: message.date(),
-            }
-        }
+        } => MessageEvent::Deleted {
+            conversation_id,
+            message_id,
+        },
         MessageEventKind::MessageReactionAdded {
             conversation_id,
             message_id,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- This PR can detect if the message deleted had been read most of the time. Detecting it all the time would require an extra call to warp_runner. This is all carefully explained in the comments. 
- This PR is a small improvement over #839. 

### Which issue(s) this PR fixes 🔨

- Resolve #830 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

