### PR TITLE
fix(groups): Make group friend filter case insensitive

### DIFF
--- a/ui/src/components/chat/create_group.rs
+++ b/ui/src/components/chat/create_group.rs
@@ -212,7 +212,7 @@ fn render_friends(cx: Scope<FriendsProps>) -> Element {
                                 if name.len() < name_prefix.len() {
                                     false
                                 } else {
-                                    &name[..(name_prefix.len())] == name_prefix.to_lowercase()
+                                    name[..(name_prefix.len())] == name_prefix.to_lowercase()
                                 }
                             } ).map(|_friend| {
                                 rsx!(

--- a/ui/src/components/chat/create_group.rs
+++ b/ui/src/components/chat/create_group.rs
@@ -208,11 +208,11 @@ fn render_friends(cx: Scope<FriendsProps>) -> Element {
                             key: "friend-group-{group_letter}",
                             class: "friend-group",
                             sorted_friends.iter().filter(|friend| {
-                                let name = friend.username();
+                                let name = friend.username().to_lowercase();
                                 if name.len() < name_prefix.len() {
                                     false
                                 } else {
-                                    &name[..(name_prefix.len())] == name_prefix
+                                    &name[..(name_prefix.len())] == name_prefix.to_lowercase()
                                 }
                             } ).map(|_friend| {
                                 rsx!(

--- a/ui/src/components/chat/edit_group.rs
+++ b/ui/src/components/chat/edit_group.rs
@@ -343,7 +343,7 @@ fn render_friends(cx: Scope<FriendsProps>) -> Element {
                                 if name.len() < name_prefix.len() {
                                     false
                                 } else {
-                                    &name[..(name_prefix.len())] == name_prefix.to_lowercase()
+                                    name[..(name_prefix.len())] == name_prefix.to_lowercase()
                                 }
                             } ).map(|_friend| {
                                 rsx!(

--- a/ui/src/components/chat/edit_group.rs
+++ b/ui/src/components/chat/edit_group.rs
@@ -339,11 +339,11 @@ fn render_friends(cx: Scope<FriendsProps>) -> Element {
                             class: "friend-group",
                             aria_label: "friend-group",
                             sorted_friends.iter().filter(|friend| {
-                                let name = friend.username();
+                                let name = friend.username().to_lowercase();
                                 if name.len() < name_prefix.len() {
                                     false
                                 } else {
-                                    &name[..(name_prefix.len())] == name_prefix
+                                    &name[..(name_prefix.len())] == name_prefix.to_lowercase()
                                 }
                             } ).map(|_friend| {
                                 rsx!(


### PR DESCRIPTION
### What this PR does 📖

- Makes the friend search for creating and editing groups case insensitive

### Which issue(s) this PR fixes 🔨

- Resolve #921

### Additional comments 🎤

Should the same be done for the search bar at the top of the sidebar that filters for chats?