### PR TITLE
fix(sidebar): Display markdown in sidebar

### DIFF
--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -160,12 +160,7 @@ pub fn Message<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
 
     // if markdown support is enabled, we will create it, otherwise we will just pass text.
     let mut formatted_text = if cx.props.parse_markdown {
-        let txt = text.trim().replace(' ', "&nbsp;"); // need to do this else leading whitespaces are ignored
-        let parser = pulldown_cmark::Parser::new(&txt);
-        // Write to a new String buffer.
-        let mut html_output = String::new();
-        pulldown_cmark::html::push_html(&mut html_output, parser);
-        html_output.replace("<p>", "").replace("</p>", "")
+        markdown(&text)
     } else {
         text
     };
@@ -367,4 +362,13 @@ fn ChatText(cx: Scope<ChatMessageProps>) -> Element {
             })))
         }
     ))
+}
+
+pub fn markdown(text: &str) -> String {
+    let txt = text.trim().replace(' ', "&nbsp;"); // need to do this else leading whitespaces are ignored
+    let parser = pulldown_cmark::Parser::new(&txt);
+    // Write to a new String buffer.
+    let mut html_output = String::new();
+    pulldown_cmark::html::push_html(&mut html_output, parser);
+    html_output.replace("<p>", "").replace("</p>", "")
 }

--- a/kit/src/components/user/mod.rs
+++ b/kit/src/components/user/mod.rs
@@ -103,7 +103,7 @@ pub fn User<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                         p {
                             class: "subtext",
                             aria_label: "User Status",
-                            "{cx.props.subtext}"
+                            dangerous_inner_html: "{cx.props.subtext}"
                         }
                     }
                 }

--- a/ui/src/components/chat/sidebar.rs
+++ b/ui/src/components/chat/sidebar.rs
@@ -6,6 +6,7 @@ use dioxus::prelude::*;
 use dioxus_router::*;
 use futures::channel::oneshot;
 use futures::StreamExt;
+use kit::components::message::markdown;
 use kit::{
     components::{
         context_menu::{ContextItem, ContextMenu},
@@ -419,7 +420,7 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
                     };
 
                     let subtext_val = match unwrapped_message.value().iter().map(|x| x.trim()).find(|x| !x.is_empty()) {
-                        Some(v) => v.into(),
+                        Some(v) => markdown(v),
                         _ => match &unwrapped_message.attachments()[..] {
                             [] => get_local_text("sidebar.chat-new"),
                             [ file ] => file.name(),


### PR DESCRIPTION
### What this PR does 📖

- Displays the chat messages as markdown in the sidebar

### Which issue(s) this PR fixes 🔨

- Resolve  #946