### PR TITLE
chore(build): add dmg file back to release

### DIFF
--- a/.github/workflows/build-dmg-universal.yml
+++ b/.github/workflows/build-dmg-universal.yml
@@ -81,10 +81,12 @@ jobs:
         with:
           name: Uplink Universal Mac App
           path: |
+            target/release/macos/Uplink.dmg
             Uplink-Mac-Universal.zip
             Uplink-Mac-Universal.zip.sha256.txt
       - name: Copy file to release
         uses: softprops/action-gh-release@v1
         with:
           files: |
+            target/release/macos/Uplink.dmg
             Uplink-Mac-Universal.zip


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
Adds the DMG attaching back to the dmg-build action

See it working here: https://github.com/Satellite-im/Uplink-TestRelease/actions/runs/5649629730

- 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

