### PR TITLE
fix(Attachments): Limit files per message and remove persistance when switching chat

### DIFF
--- a/common/locales/en-US/main.ftl
+++ b/common/locales/en-US/main.ftl
@@ -81,7 +81,7 @@ messages = Messages
     .participants = Participants
     .fetching = Fetching more messages...
     .group-creator-label = Group Creator
-    .maximum-eight-files-per-message = Maximum of 8 files can be sent in a single message.
+    .maximum-amount-files-per-message = You reached { $amount } files per message limit
     
 favorites = Favorites
     .favorites = Favorites

--- a/common/locales/en-US/main.ftl
+++ b/common/locales/en-US/main.ftl
@@ -81,6 +81,7 @@ messages = Messages
     .participants = Participants
     .fetching = Fetching more messages...
     .group-creator-label = Group Creator
+    .maximum-eight-files-per-message = Maximum of 8 files can be sent in a single message.
     
 favorites = Favorites
     .favorites = Favorites

--- a/common/src/state/action.rs
+++ b/common/src/state/action.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, rc::Weak};
+use std::{collections::HashMap, path::PathBuf, rc::Weak};
 
 use derive_more::Display;
 
@@ -159,6 +159,12 @@ pub enum Action<'a> {
     /// Sets a draft message for the chatbar for a given chat.
     #[display(fmt = "SetChatDraft")]
     SetChatDraft(Uuid, String),
+    /// Sets a files attached to send
+    #[display(fmt = "SetChatAttachments")]
+    SetChatAttachments(Uuid, Vec<PathBuf>),
+    /// Clear attachments on chat
+    #[display(fmt = "ClearChatAttachments")]
+    ClearChatAttachments(Uuid),
     /// Clears a drafted message from a given chat.
     #[display(fmt = "ClearChatDraft")]
     ClearChatDraft(Uuid),

--- a/common/src/state/chats.rs
+++ b/common/src/state/chats.rs
@@ -68,6 +68,8 @@ pub struct Chat {
     pub has_more_messages: bool,
     #[serde(skip)]
     pub pending_outgoing_messages: Vec<PendingMessage>,
+    #[serde(skip)]
+    pub files_attached_to_send: Vec<PathBuf>,
 }
 
 impl Chat {

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -857,7 +857,7 @@ impl State {
 
     fn clear_chat_attachments(&mut self, chat_id: &Uuid) {
         if let Some(c) = self.chats.all.get_mut(chat_id) {
-            c.files_attached_to_send = Vec::new();
+            c.files_attached_to_send.clear();
         }
     }
 

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -233,6 +233,10 @@ impl State {
             }
             Action::SetChatDraft(chat_id, value) => self.set_chat_draft(&chat_id, value),
             Action::ClearChatDraft(chat_id) => self.clear_chat_draft(&chat_id),
+            Action::SetChatAttachments(chat_id, value) => {
+                self.set_chat_attachments(&chat_id, value)
+            }
+            Action::ClearChatAttachments(chat_id) => self.clear_chat_attachments(&chat_id),
             Action::AddReaction(_, _, _) => todo!(),
             Action::RemoveReaction(_, _, _) => todo!(),
             Action::MockSend(id, msg) => {
@@ -851,6 +855,12 @@ impl State {
         }
     }
 
+    fn clear_chat_attachments(&mut self, chat_id: &Uuid) {
+        if let Some(c) = self.chats.all.get_mut(chat_id) {
+            c.files_attached_to_send = Vec::new();
+        }
+    }
+
     /// Clear unreads  within a given chat on `State` struct.
     ///
     /// # Arguments
@@ -1028,6 +1038,12 @@ impl State {
     ) {
         if let Some(chat) = self.chats.all.get_mut(&conv_id) {
             chat.remove_pending_msg(msg, attachments, uuid);
+        }
+    }
+
+    fn set_chat_attachments(&mut self, chat_id: &Uuid, value: Vec<PathBuf>) {
+        if let Some(c) = self.chats.all.get_mut(chat_id) {
+            c.files_attached_to_send = value;
         }
     }
 

--- a/common/src/testing/mock.rs
+++ b/common/src/testing/mock.rs
@@ -129,6 +129,7 @@ fn generate_fake_chat(participants: Vec<Identity>, conversation: Uuid) -> Chat {
         draft: None,
         has_more_messages: false,
         pending_outgoing_messages: vec![],
+        files_attached_to_send: Vec::new(),
     }
 }
 

--- a/common/src/warp_runner/ui_adapter/mod.rs
+++ b/common/src/warp_runner/ui_adapter/mod.rs
@@ -211,6 +211,7 @@ pub async fn conversation_to_chat(
         draft: None,
         has_more_messages,
         pending_outgoing_messages: vec![],
+        files_attached_to_send: vec![],
     })
 }
 

