### PR TITLE
fix(sidebar): mobile view sidebar would stick

### DIFF
--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -68,7 +68,6 @@ pub struct State {
     #[serde(skip)]
     id: DID,
     pub route: route::Route,
-    pub chats: chats::Chats,
     friends: friends::Friends,
     #[serde(skip)]
     pub storage: storage::Storage,
@@ -493,9 +492,6 @@ impl State {
                         }
                     }
                     chat.messages.retain(|msg| msg.inner.id() != message_id);
-                    if chat.unreads > 0 {
-                        chat.unreads -= 1;
-                    }
                 }
 
                 if should_decrement_notifications {
@@ -862,19 +858,6 @@ impl State {
     fn clear_unreads(&mut self, chat_id: Uuid) {
         if let Some(chat) = self.chats.all.get_mut(&chat_id) {
             chat.unreads = 0;
-        }
-    }
-    /// get unreads  within a given chat on `State` struct.
-    ///
-    /// # Arguments
-    ///
-    /// * `chat_id` - The chat to get.
-    ///
-    pub fn get_unread_count(&mut self, chat_id: Uuid) -> u32 {
-        if let Some(chat) = self.chats.all.get_mut(&chat_id) {
-            chat.unreads
-        } else {
-            0
         }
     }
     /// Adds the given chat to the user's favorites.

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -68,7 +68,7 @@ pub struct State {
     #[serde(skip)]
     id: DID,
     pub route: route::Route,
-    chats: chats::Chats,
+    pub chats: chats::Chats,
     friends: friends::Friends,
     #[serde(skip)]
     pub storage: storage::Storage,
@@ -493,6 +493,9 @@ impl State {
                         }
                     }
                     chat.messages.retain(|msg| msg.inner.id() != message_id);
+                    if chat.unreads > 0 {
+                        chat.unreads -= 1;
+                    }
                 }
 
                 if should_decrement_notifications {
@@ -859,6 +862,19 @@ impl State {
     fn clear_unreads(&mut self, chat_id: Uuid) {
         if let Some(chat) = self.chats.all.get_mut(&chat_id) {
             chat.unreads = 0;
+        }
+    }
+    /// get unreads  within a given chat on `State` struct.
+    ///
+    /// # Arguments
+    ///
+    /// * `chat_id` - The chat to get.
+    ///
+    pub fn get_unread_count(&mut self, chat_id: Uuid) -> u32 {
+        if let Some(chat) = self.chats.all.get_mut(&chat_id) {
+            chat.unreads
+        } else {
+            0
         }
     }
     /// Adds the given chat to the user's favorites.

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -68,7 +68,6 @@ pub struct State {
     #[serde(skip)]
     id: DID,
     pub route: route::Route,
-
     chats: chats::Chats,
     friends: friends::Friends,
     #[serde(skip)]

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -68,6 +68,8 @@ pub struct State {
     #[serde(skip)]
     id: DID,
     pub route: route::Route,
+
+    chats: chats::Chats,
     friends: friends::Friends,
     #[serde(skip)]
     pub storage: storage::Storage,

--- a/ui/src/layouts/loading.rs
+++ b/ui/src/layouts/loading.rs
@@ -23,7 +23,7 @@ pub fn LoadingLayout(cx: Scope) -> Element {
             } else {
                 desktop.set_inner_size(LogicalSize::new(950.0, 600.0));
             }
-            desktop.set_min_inner_size(Some(LogicalSize::new(300.0, 500.0)));
+            desktop.set_min_inner_size(Some(LogicalSize::new(950.0, 500.0)));
         }
     });
 

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -417,7 +417,7 @@ pub fn app_bootstrap(cx: Scope, identity: multipass::identity::Identity) -> Elem
         focused: desktop.is_focused(),
         maximized: desktop.is_maximized(),
         minimized: desktop.is_minimized(),
-        minimal_view: size.width < 1200, // todo: why is it that on Linux, checking if desktop.inner_size().width < 600 is true?
+        minimal_view: size.width < 600, // todo: why is it that on Linux, checking if desktop.inner_size().width < 600 is true?
     };
     state.ui.metadata = window_meta;
 
@@ -622,7 +622,7 @@ fn app(cx: Scope) -> Element {
 
                 let metadata = state.read().ui.metadata.clone();
                 let new_metadata = WindowMeta {
-                    minimal_view: size.width < 1200,
+                    minimal_view: size.width < 600,
                     ..metadata
                 };
                 if metadata != new_metadata {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -622,7 +622,7 @@ fn app(cx: Scope) -> Element {
 
                 let metadata = state.read().ui.metadata.clone();
                 let new_metadata = WindowMeta {
-                    minimal_view: size.width < 600,
+                    minimal_view: size.width < 1200,
                     ..metadata
                 };
                 if metadata != new_metadata {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -255,7 +255,7 @@ pub fn get_window_builder(with_predefined_size: bool, with_menu: bool) -> Window
         .with_title(title)
         .with_resizable(true)
         // We start the min inner size smaller because the prelude pages like unlock can be rendered much smaller.
-        .with_min_inner_size(LogicalSize::new(300.0, 350.0));
+        .with_min_inner_size(LogicalSize::new(950.0, 350.0));
 
     if with_predefined_size {
         window = window.with_inner_size(LogicalSize::new(950.0, 600.0));
@@ -417,7 +417,7 @@ pub fn app_bootstrap(cx: Scope, identity: multipass::identity::Identity) -> Elem
         focused: desktop.is_focused(),
         maximized: desktop.is_maximized(),
         minimized: desktop.is_minimized(),
-        minimal_view: size.width < 600, // todo: why is it that on Linux, checking if desktop.inner_size().width < 600 is true?
+        minimal_view: size.width < 950, // todo: why is it that on Linux, checking if desktop.inner_size().width < 600 is true?
     };
     state.ui.metadata = window_meta;
 
@@ -614,15 +614,9 @@ fn app(cx: Scope) -> Element {
                 }
                 let size = webview.inner_size();
 
-                //log::trace!(
-                //    "Resized - PhysicalSize: {:?}, Minimal: {:?}",
-                //    size,
-                //    size.width < 1200
-                //);
-
                 let metadata = state.read().ui.metadata.clone();
                 let new_metadata = WindowMeta {
-                    minimal_view: size.width < 600,
+                    minimal_view: size.width < 950,
                     ..metadata
                 };
                 if metadata != new_metadata {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- when you downsize the app a "mobile view" on Linux everything works really well when you click a chat it goes into chat, switching pages shows correct page etc etc but on MacOS and Windows you cant click into chats, and sidebar will persist when switching between pages. 

### Which issue(s) this PR fixes 🔨

- Resolve #1008

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

Currently only tested on Mac!

### Additional comments 🎤

