### PR TITLE
fix(GroupUsers): Let find users with case non sensitive

### DIFF
--- a/ui/src/components/chat/group_users.rs
+++ b/ui/src/components/chat/group_users.rs
@@ -102,7 +102,7 @@ fn render_friends(cx: Scope<FriendsProps>) -> Element {
                                 if name.len() < name_prefix.len() {
                                     false
                                 } else {
-                                    name[..(name_prefix.len())].eq_ignore_ascii_case(&name_prefix)
+                                    name[..(name_prefix.len())].eq_ignore_ascii_case(name_prefix)
                                 }
                             } ).map(|_friend| {
                                 let friendid = _friend.did_key();

--- a/ui/src/components/chat/group_users.rs
+++ b/ui/src/components/chat/group_users.rs
@@ -102,7 +102,7 @@ fn render_friends(cx: Scope<FriendsProps>) -> Element {
                                 if name.len() < name_prefix.len() {
                                     false
                                 } else {
-                                    &name[..(name_prefix.len())] == name_prefix
+                                    name[..(name_prefix.len())].eq_ignore_ascii_case(&name_prefix)
                                 }
                             } ).map(|_friend| {
                                 let friendid = _friend.did_key();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
### 1. Let find users with case non sensitive
<img width="628" alt="image" src="https://github.com/Satellite-im/Uplink/assets/63157656/4d371125-2180-42f9-9af0-914b92444755">

### Which issue(s) this PR fixes 🔨

- Resolve #1039 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

