### PR TITLE
update(Link): Link just with www, will work as text and not as link

### DIFF
--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -88,7 +88,7 @@ pub struct Props<'a> {
 }
 
 fn wrap_links_with_a_tags(text: &str) -> String {
-    let re = Regex::new(r#"(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’]))"#).unwrap();
+    let re = Regex::new(r#"(?i)\b((?:https?://)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’]))"#).unwrap();
 
     re.replace_all(text, |caps: &regex::Captures| {
         let url = caps.get(0).unwrap().as_str();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
### 1. let "link" just with www work as text, and not as link
![image](https://github.com/Satellite-im/Uplink/assets/63157656/f3070f20-e6d3-456a-af7b-10c8df8afddd)


### Which issue(s) this PR fixes 🔨

- Resolve #979 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