--- a/kit/Cargo.toml
+++ b/kit/Cargo.toml
@@ -24,6 +24,8 @@ pulldown-cmark = "0.9.2"
 linkify = { workspace = true }
 reqwest = { workspace = true }
 select = { workspace = true }
+base64 = { workspace = true }
+mime = { workspace = true }
 
 [dependencies.uuid]
 workspace = true

--- a/kit/src/components/embeds/file_embed/mod.rs
+++ b/kit/src/components/embeds/file_embed/mod.rs
@@ -206,6 +206,7 @@ pub fn FileEmbed<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     }
                     div {
                         class: "file-info",
+                        width: "100%",
                         aria_label: "file-info",
                         p {
                             class: "name",

--- a/kit/src/components/embeds/file_embed/mod.rs
+++ b/kit/src/components/embeds/file_embed/mod.rs
@@ -77,7 +77,11 @@ pub fn FileEmbed<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 Some(size) => {
                     file_size_pending
                         .push_str(&format_args!("{}", format_size(*size, DECIMAL)).to_string());
-                    current * 100 / size
+                    if *current > 0 && *size > 0 {
+                        current * 100 / size
+                    } else {
+                        0
+                    }
                 }
                 None => 0,
             },

--- a/kit/src/components/embeds/file_embed/mod.rs
+++ b/kit/src/components/embeds/file_embed/mod.rs
@@ -213,7 +213,7 @@ pub fn FileEmbed<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                         class: "icon",
                         aria_label: "file-icon",
                         if let Some(filepath) = cx.props.filepath.clone() {
-                            let file = std::fs::read(&filepath).unwrap(); 
+                            let file = std::fs::read(&filepath).unwrap();
                             let parts_of_filename: Vec<&str> = filename.split('.').collect();
                             let mime = match parts_of_filename.last() {
                                 Some(m) => match *m {
@@ -239,13 +239,12 @@ pub fn FileEmbed<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                                         img
                                     }
                                 };
-                                rsx!(img {
+                                rsx!( img {
+                                    max_width: "120px",
+                                    max_height: "60px",
                                     aria_label: "image-preview-modal",
-                                    max_width: "50px",
-                                    src: format_args!("{}", image),
-                                    onclick: move |e| {
-                                        println!("filepath: {}", filepath.to_string_lossy().to_string());
-                                        e.stop_propagation()},
+                                    src: "{image}",
+                                    onclick: move |e| e.stop_propagation(),
                                 })
                             }
                         } else {

--- a/kit/src/components/embeds/file_embed/mod.rs
+++ b/kit/src/components/embeds/file_embed/mod.rs
@@ -21,7 +21,7 @@ pub struct Props<'a> {
     // The filename of the file
     filename: String,
 
-    // The filename of the file
+    // The local filepath of the file
     filepath: Option<PathBuf>,
 
     // The size of the file in bytes
@@ -302,7 +302,7 @@ pub fn FileEmbed<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
 }
 
 fn get_file_thumbnail_if_is_image(filepath: PathBuf, filename: String) -> String {
-    let file = match std::fs::read(&filepath) {
+    let file = match std::fs::read(filepath) {
         Ok(file) => file,
         Err(_) => {
             return String::new();

--- a/kit/src/components/embeds/file_embed/mod.rs
+++ b/kit/src/components/embeds/file_embed/mod.rs
@@ -266,7 +266,7 @@ pub fn FileEmbed<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                         p {
                             class: "name",
                             aria_label: "file-name",
-                            color: "var(--text-color-dark)",
+                            color: "var(--text-color)",
                             "{filename}"
                         },
                         p {

--- a/kit/src/components/embeds/file_embed/mod.rs
+++ b/kit/src/components/embeds/file_embed/mod.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::path::PathBuf;
 
 use crate::elements::button::Button;
@@ -57,6 +58,11 @@ pub struct Props<'a> {
 #[allow(non_snake_case)]
 pub fn FileEmbed<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let fullscreen_preview = use_state(cx, || false);
+    let file_extension = std::path::Path::new(&cx.props.filename)
+        .extension()
+        .and_then(OsStr::to_str)
+        .map(|s| format!(".{s}"))
+        .unwrap_or_default();
     let filename = &cx.props.filename;
     let download_pending = cx.props.download_pending.unwrap_or(false);
     let btn_icon = if !download_pending {
@@ -213,44 +219,44 @@ pub fn FileEmbed<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                         class: "icon",
                         aria_label: "file-icon",
                         if let Some(filepath) = cx.props.filepath.clone() {
-                            let file = std::fs::read(&filepath).unwrap();
-                            let parts_of_filename: Vec<&str> = filename.split('.').collect();
-                            let mime = match parts_of_filename.last() {
-                                Some(m) => match *m {
-                                    "png" => IMAGE_PNG.to_string(),
-                                    "jpg" => IMAGE_JPEG.to_string(),
-                                    "jpeg" => IMAGE_JPEG.to_string(),
-                                    "svg" => IMAGE_SVG.to_string(),
-                                    &_ => "".to_string(),
-                                },
-                                None => "".to_string(),
-                            };
-                            if mime.is_empty() {
-                                rsx!(IconElement {
-                                    icon: cx.props.attachment_icon.unwrap_or(Icon::Document)
-                                })
-                            } else {
-                                let image = match &file.len() {
-                                    0 => "".to_string(),
-                                    _ => {
-                                        let prefix = format!("data:{mime};base64,");
-                                        let base64_image = base64::encode(&file);
-                                        let img = prefix + base64_image.as_str();
-                                        img
+                            let thubmnail = get_file_thumbnail_if_is_image(filepath, filename.clone());
+                            if thubmnail.is_empty() {
+                                rsx!(
+                                    div {
+                                        IconElement {
+                                            icon: cx.props.attachment_icon.unwrap_or(Icon::Document)
+                                        }
+                                        if !file_extension.is_empty() {
+                                            rsx!( label {
+                                                class: "file-embed-type",
+                                                "{file_extension}"
+                                            })
+                                        }
                                     }
-                                };
+                                    )
+                            } else {
                                 rsx!( img {
                                     max_width: "120px",
                                     max_height: "60px",
                                     aria_label: "image-preview-modal",
-                                    src: "{image}",
+                                    src: "{thubmnail}",
                                     onclick: move |e| e.stop_propagation(),
                                 })
                             }
                         } else {
-                            rsx!(IconElement {
-                            icon: cx.props.attachment_icon.unwrap_or(Icon::Document)
-                        })
+                            rsx!(
+                                div {
+                                    IconElement {
+                                        icon: cx.props.attachment_icon.unwrap_or(Icon::Document)
+                                    }
+                                    if !file_extension.is_empty() {
+                                        rsx!( label {
+                                            class: "file-embed-type",
+                                            "{file_extension}"
+                                        })
+                                    }
+                                }
+                                )
                         }
                     }
                     div {
@@ -293,4 +299,40 @@ pub fn FileEmbed<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
 
         }
     ))
+}
+
+fn get_file_thumbnail_if_is_image(filepath: PathBuf, filename: String) -> String {
+    let file = match std::fs::read(&filepath) {
+        Ok(file) => file,
+        Err(_) => {
+            return String::new();
+        }
+    };
+
+    let parts_of_filename: Vec<&str> = filename.split('.').collect();
+    let mime = match parts_of_filename.last() {
+        Some(m) => match *m {
+            "png" => IMAGE_PNG.to_string(),
+            "jpg" => IMAGE_JPEG.to_string(),
+            "jpeg" => IMAGE_JPEG.to_string(),
+            "svg" => IMAGE_SVG.to_string(),
+            &_ => "".to_string(),
+        },
+        None => "".to_string(),
+    };
+
+    if mime.is_empty() {
+        return String::new();
+    }
+
+    let image = match &file.len() {
+        0 => "".to_string(),
+        _ => {
+            let prefix = format!("data:{mime};base64,");
+            let base64_image = base64::encode(&file);
+            let img = prefix + base64_image.as_str();
+            img
+        }
+    };
+    image
 }

--- a/kit/src/components/embeds/file_embed/style.scss
+++ b/kit/src/components/embeds/file_embed/style.scss
@@ -59,10 +59,11 @@
   }
   .icon {
     svg {
-      stroke: var(--text-color);
-      fill: transparent;
-      height: var(--height-input);
-      width: var(--height-input);
+      transition: stroke var(--animation-time);
+			fill: transparent;
+			stroke: var(--warning-light);
+      width: 60px;
+      height: 60px;
     }
   }
 }
@@ -104,22 +105,12 @@
   word-break: break-all;
 }
 
-.icon-file-embed {
-  svg {
-    transition: stroke var(--animation-time);
-    fill: transparent;
-    stroke: var(--warning-light);
-    width: 100%;
-    height: 100%;
-  }
-}
-
 .file-embed-type {
 	text-transform: none;
 	text-align: center;
-	position: absolute;
-  right: 590px;
-  bottom: 260px;
+  position: relative;
+  right: -35px;
+  bottom: 25px;
 	padding:2px;
 	background-color: var(--warning-light);
 	border-radius: 4px;

--- a/kit/src/components/embeds/file_embed/style.scss
+++ b/kit/src/components/embeds/file_embed/style.scss
@@ -103,3 +103,26 @@
 .file-info {
   word-break: break-all;
 }
+
+.icon-file-embed {
+  svg {
+    transition: stroke var(--animation-time);
+    fill: transparent;
+    stroke: var(--warning-light);
+    width: 100%;
+    height: 100%;
+  }
+}
+
+.file-embed-type {
+	text-transform: none;
+	text-align: center;
+	position: absolute;
+  right: 590px;
+  bottom: 260px;
+	padding:2px;
+	background-color: var(--warning-light);
+	border-radius: 4px;
+	color: var(--text-color-dark);
+	font-size: var(--text-size-less);
+}

--- a/kit/src/components/embeds/file_embed/style.scss
+++ b/kit/src/components/embeds/file_embed/style.scss
@@ -13,8 +13,12 @@
 .file-embed {
   display: inline-flex;
   gap: var(--gap);
-  width: fit-content;
+  width: 95%;
+  margin-left: var(--gap);
   color: var(--text-color);
+  padding-top: var(--gap);
+  padding-bottom: 4px;
+  padding-right: var(--gap);
   align-content: center;
   align-self: flex-end;
 
@@ -61,6 +65,9 @@
       width: var(--height-input);
     }
   }
+}
+.file-embed:hover {
+  background-color: var(--background-light);
 }
 
 .icon {

--- a/kit/src/components/embeds/file_embed/style.scss
+++ b/kit/src/components/embeds/file_embed/style.scss
@@ -99,3 +99,7 @@
     transition: 1s;
   }
 }
+
+.file-info {
+  word-break: break-all;
+}

--- a/ui/src/components/chat/compose/chatbar.rs
+++ b/ui/src/components/chat/compose/chatbar.rs
@@ -594,9 +594,9 @@ fn Attachments<'a>(cx: Scope<'a, AttachmentProps>) -> Element<'a> {
         .unwrap_or_default()
         .iter()
         .map(|file_path| {
-            let filename = file_path.to_string_lossy().to_string().clone();
+            let filename = file_path.to_string_lossy().to_string();
             rsx!(FileEmbed {
-                filename: file_path.to_string_lossy().to_string().clone(),
+                filename: file_path.to_string_lossy().to_string(),
                 filepath: file_path.clone(),
                 remote: false,
                 button_icon: icons::outline::Shape::Trash,

--- a/ui/src/components/chat/compose/chatbar.rs
+++ b/ui/src/components/chat/compose/chatbar.rs
@@ -84,8 +84,7 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
         let valid = state.read().active_chat_has_draft()
             || !state
                 .read()
-                .get_active_chat()
-                .and_then(|f| Some(f.files_attached_to_send))
+                .get_active_chat().map(|f| f.files_attached_to_send)
                 .unwrap_or_default()
                 .is_empty();
         if !can_send.get().eq(&valid) {
@@ -96,8 +95,7 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
 
     let mut files_attached = state
         .read()
-        .get_active_chat()
-        .and_then(|f| Some(f.files_attached_to_send))
+        .get_active_chat().map(|f| f.files_attached_to_send)
         .unwrap_or_default();
 
     if files_attached.len() > 8 {
@@ -142,8 +140,7 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
                 let (tx, rx) = oneshot::channel::<Result<(), warp::error::Error>>();
                 let attachments = state
                     .read()
-                    .get_active_chat()
-                    .and_then(|f| Some(f.files_attached_to_send))
+                    .get_active_chat().map(|f| f.files_attached_to_send)
                     .unwrap_or_default();
                 let msg_clone = msg.clone();
                 let cmd = match reply {
@@ -164,8 +161,7 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
                 };
                 let attachments = state
                     .read()
-                    .get_active_chat()
-                    .and_then(|f| Some(f.files_attached_to_send))
+                    .get_active_chat().map(|f| f.files_attached_to_send)
                     .unwrap_or_default();
                 state
                     .write_silent()
@@ -323,8 +319,7 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
         (!msg.is_empty() && msg.iter().any(|line| !line.trim().is_empty()))
             || !state
                 .read()
-                .get_active_chat()
-                .and_then(|f| Some(f.files_attached_to_send))
+                .get_active_chat().map(|f| f.files_attached_to_send)
                 .unwrap_or_default()
                 .is_empty()
     };
@@ -335,8 +330,7 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
         let files_to_upload = state
             .read()
             .get_active_chat()
-            .as_ref()
-            .and_then(|d| Some(d.files_attached_to_send.clone()))
+            .as_ref().map(|d| d.files_attached_to_send.clone())
             .unwrap_or_default();
 
         let msg = state
@@ -501,8 +495,7 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
                                 .set_directory(dirs::home_dir().unwrap_or_default())
                                 .pick_files()
                             {
-                                let mut new_files_to_upload: Vec<_> = state.read().get_active_chat()
-                                    .and_then(|f| Some(f.files_attached_to_send))
+                                let mut new_files_to_upload: Vec<_> = state.read().get_active_chat().map(|f| f.files_attached_to_send)
                                     .unwrap_or_default()
                                     .iter()
                                     .filter(|file_name| !new_files.contains(file_name))
@@ -564,8 +557,7 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
             rsx!(paste_files_with_shortcut::PasteFilesShortcut {
                 on_paste: move |files_local_path: Vec<PathBuf>| {
                     if !files_local_path.is_empty() {
-                        let mut new_files_to_upload: Vec<_> = state.read().get_active_chat()
-                            .and_then(|f| Some(f.files_attached_to_send))
+                        let mut new_files_to_upload: Vec<_> = state.read().get_active_chat().map(|f| f.files_attached_to_send)
                             .unwrap_or_default()
                             .iter()
                             .filter(|file_name| !files_local_path.contains(file_name))
@@ -600,8 +592,7 @@ fn Attachments<'a>(cx: Scope<'a, AttachmentProps>) -> Element<'a> {
     // todo: pick an icon based on the file extension
     let attachments = cx.render(rsx!(state
         .read()
-        .get_active_chat()
-        .and_then(|f| Some(f.files_attached_to_send))
+        .get_active_chat().map(|f| f.files_attached_to_send)
         .unwrap_or_default()
         .iter()
         .map(|x| x.to_string_lossy().to_string())
@@ -613,8 +604,7 @@ fn Attachments<'a>(cx: Scope<'a, AttachmentProps>) -> Element<'a> {
                 on_press: move |_| {
                     let mut attachments = state
                         .read()
-                        .get_active_chat()
-                        .and_then(|f| Some(f.files_attached_to_send))
+                        .get_active_chat().map(|f| f.files_attached_to_send)
                         .unwrap_or_default();
                     attachments.retain(|x| {
                         let s = x.to_string_lossy().to_string();

--- a/ui/src/components/chat/compose/chatbar.rs
+++ b/ui/src/components/chat/compose/chatbar.rs
@@ -6,7 +6,7 @@ use std::{
 use common::{
     icons,
     language::get_local_text,
-    state::{Action, Identity, State},
+    state::{Action, Identity, State, ToastNotification},
     warp_runner::{RayGunCmd, WarpCmd},
     STATIC_ARGS, WARP_CMD_CH,
 };
@@ -84,6 +84,23 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
         }
     };
     update_send();
+
+    let mut files_attached = cx.props.upload_files.get().clone();
+
+    if cx.props.upload_files.get().len() > 8 {
+        files_attached.truncate(8);
+        cx.props.upload_files.set(files_attached);
+        state
+            .write()
+            .mutate(common::state::Action::AddToastNotification(
+                ToastNotification::init(
+                    "".into(),
+                    get_local_text("messages.maximum-eight-files-per-message"),
+                    None,
+                    4,
+                ),
+            ));
+    }
 
     // used to render the typing indicator
     // for now it doesn't quite work for group messages

--- a/ui/src/components/chat/compose/chatbar.rs
+++ b/ui/src/components/chat/compose/chatbar.rs
@@ -593,10 +593,11 @@ fn Attachments<'a>(cx: Scope<'a, AttachmentProps>) -> Element<'a> {
         .map(|f| f.files_attached_to_send)
         .unwrap_or_default()
         .iter()
-        .map(|x| x.to_string_lossy().to_string())
-        .map(|file_name| {
+        .map(|file_path| {
+            let filename = file_path.to_string_lossy().to_string().clone();
             rsx!(FileEmbed {
-                filename: file_name.clone(),
+                filename: file_path.to_string_lossy().to_string().clone(),
+                filepath: file_path.clone(),
                 remote: false,
                 button_icon: icons::outline::Shape::Trash,
                 on_press: move |_| {
@@ -607,7 +608,7 @@ fn Attachments<'a>(cx: Scope<'a, AttachmentProps>) -> Element<'a> {
                         .unwrap_or_default();
                     attachments.retain(|x| {
                         let s = x.to_string_lossy().to_string();
-                        s != file_name
+                        s != filename
                     });
                     state
                         .write()

--- a/ui/src/components/chat/compose/chatbar.rs
+++ b/ui/src/components/chat/compose/chatbar.rs
@@ -5,7 +5,7 @@ use std::{
 
 use common::{
     icons,
-    language::get_local_text,
+    language::{get_local_text, get_local_text_args_builder},
     state::{Action, Identity, State},
     warp_runner::{RayGunCmd, WarpCmd},
     STATIC_ARGS, WARP_CMD_CH,
@@ -641,7 +641,9 @@ fn Attachments<'a>(cx: Scope<'a, AttachmentProps>) -> Element<'a> {
                         margin_top: "var(--gap)",
                         margin_bottom: "var(--gap)",
                         color: "var(--warning-light)",
-                        format!("You reached {} files per message limit", MAX_FILES_PER_MESSAGE)
+                        get_local_text_args_builder("messages.maximum-amount-files-per-message", |m| {
+                            m.insert("amount", MAX_FILES_PER_MESSAGE.into());
+                        })
                     })
                 }
             attachments

--- a/ui/src/components/chat/compose/chatbar.rs
+++ b/ui/src/components/chat/compose/chatbar.rs
@@ -36,6 +36,7 @@ use warp::{
 };
 
 const MAX_CHARS_LIMIT: usize = 1024;
+const MAX_FILES_PER_MESSAGE: usize = 8;
 
 use crate::{
     components::paste_files_with_shortcut,
@@ -100,8 +101,8 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
         .map(|f| f.files_attached_to_send)
         .unwrap_or_default();
 
-    if files_attached.len() > 8 {
-        files_attached.truncate(8);
+    if files_attached.len() > MAX_FILES_PER_MESSAGE {
+        files_attached.truncate(MAX_FILES_PER_MESSAGE);
         state
             .write()
             .mutate(Action::SetChatAttachments(chat_id, files_attached));

--- a/ui/src/components/chat/compose/chatbar.rs
+++ b/ui/src/components/chat/compose/chatbar.rs
@@ -84,7 +84,8 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
         let valid = state.read().active_chat_has_draft()
             || !state
                 .read()
-                .get_active_chat().map(|f| f.files_attached_to_send)
+                .get_active_chat()
+                .map(|f| f.files_attached_to_send)
                 .unwrap_or_default()
                 .is_empty();
         if !can_send.get().eq(&valid) {
@@ -95,7 +96,8 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
 
     let mut files_attached = state
         .read()
-        .get_active_chat().map(|f| f.files_attached_to_send)
+        .get_active_chat()
+        .map(|f| f.files_attached_to_send)
         .unwrap_or_default();
 
     if files_attached.len() > 8 {
@@ -140,7 +142,8 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
                 let (tx, rx) = oneshot::channel::<Result<(), warp::error::Error>>();
                 let attachments = state
                     .read()
-                    .get_active_chat().map(|f| f.files_attached_to_send)
+                    .get_active_chat()
+                    .map(|f| f.files_attached_to_send)
                     .unwrap_or_default();
                 let msg_clone = msg.clone();
                 let cmd = match reply {
@@ -161,7 +164,8 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
                 };
                 let attachments = state
                     .read()
-                    .get_active_chat().map(|f| f.files_attached_to_send)
+                    .get_active_chat()
+                    .map(|f| f.files_attached_to_send)
                     .unwrap_or_default();
                 state
                     .write_silent()
@@ -319,7 +323,8 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
         (!msg.is_empty() && msg.iter().any(|line| !line.trim().is_empty()))
             || !state
                 .read()
-                .get_active_chat().map(|f| f.files_attached_to_send)
+                .get_active_chat()
+                .map(|f| f.files_attached_to_send)
                 .unwrap_or_default()
                 .is_empty()
     };
@@ -330,7 +335,8 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
         let files_to_upload = state
             .read()
             .get_active_chat()
-            .as_ref().map(|d| d.files_attached_to_send.clone())
+            .as_ref()
+            .map(|d| d.files_attached_to_send.clone())
             .unwrap_or_default();
 
         let msg = state
@@ -592,7 +598,8 @@ fn Attachments<'a>(cx: Scope<'a, AttachmentProps>) -> Element<'a> {
     // todo: pick an icon based on the file extension
     let attachments = cx.render(rsx!(state
         .read()
-        .get_active_chat().map(|f| f.files_attached_to_send)
+        .get_active_chat()
+        .map(|f| f.files_attached_to_send)
         .unwrap_or_default()
         .iter()
         .map(|x| x.to_string_lossy().to_string())
@@ -604,7 +611,8 @@ fn Attachments<'a>(cx: Scope<'a, AttachmentProps>) -> Element<'a> {
                 on_press: move |_| {
                     let mut attachments = state
                         .read()
-                        .get_active_chat().map(|f| f.files_attached_to_send)
+                        .get_active_chat()
+                        .map(|f| f.files_attached_to_send)
                         .unwrap_or_default();
                     attachments.retain(|x| {
                         let s = x.to_string_lossy().to_string();

--- a/ui/src/components/chat/compose/chatbar.rs
+++ b/ui/src/components/chat/compose/chatbar.rs
@@ -74,22 +74,37 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
     let data = &cx.props.data;
     let is_loading = data.is_none();
     let active_chat_id = data.as_ref().map(|d| d.active_chat.id);
+    let chat_id = data
+        .as_ref()
+        .map(|data| data.active_chat.id)
+        .unwrap_or(Uuid::nil());
     let can_send = use_state(cx, || state.read().active_chat_has_draft());
 
-    let files_to_upload = &cx.props.upload_files;
     let update_send = move || {
-        let valid = state.read().active_chat_has_draft() || !files_to_upload.is_empty();
+        let valid = state.read().active_chat_has_draft()
+            || !state
+                .read()
+                .get_active_chat()
+                .and_then(|f| Some(f.files_attached_to_send))
+                .unwrap_or_default()
+                .is_empty();
         if !can_send.get().eq(&valid) {
             can_send.set(valid);
         }
     };
     update_send();
 
-    let mut files_attached = cx.props.upload_files.get().clone();
+    let mut files_attached = state
+        .read()
+        .get_active_chat()
+        .and_then(|f| Some(f.files_attached_to_send))
+        .unwrap_or_default();
 
-    if cx.props.upload_files.get().len() > 8 {
+    if files_attached.len() > 8 {
         files_attached.truncate(8);
-        cx.props.upload_files.set(files_attached);
+        state
+            .write()
+            .mutate(Action::SetChatAttachments(chat_id, files_attached));
         state
             .write()
             .mutate(common::state::Action::AddToastNotification(
@@ -120,12 +135,16 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
     let users_typing = state.read().get_identities(&users_typing);
 
     let msg_ch = use_coroutine(cx, |mut rx: UnboundedReceiver<ChatInput>| {
-        to_owned![files_to_upload, state];
+        to_owned![state];
         async move {
             let warp_cmd_tx = WARP_CMD_CH.tx.clone();
             while let Some((msg, conv_id, ui_msg_id, reply)) = rx.next().await {
                 let (tx, rx) = oneshot::channel::<Result<(), warp::error::Error>>();
-                let attachments = files_to_upload.current().to_vec();
+                let attachments = state
+                    .read()
+                    .get_active_chat()
+                    .and_then(|f| Some(f.files_attached_to_send))
+                    .unwrap_or_default();
                 let msg_clone = msg.clone();
                 let cmd = match reply {
                     Some(reply_to) => RayGunCmd::Reply {
@@ -143,8 +162,14 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
                         rsp: tx,
                     },
                 };
-                let attachments = files_to_upload.current().to_vec();
-                files_to_upload.set(vec![]);
+                let attachments = state
+                    .read()
+                    .get_active_chat()
+                    .and_then(|f| Some(f.files_attached_to_send))
+                    .unwrap_or_default();
+                state
+                    .write_silent()
+                    .mutate(Action::ClearChatAttachments(conv_id));
                 let attachment_files: Vec<String> = attachments
                     .iter()
                     .map(|p| {
@@ -296,11 +321,23 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
 
     let msg_valid = |msg: &[String]| {
         (!msg.is_empty() && msg.iter().any(|line| !line.trim().is_empty()))
-            || !cx.props.upload_files.current().is_empty()
+            || !state
+                .read()
+                .get_active_chat()
+                .and_then(|f| Some(f.files_attached_to_send))
+                .unwrap_or_default()
+                .is_empty()
     };
 
     let submit_fn = move || {
         local_typing_ch.send(TypingIndicator::NotTyping);
+
+        let files_to_upload = state
+            .read()
+            .get_active_chat()
+            .as_ref()
+            .and_then(|d| Some(d.files_attached_to_send.clone()))
+            .unwrap_or_default();
 
         let msg = state
             .read()
@@ -335,7 +372,7 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
             }
             let ui_id = state
                 .write()
-                .increment_outgoing_messages(msg.clone(), files_to_upload);
+                .increment_outgoing_messages(msg.clone(), &files_to_upload);
             msg_ch.send((msg, id, ui_id, replying_to));
         }
     };
@@ -464,14 +501,15 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
                                 .set_directory(dirs::home_dir().unwrap_or_default())
                                 .pick_files()
                             {
-                                let mut new_files_to_upload: Vec<_> = cx.props.upload_files
-                                    .current()
+                                let mut new_files_to_upload: Vec<_> = state.read().get_active_chat()
+                                    .and_then(|f| Some(f.files_attached_to_send))
+                                    .unwrap_or_default()
                                     .iter()
                                     .filter(|file_name| !new_files.contains(file_name))
                                     .cloned()
                                     .collect();
                                 new_files_to_upload.extend(new_files);
-                                cx.props.upload_files.set(new_files_to_upload);
+                                state.write().mutate(Action::SetChatAttachments(chat_id, new_files_to_upload));
                                 update_send();
                             }
                         },
@@ -526,22 +564,21 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
             rsx!(paste_files_with_shortcut::PasteFilesShortcut {
                 on_paste: move |files_local_path: Vec<PathBuf>| {
                     if !files_local_path.is_empty() {
-                        let mut new_files_to_upload: Vec<_> = cx
-                        .props
-                        .upload_files
-                        .current()
-                        .iter()
-                        .filter(|file_name| !files_local_path.contains(file_name))
-                        .cloned()
-                        .collect();
+                        let mut new_files_to_upload: Vec<_> = state.read().get_active_chat()
+                            .and_then(|f| Some(f.files_attached_to_send))
+                            .unwrap_or_default()
+                            .iter()
+                            .filter(|file_name| !files_local_path.contains(file_name))
+                            .cloned()
+                            .collect();
                     new_files_to_upload.extend(files_local_path);
-                    cx.props.upload_files.set(new_files_to_upload);
+                    state.write().mutate(Action::SetChatAttachments(chat_id, new_files_to_upload));
                     }
                 },
             })
         }
         Attachments {
-            files: cx.props.upload_files.clone(),
+            chat_id: chat_id,
             on_remove: move |_| {
                 update_send();
             }
@@ -552,17 +589,20 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
 
 #[derive(Props)]
 pub struct AttachmentProps<'a> {
-    files: UseState<Vec<PathBuf>>,
+    chat_id: Uuid,
     on_remove: EventHandler<'a, ()>,
 }
 
 #[allow(non_snake_case)]
 fn Attachments<'a>(cx: Scope<'a, AttachmentProps>) -> Element<'a> {
+    let state = use_shared_state::<State>(cx)?;
+
     // todo: pick an icon based on the file extension
-    let attachments = cx.render(rsx!(cx
-        .props
-        .files
-        .current()
+    let attachments = cx.render(rsx!(state
+        .read()
+        .get_active_chat()
+        .and_then(|f| Some(f.files_attached_to_send))
+        .unwrap_or_default()
         .iter()
         .map(|x| x.to_string_lossy().to_string())
         .map(|file_name| {
@@ -571,19 +611,22 @@ fn Attachments<'a>(cx: Scope<'a, AttachmentProps>) -> Element<'a> {
                 remote: false,
                 button_icon: icons::outline::Shape::Trash,
                 on_press: move |_| {
-                    let mut b = false;
-                    cx.props.files.with_mut(|files| {
-                        files.retain(|x| {
-                            let s = x.to_string_lossy().to_string();
-                            s != file_name
-                        });
-                        b = !files.is_empty();
+                    let mut attachments = state
+                        .read()
+                        .get_active_chat()
+                        .and_then(|f| Some(f.files_attached_to_send))
+                        .unwrap_or_default();
+                    attachments.retain(|x| {
+                        let s = x.to_string_lossy().to_string();
+                        s != file_name
                     });
+                    state
+                        .write()
+                        .mutate(Action::SetChatAttachments(cx.props.chat_id, attachments));
                     cx.props.on_remove.call(());
                 },
             })
         })));
-
     cx.render(rsx!(div {
         id: "compose-attachments",
         aria_label: "compose-attachments",

--- a/ui/src/components/chat/compose/mod.rs
+++ b/ui/src/components/chat/compose/mod.rs
@@ -158,8 +158,7 @@ pub fn Compose(cx: Scope) -> Element {
                         to_owned![drag_event, window, overlay_script, state];
                         async move {
                            let new_files = drag_and_drop_function(&window, &drag_event, overlay_script).await;
-                            let mut new_files_to_upload: Vec<_> = state.read().get_active_chat()
-                                .and_then(|f| Some(f.files_attached_to_send))
+                            let mut new_files_to_upload: Vec<_> = state.read().get_active_chat().map(|f| f.files_attached_to_send)
                                 .unwrap_or_default()
                                 .iter()
                                 .filter(|file_name| !new_files.contains(file_name))

--- a/ui/src/components/chat/style.scss
+++ b/ui/src/components/chat/style.scss
@@ -242,6 +242,11 @@
   display: inline-flex;
   overflow-y: auto;
   flex-direction: row;
+  margin-left: var(--gap);
+  padding-top: var(--gap);
+  z-index: 2;
+  box-shadow: 0px 0px 4px var(--text-color-muted);
+  width: 95%;
 }
 
 #compose #messages {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
### 1. Allow just 8 files per message
### 2. Show warning if user attach 8 files
### 3. Fix bug that attachments were persisting between chats

### 4. Improve UI when attach files 
a. Let files attached in vertical now, with document icon with extension or thumbnail if file is image 
<img width="645" alt="image" src="https://github.com/Satellite-im/Uplink/assets/63157656/fdb8e3b4-8186-4a09-ba4b-8545088a9a9d">

b. When files in chat, they are aligned now, with document and extension when they do not have thumbnail
<img width="340" alt="image" src="https://github.com/Satellite-im/Uplink/assets/63157656/18f9e0c1-8dfe-4b84-b945-8b725635e874">

c. Files aligned when they are loading to be sent as well

<img width="595" alt="image" src="https://github.com/Satellite-im/Uplink/assets/63157656/baa54e8b-dd1a-4a58-9c72-6d752d7be0fd">

### Which issue(s) this PR fixes 🔨

- Resolve #1026 
- Resolve #1046 
- Resolve #1040 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

