### PR TITLE
chore(allure): update workflow to upload artifacts from allure report

### DIFF
--- a/.github/workflows/ui-test-automation.yml
+++ b/.github/workflows/ui-test-automation.yml
@@ -193,7 +193,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-allure-mac-ci
-          path: ./appium-tests/allure-results/*.json
+          path: ./appium-tests/allure-results/
 
       - name: Upload Screenshots for MacOS 📷
         uses: actions/upload-artifact@v3
@@ -282,7 +282,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-allure-windows-chats
-          path: ./appium-tests/allure-results/*.json
+          path: ./appium-tests/allure-results/
 
       - name: Upload Screenshots for Windows - Chats 📷
         uses: actions/upload-artifact@v3
@@ -371,7 +371,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-allure-windows-ci
-          path: ./appium-tests/allure-results/*.json
+          path: ./appium-tests/allure-results/
 
       - name: Upload Screenshots for Windows 📷
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
### What this PR does 📖

- Update ui automation tests workflow to attach all files from allure-report folder as artifact on testing jobs. This is required in order to upload the screenshots in tests failed to the Allure Test Report, which willl show like this:
![image](https://github.com/Satellite-im/Uplink/assets/35935591/73fd9f72-6707-422b-8666-d413fe926a3b)


### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

