### PR TITLE
chore(cargo): Update dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9197,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "warp"
 version = "0.1.0"
-source = "git+https://github.com/Satellite-im/Warp?rev=2cdb98299d70bd7b555573ee9333091019f4ecf4#2cdb98299d70bd7b555573ee9333091019f4ecf4"
+source = "git+https://github.com/Satellite-im/Warp?rev=7882a03c34dc09352e0a6ade3760bcf816221e7b#7882a03c34dc09352e0a6ade3760bcf816221e7b"
 dependencies = [
  "aes-gcm 0.10.2",
  "anyhow",
@@ -9253,7 +9253,7 @@ dependencies = [
 [[package]]
 name = "warp-blink-wrtc"
 version = "0.1.0"
-source = "git+https://github.com/Satellite-im/Warp?rev=2cdb98299d70bd7b555573ee9333091019f4ecf4#2cdb98299d70bd7b555573ee9333091019f4ecf4"
+source = "git+https://github.com/Satellite-im/Warp?rev=7882a03c34dc09352e0a6ade3760bcf816221e7b#7882a03c34dc09352e0a6ade3760bcf816221e7b"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -9282,7 +9282,7 @@ dependencies = [
 [[package]]
 name = "warp-derive"
 version = "0.1.0"
-source = "git+https://github.com/Satellite-im/Warp?rev=2cdb98299d70bd7b555573ee9333091019f4ecf4#2cdb98299d70bd7b555573ee9333091019f4ecf4"
+source = "git+https://github.com/Satellite-im/Warp?rev=7882a03c34dc09352e0a6ade3760bcf816221e7b#7882a03c34dc09352e0a6ade3760bcf816221e7b"
 dependencies = [
  "paste",
  "quote",
@@ -9292,7 +9292,7 @@ dependencies = [
 [[package]]
 name = "warp-fs-ipfs"
 version = "0.1.0"
-source = "git+https://github.com/Satellite-im/Warp?rev=2cdb98299d70bd7b555573ee9333091019f4ecf4#2cdb98299d70bd7b555573ee9333091019f4ecf4"
+source = "git+https://github.com/Satellite-im/Warp?rev=7882a03c34dc09352e0a6ade3760bcf816221e7b#7882a03c34dc09352e0a6ade3760bcf816221e7b"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -9316,7 +9316,7 @@ dependencies = [
 [[package]]
 name = "warp-mp-ipfs"
 version = "0.1.0"
-source = "git+https://github.com/Satellite-im/Warp?rev=2cdb98299d70bd7b555573ee9333091019f4ecf4#2cdb98299d70bd7b555573ee9333091019f4ecf4"
+source = "git+https://github.com/Satellite-im/Warp?rev=7882a03c34dc09352e0a6ade3760bcf816221e7b#7882a03c34dc09352e0a6ade3760bcf816221e7b"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -9339,7 +9339,7 @@ dependencies = [
 [[package]]
 name = "warp-rg-ipfs"
 version = "0.1.0"
-source = "git+https://github.com/Satellite-im/Warp?rev=2cdb98299d70bd7b555573ee9333091019f4ecf4#2cdb98299d70bd7b555573ee9333091019f4ecf4"
+source = "git+https://github.com/Satellite-im/Warp?rev=7882a03c34dc09352e0a6ade3760bcf816221e7b#7882a03c34dc09352e0a6ade3760bcf816221e7b"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,11 @@ humansize = "2.1.3"
 window-vibrancy = "0.3.2"
 uuid = { version = "1", features = ["serde", "v4"] }
 libloading = "0.7.4"
-warp = { git = "https://github.com/Satellite-im/Warp", rev = "2cdb98299d70bd7b555573ee9333091019f4ecf4" }
-warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "2cdb98299d70bd7b555573ee9333091019f4ecf4" }
-warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "2cdb98299d70bd7b555573ee9333091019f4ecf4" }
-warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "2cdb98299d70bd7b555573ee9333091019f4ecf4" }
-warp-blink-wrtc = { git = "https://github.com/Satellite-im/Warp", rev = "2cdb98299d70bd7b555573ee9333091019f4ecf4" }
+warp = { git = "https://github.com/Satellite-im/Warp", rev = "7882a03c34dc09352e0a6ade3760bcf816221e7b" }
+warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "7882a03c34dc09352e0a6ade3760bcf816221e7b" }
+warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "7882a03c34dc09352e0a6ade3760bcf816221e7b" }
+warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "7882a03c34dc09352e0a6ade3760bcf816221e7b" }
+warp-blink-wrtc = { git = "https://github.com/Satellite-im/Warp", rev = "7882a03c34dc09352e0a6ade3760bcf816221e7b" }
 rfd = "0.11.3"
 mime = "0.3.16"
 serde = "1.0"

--- a/common/src/state/identity.rs
+++ b/common/src/state/identity.rs
@@ -10,6 +10,9 @@ pub struct Identity {
     identity: WarpIdentity,
     status: IdentityStatus,
     platform: Platform,
+    //TODO: Use `Option<String>` in the future unless this is split away
+    profile_image: String,
+    profile_banner: String,
 }
 
 impl Hash for Identity {
@@ -38,6 +41,8 @@ impl From<WarpIdentity> for Identity {
             identity,
             status: IdentityStatus::Offline,
             platform: Default::default(),
+            profile_image: String::new(),
+            profile_banner: String::new(),
         }
     }
 }
