### PR TITLE
add(aria): Add missing aria labels for UI elements

### DIFF
--- a/kit/src/components/embeds/file_embed/mod.rs
+++ b/kit/src/components/embeds/file_embed/mod.rs
@@ -154,6 +154,7 @@ pub fn FileEmbed<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                             open: *fullscreen_preview.clone(),
                             onclose: move |_| fullscreen_preview.set(false),
                             img {
+                                aria_label: "image-preview-modal",
                                 src: "{large_thumbnail}",
                                 onclick: move |e| e.stop_propagation(),
                             }
@@ -161,7 +162,9 @@ pub fn FileEmbed<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     )),
                     div {
                         class: "image-container",
+                        aria_label: "message-image-container",
                         img {
+                            aria_label: "message-image",
                             onclick: move |_| fullscreen_preview.set(true),
                             class: format_args!(
                                 "image {} expandable-image",

--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -189,13 +189,13 @@ pub fn Message<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             },
             aria_label: {
                 format_args!(
-                    "{}-{}",
-                    if cx.props.order.is_some() {
-                        order.to_string()
-                    } else { "".into() }, 
+                    "message-{}-{}",
                     if is_remote {
                         "remote"
                     } else { "local" },
+                    if cx.props.order.is_some() {
+                        order.to_string()
+                    } else { "".into() }
                 )
             },
             white_space: "pre-wrap",

--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -189,10 +189,13 @@ pub fn Message<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             },
             aria_label: {
                 format_args!(
-                    "message-{}",
+                    "{}-{}",
+                    if cx.props.order.is_some() {
+                        order.to_string()
+                    } else { "".into() }, 
                     if is_remote {
                         "remote"
-                    } else { "local" }
+                    } else { "local" },
                 )
             },
             white_space: "pre-wrap",

--- a/kit/src/elements/textarea/mod.rs
+++ b/kit/src/elements/textarea/mod.rs
@@ -158,6 +158,7 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                         key: "{id_char_counter}-char-counter",
                         id: "{id_char_counter}-char-counter",
                         class: "input-char-counter",
+                        aria_label: "input-char-counter",
                         format!("{}/{}", cv3.len(), max_length - 1),
                     })
                 }

--- a/kit/src/layout/modal/mod.rs
+++ b/kit/src/layout/modal/mod.rs
@@ -16,6 +16,7 @@ pub fn Modal<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     cx.render(rsx!(cx.props.open.then(|| rsx!(
         div {
             class: "modal",
+            aria_label: "modal",
             onclick: move |_| cx.props.onclose.call(()),
             Button {
                 icon: Icon::XMark,

--- a/ui/src/components/chat/sidebar.rs
+++ b/ui/src/components/chat/sidebar.rs
@@ -64,6 +64,7 @@ fn search_friends<'a>(cx: Scope<'a, SearchProps<'a>>) -> Element<'a> {
     cx.render(rsx!(
         div {
             class: "searchbar-dropdown",
+            aria_label: "searchbar-dropwdown",
             onmouseenter: |_| {
                 *cx.props.search_dropdown_hover.write_silent() = true;
             },
@@ -74,6 +75,7 @@ fn search_friends<'a>(cx: Scope<'a, SearchProps<'a>>) -> Element<'a> {
                 rsx!(
                     a {
                         class: "search-friends-dropdown",
+                        aria_label: "search-friends-result",
                         href: "#{entry.display_name}",
                         prevent_default: "onclick",
                         rel: "noopener noreferrer",

--- a/ui/src/components/files/upload_progress_bar/mod.rs
+++ b/ui/src/components/files/upload_progress_bar/mod.rs
@@ -146,16 +146,19 @@ pub fn UploadProgressBar<'a>(cx: Scope<'a, Props>) -> Element<'a> {
         return cx.render(rsx!(
             div {
                 class: "upload-progress-bar-container",
+                aria_label: "upload-progress-bar-container",
                 div {
                     class: "progress-percentage-description-container",
                     p {
                         id: "upload-progress-description",
                         class: "upload-progress-description",
+                        aria_label: "upload-progress-description",
                         get_local_text("files.uploading-file"),
                     },
                     p {
                         id: "upload-progress-percentage",
                         class: "upload-progress-percentage",
+                        aria_label: "upload-progress-percentage",
                         "0%",
                     },
                     p {
@@ -172,6 +175,7 @@ pub fn UploadProgressBar<'a>(cx: Scope<'a, Props>) -> Element<'a> {
                             div {
                                 id: "progress-percentage",
                                 class: "progress-percentage",
+                                aria_label: "progress-percentage",
                             },
                         }
                         div {
@@ -179,9 +183,11 @@ pub fn UploadProgressBar<'a>(cx: Scope<'a, Props>) -> Element<'a> {
                             p {
                                 id: "upload-progress-filename",
                                 class: "filename-and-file-queue-text",
+                                aria_label: "filename-and-file-queue-text",
                             },
                             p {
                                 id: "upload-progress-files-queue",
+                                aria_label: "upload-progress-files-queue",
                                 class: "file-queue-text",
                             },
                         }


### PR DESCRIPTION
### What this PR does 📖

- Add aria labels to use as UI element locators on appium tests for File Upload Progress Bar, Chat Messages Order, Image Preview and Modal, input char counter and sidebar search.

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

