### PR TITLE
fix(files): Improv file/folder renaming

### DIFF
--- a/kit/src/elements/file/mod.rs
+++ b/kit/src/elements/file/mod.rs
@@ -132,7 +132,9 @@ pub fn File<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                         },
                         Input {
                                 disabled: disabled,
-                                placeholder: placeholder,
+                                placeholder: String::new(),
+                                default_text: placeholder,
+                                select_on_focus: true,
                                 focus: true,
                                 size: Size::Small,
                                 options: Options {

--- a/kit/src/elements/folder/mod.rs
+++ b/kit/src/elements/folder/mod.rs
@@ -74,7 +74,9 @@ pub fn Folder<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                         rsx! (
                             Input {
                                 disabled: disabled,
-                                placeholder: placeholder,
+                                placeholder: String::new(),
+                                default_text: placeholder,
+                                select_on_focus: true,
                                 focus: true,
                                 size: Size::Small,
                                 options: Options {

--- a/kit/src/elements/input/mod.rs
+++ b/kit/src/elements/input/mod.rs
@@ -140,6 +140,7 @@ pub struct Props<'a> {
     #[props(optional)]
     value: Option<String>,
     options: Option<Options>,
+    select_on_focus: Option<bool>,
     onchange: Option<EventHandler<'a, (String, bool)>>,
     onreturn: Option<EventHandler<'a, (String, bool, Code)>>,
     reset: Option<UseState<bool>>,
@@ -308,7 +309,6 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
         true => "progress",
         false => "",
     };
-
     if let Some(value) = &cx.props.value {
         val.set(value.clone());
     }
@@ -380,7 +380,7 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 )),
                 input {
                     id: "{input_id}",
-                    class: "{loading_class}",
+                    class: format_args!("{} {}", loading_class, if cx.props.select_on_focus.unwrap_or_default() {"select"} else {""}),
                     aria_label: "{aria_label}",
                     spellcheck: "{false}",
                     disabled: "{disabled}",

--- a/kit/src/elements/input/script.js
+++ b/kit/src/elements/input/script.js
@@ -3,4 +3,8 @@ if (input_element == null) {
     console.log("error: could not find input_element to focus on");
 } else {
     input_element.focus();
+    if (input_element.classList.contains("select")) {
+        input_element.select();
+        input_element.classList.remove("select")
+    }
 }

--- a/ui/src/layouts/storage/mod.rs
+++ b/ui/src/layouts/storage/mod.rs
@@ -376,6 +376,7 @@ pub fn FilesLayout(cx: Scope<Props>) -> Element {
                                                 return;
                                             }
                                             storage_controller.with_mut(|i| i.is_renaming_map = None);
+                                            storage_controller.write().finish_renaming_item(false);
                                             if key_code == Code::Enter {
                                                 ch.send(ChanCmd::RenameItem{old_name: folder_name2.clone(), new_name: val});
                                             }
@@ -480,6 +481,7 @@ pub fn FilesLayout(cx: Scope<Props>) -> Element {
                                                     return;
                                                 }
                                                 storage_controller.with(|i| i.is_renaming_map.is_none());
+                                                storage_controller.write().finish_renaming_item(false);
                                                 if key_code == Code::Enter && !new_name.is_empty() && !new_name.chars().all(char::is_whitespace) {
                                                     ch.send(ChanCmd::RenameItem{old_name: file_name.clone(), new_name});
                                                 }


### PR DESCRIPTION
### What this PR does 📖

- Unfocus the rename bar when hitting enter.
- Removed placeholder text instead have it as the starting value during renaming.
  Also select the whole text at the start. This is more inline with the behavior in other file apps when renaming

### Which issue(s) this PR fixes 🔨

- Resolve #962