@@ -61,6 +66,8 @@ impl Identity {
             identity,
             status,
             platform,
+            profile_image: String::new(),
+            profile_banner: String::new(),
         }
     }
     pub fn identity_status(&self) -> IdentityStatus {
@@ -71,20 +78,28 @@ impl Identity {
         self.platform
     }
 
+    pub fn set_profile_picture(&mut self, image: &str) {
+        self.profile_image = image.to_string();
+    }
+
+    pub fn set_profile_banner(&mut self, image: &str) {
+        self.profile_banner = image.to_string();
+    }
+
     pub fn profile_picture(&self) -> String {
-        let picture = self.identity.profile_picture();
+        let picture = &self.profile_image;
         match self.contains_default_picture() {
             true => picture[..picture.len() - 3].to_string(),
-            false => picture,
+            false => picture.clone(),
         }
     }
 
     pub fn profile_banner(&self) -> String {
-        self.identity.profile_banner()
+        self.profile_banner.clone()
     }
 
     pub fn contains_default_picture(&self) -> bool {
-        let picture = self.identity.profile_picture();
+        let picture = &self.profile_image;
 
         if picture.is_empty() || picture.len() < 6 {
             return false;

--- a/common/src/warp_runner/manager/commands/multipass_commands.rs
+++ b/common/src/warp_runner/manager/commands/multipass_commands.rs
@@ -241,7 +241,7 @@ pub async fn handle_multipass_cmd(cmd: MultiPassCmd, warp: &mut super::super::Wa
                 .await
             {
                 Ok(_) => {
-                    let id = warp
+                    let mut id = warp
                         .multipass
                         .get_own_identity()
                         .await
@@ -250,6 +250,15 @@ pub async fn handle_multipass_cmd(cmd: MultiPassCmd, warp: &mut super::super::Wa
                             log::error!("failed to get own identity: {e}");
                             e
                         });
+                    if let Ok(id) = id.as_mut() {
+                        if let Ok(picture) = warp.multipass.identity_picture(&id.did_key()).await {
+                            id.set_profile_picture(&picture);
+                        }
+
+                        if let Ok(banner) = warp.multipass.identity_banner(&id.did_key()).await {
+                            id.set_profile_banner(&banner);
+                        }
+                    }
                     rsp.send(id)
                 }
                 Err(e) => {
@@ -269,7 +278,8 @@ pub async fn handle_multipass_cmd(cmd: MultiPassCmd, warp: &mut super::super::Wa
                     .await
                 {
                     Ok(_) => {
-                        if let Ok(picture) = warp.multipass.identity_picture(&my_id.did_key()).await {
+                        if let Ok(picture) = warp.multipass.identity_picture(&my_id.did_key()).await
+                        {
                             my_id.set_profile_picture(&picture);
                         }
 
@@ -322,7 +332,16 @@ pub async fn handle_multipass_cmd(cmd: MultiPassCmd, warp: &mut super::super::Wa
                 .await;
             let _ = match r {
                 Ok(_) => {
-                    let id = warp.multipass.get_own_identity().await.map(Identity::from);
+                    let mut id = warp.multipass.get_own_identity().await.map(Identity::from);
+                    if let Ok(id) = id.as_mut() {
+                        if let Ok(picture) = warp.multipass.identity_picture(&id.did_key()).await {
+                            id.set_profile_picture(&picture);
+                        }
+
+                        if let Ok(banner) = warp.multipass.identity_banner(&id.did_key()).await {
+                            id.set_profile_banner(&banner);
+                        }
+                    }
                     rsp.send(id)
                 }
                 Err(e) => {
@@ -336,7 +355,16 @@ pub async fn handle_multipass_cmd(cmd: MultiPassCmd, warp: &mut super::super::Wa
                 .multipass
                 .update_identity(IdentityUpdate::StatusMessage(status))
                 .await;
-            let id = warp.multipass.get_own_identity().await.map(Identity::from);
+            let mut id = warp.multipass.get_own_identity().await.map(Identity::from);
+            if let Ok(id) = id.as_mut() {
+                if let Ok(picture) = warp.multipass.identity_picture(&id.did_key()).await {
+                    id.set_profile_picture(&picture);
+                }
+
+                if let Ok(banner) = warp.multipass.identity_banner(&id.did_key()).await {
+                    id.set_profile_banner(&banner);
+                }
+            }
             let _ = match r {
                 Ok(_) => rsp.send(id),
                 Err(e) => {
@@ -350,7 +378,16 @@ pub async fn handle_multipass_cmd(cmd: MultiPassCmd, warp: &mut super::super::Wa
                 .multipass
                 .update_identity(IdentityUpdate::Username(username))
                 .await;
-            let id = warp.multipass.get_own_identity().await.map(Identity::from);
+            let mut id = warp.multipass.get_own_identity().await.map(Identity::from);
+            if let Ok(id) = id.as_mut() {
+                if let Ok(picture) = warp.multipass.identity_picture(&id.did_key()).await {
+                    id.set_profile_picture(&picture);
+                }
+
+                if let Ok(banner) = warp.multipass.identity_banner(&id.did_key()).await {
+                    id.set_profile_banner(&banner);
+                }
+            }
             let _ = match r {
                 Ok(_) => rsp.send(id),
                 Err(e) => {

--- a/common/src/warp_runner/manager/commands/multipass_commands.rs
+++ b/common/src/warp_runner/manager/commands/multipass_commands.rs
@@ -269,7 +269,14 @@ pub async fn handle_multipass_cmd(cmd: MultiPassCmd, warp: &mut super::super::Wa
                     .await
                 {
                     Ok(_) => {
-                        my_id.set_profile_picture(&pfp);
+                        if let Ok(picture) = warp.multipass.identity_picture(&my_id.did_key()).await {
+                            my_id.set_profile_picture(&picture);
+                        }
+
+                        if let Ok(banner) = warp.multipass.identity_banner(&my_id.did_key()).await {
+                            my_id.set_profile_banner(&banner);
+                        }
+
                         rsp.send(Ok(my_id))
                     }
                     Err(e) => {
@@ -290,7 +297,16 @@ pub async fn handle_multipass_cmd(cmd: MultiPassCmd, warp: &mut super::super::Wa
                 .await;
             let _ = match r {
                 Ok(_) => {
-                    let id = warp.multipass.get_own_identity().await.map(Identity::from);
+                    let mut id = warp.multipass.get_own_identity().await.map(Identity::from);
+                    if let Ok(id) = id.as_mut() {
+                        if let Ok(picture) = warp.multipass.identity_picture(&id.did_key()).await {
+                            id.set_profile_picture(&picture);
+                        }
+
+                        if let Ok(banner) = warp.multipass.identity_banner(&id.did_key()).await {
+                            id.set_profile_banner(&banner);
+                        }
+                    }
                     rsp.send(id)
                 }
                 Err(e) => {

--- a/common/src/warp_runner/manager/events.rs
+++ b/common/src/warp_runner/manager/events.rs
@@ -154,8 +154,8 @@ pub async fn handle_warp_command(
             // not accepted at this stage of the program. do nothing and drop the rsp channel
         }
         WarpCmd::MultiPass(cmd) => {
-            // if a command to block a user comes in, need to update the UI because warp doesn't generate an event for a user being blocked.
-            // todo: ask for that event
+            // if a command to block a user comes in, need to update the UI
+            // todo: handle block events
             if let MultiPassCmd::Block { did, .. } = &cmd {
                 if let Ok(ident) = did_to_identity(did, &warp.multipass).await {
                     if warp_event_tx

--- a/common/src/warp_runner/ui_adapter/mod.rs
+++ b/common/src/warp_runner/ui_adapter/mod.rs
@@ -104,7 +104,17 @@ pub async fn did_to_identity(
                 .identity_platform(&id.did_key())
                 .await
                 .unwrap_or(Platform::Unknown);
-            state::Identity::new(id, status, platform)
+            let mut id = state::Identity::new(id, status, platform);
+
+            if let Ok(picture) = account.identity_picture(&id.did_key()).await {
+                id.set_profile_picture(&picture);
+            }
+
+            if let Ok(banner) = account.identity_banner(&id.did_key()).await {
+                id.set_profile_banner(&banner);
+            }
+
+            id
         }
         None => get_uninitialized_identity(did)?,
     };
@@ -125,7 +135,17 @@ pub async fn dids_to_identity(
             .identity_platform(&id.did_key())
             .await
             .unwrap_or(Platform::Unknown);
-        state::Identity::new(id, status, platform)
+        let mut id = state::Identity::new(id, status, platform);
+
+        if let Ok(picture) = account.identity_picture(&id.did_key()).await {
+            id.set_profile_picture(&picture);
+        }
+
+        if let Ok(banner) = account.identity_banner(&id.did_key()).await {
+            id.set_profile_banner(&banner);
+        }
+
+        id
     });
     let converted_ids = FuturesOrdered::from_iter(ids).collect().await;
     Ok(converted_ids)

--- a/ui/src/components/settings/sub_pages/profile/mod.rs
+++ b/ui/src/components/settings/sub_pages/profile/mod.rs
@@ -1,7 +1,7 @@
 use arboard::Clipboard;
 use common::get_images_dir;
 use common::language::get_local_text;
-use common::state::{Action, State, ToastNotification};
+use common::state::{Action, State, ToastNotification, Identity};
 use common::warp_runner::{MultiPassCmd, WarpCmd};
 use common::{icons::outline::Shape as Icon, WARP_CMD_CH};
 use dioxus::prelude::*;
@@ -17,7 +17,6 @@ use kit::elements::{
 };
 use mime::*;
 use rfd::FileDialog;
-use warp::multipass;
 use warp::{error::Error, logging::tracing::log};
 
 #[derive(Clone)]
@@ -37,7 +36,7 @@ pub fn ProfileSettings(cx: Scope) -> Element {
     let state = use_shared_state::<State>(cx)?;
     let user_status = state.read().status_message().unwrap_or_default();
     let username = state.read().username();
-    let should_update: &UseState<Option<multipass::identity::Identity>> = use_state(cx, || None);
+    let should_update: &UseState<Option<Identity>> = use_state(cx, || None);
     let update_failed: &UseState<Option<String>> = use_state(cx, || None);
     // TODO: This needs to persist across restarts but a config option seems overkill. Should we have another kind of file to cache flags?
     let identity = state.read().get_own_identity();
@@ -51,7 +50,7 @@ pub fn ProfileSettings(cx: Scope) -> Element {
 
     if let Some(ident) = should_update.get() {
         log::trace!("Updating ProfileSettings");
-        state.write().set_own_identity(ident.clone().into());
+        state.write().set_own_identity(ident.clone());
         state
             .write()
             .mutate(common::state::Action::AddToastNotification(

--- a/ui/src/components/settings/sub_pages/profile/mod.rs
+++ b/ui/src/components/settings/sub_pages/profile/mod.rs
@@ -1,7 +1,7 @@
 use arboard::Clipboard;
 use common::get_images_dir;
 use common::language::get_local_text;
-use common::state::{Action, State, ToastNotification, Identity};
+use common::state::{Action, Identity, State, ToastNotification};
 use common::warp_runner::{MultiPassCmd, WarpCmd};
 use common::{icons::outline::Shape as Icon, WARP_CMD_CH};
 use dioxus::prelude::*;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Removes profile banner and picture from multipass `Identity` and stores it as apart of the `Identity` wrapper in uplink
- Slight improvement to attachment stream for `RayGun::attach`
- Fetch images when performing any update or changes to one own identity
- Add `MultiPassCmd::GetProfilePicture` and `MultiPassCmd::GetProfileBanner`

### Which issue(s) this PR fixes 🔨
- N/A

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️
Assure that images are being properly updated for your own identity as well as any friends or participants in chat.

### Additional comments 🎤
A later PR should make it so images are fetched separately from the identity as `Identity` no longer stores its images as apart of the struct. This would, long term, reduce memory usage and improve speeds when fetching multiple identities since the images would not be apart of the struct but could be concurrently fetched allowing one to update the UI accordingly without impact to performance. Until then, images are fetched apart of various commands when performing updates to your own identity or fetching other identities. 
