### PR TITLE
chore(appium): fail build job on appium workflow if app binary is not found

### DIFF
--- a/.github/workflows/ui-test-automation.yml
+++ b/.github/workflows/ui-test-automation.yml
@@ -54,6 +54,7 @@ jobs:
 
       - name: Upload Artifact ⬆️
         uses: actions/upload-artifact@v3
+        if-no-files-found: error
         env:
           NODE_OPTIONS: "--max-old-space-size=8192"
         with:
@@ -100,6 +101,7 @@ jobs:
 
       - name: Upload Executable ⬆️
         uses: actions/upload-artifact@v3
+        if-no-files-found: error
         with:
           name: Uplink-Windows
           path: |


### PR DESCRIPTION
### What this PR does 📖

- Currently, the build job on appium workflow continues trying to execute the next steps even if the app binary was not found when attempting to upload this as workflow artifact, since only a warning is displayed for this.
- So, I am updating the step of uploading the app binary as artifact to show error instead of warning if the binary is not found on next steps

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

