### PR TITLE
fix(chat): wrap username in topbar

### DIFF
--- a/ui/src/components/chat/style.scss
+++ b/ui/src/components/chat/style.scss
@@ -322,6 +322,7 @@
   -webkit-line-clamp: 1; /* number of lines to show */
   line-clamp: 1;
   -webkit-box-orient: vertical;
+  word-wrap: anywhere;
 }
 
 #compose .topbar .children .status {


### PR DESCRIPTION
### What this PR does 📖

- Warps the username in the topper preventing it rendering behind buttons

### Which issue(s) this PR fixes 🔨

- Resolve #970