### PR TITLE
fix(input): Add margin to textareas

### DIFF
--- a/kit/src/elements/textarea/style.scss
+++ b/kit/src/elements/textarea/style.scss
@@ -4,6 +4,7 @@ textarea {
 	width: 100%;
 	height: "auto";
 	max-height: 250px; //Maybe make max variable?
+	margin: 9px 0;
 	&.disabled {
 		cursor: not-allowed;
 		filter: brightness(85%);


### PR DESCRIPTION
### What this PR does 📖

- Adds a margin to textareas making multilines look better

Without margin:
<img width="485" alt="Screenshot 2023-07-24 at 16 50 47" src="https://github.com/Satellite-im/Uplink/assets/34157027/b7232ae4-e9e2-45c7-b44c-ced3638df5be">

With: 
<img width="538" alt="Screenshot 2023-07-24 at 16 50 26" src="https://github.com/Satellite-im/Uplink/assets/34157027/43dbe03e-367f-4bd3-aa06-d9929dd22fbf">
