### PR TITLE
fix(settings): Change update message in the about section

### DIFF
--- a/common/locales/en-US/main.ftl
+++ b/common/locales/en-US/main.ftl
@@ -257,8 +257,10 @@ settings-about = About Settings
     .open-codebase = Open Source Code
     .open-codebase-description = Opens the codebase in your default web browser.
     .no-update-available = Your software is up to date!
-    .update-check-error = Failed to fetch update. Please check your internet connection.
-    
+    .update-check-error = Failed to fetch update! Check your logs for more info.
+    .update-check-error-timeout = Failed to fetch update! Request timed out.
+    .update-check-error-request = Failed to fetch update! Couldn't send update request. Please check your internet connection.
+
 media-player = Media Player 
     .enable-camera = Enable Camera 
     .fullscreen = Fullscreen

--- a/ui/src/components/settings/sub_pages/about.rs
+++ b/ui/src/components/settings/sub_pages/about.rs
@@ -46,13 +46,22 @@ pub fn AboutPage(cx: Scope) -> Element {
                         download_available.set(opt);
                     }
                     Err(e) => {
+                        let opt_err: Option<&reqwest::Error> = e.downcast_ref();
+                        let msg = match opt_err {
+                            Some(e) => {
+                                // Most common ones. Else display a generic error message
+                                if e.is_timeout() {
+                                    "settings-about.update-check-error-timeout"
+                                } else if e.is_request() {
+                                    "settings-about.update-check-error-request"
+                                } else {
+                                    "settings-about.update-check-error"
+                                }
+                            }
+                            None => "settings-about.update-check-error",
+                        };
                         state.write().mutate(Action::AddToastNotification(
-                            ToastNotification::init(
-                                "".into(),
-                                get_local_text("settings-about.update-check-error"),
-                                None,
-                                4,
-                            ),
+                            ToastNotification::init("".into(), get_local_text(msg), None, 4),
                         ));
                         log::error!("failed to check for updates: {e}");
                     }


### PR DESCRIPTION
### What this PR does 📖

- Changes the current message when failing to fetch an update to a more generic one. (Currently it always says `check your internet connection`
- Also add different message for when internet is actually missing and/or the page timed out

### Which issue(s) this PR fixes 🔨

- Resolve #876