### PR TITLE
fix(cargo): remove warning from cargo build

### DIFF
--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -84,5 +84,3 @@ core-foundation = "0.9.3"
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1.12"
 
-[profile.release]
-panic = 'abort'


### PR DESCRIPTION
### What this PR does 📖

- removes this warning!
![image](https://github.com/Satellite-im/Uplink/assets/223338/7708b721-7368-4ff8-bafb-d6041a7e338f)


### Which issue(s) this PR fixes 🔨

### Special notes for reviewers 🗒️

Just removes that warning above when you cargo build or cargo run. 

### Additional comments 🎤

