### PR TITLE
fix(messages): show past messages in correct order

### DIFF
--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -898,13 +898,16 @@ impl State {
             .cloned()
     }
     // assumes the messages are sorted by most recent to oldest
-    pub fn update_chat_messages(
+    pub fn prepend_chat_messages(
         &mut self,
         conversation_id: Uuid,
         messages: Vec<ui_adapter::Message>,
     ) {
         if let Some(chat) = self.chats.all.get_mut(&conversation_id) {
-            chat.messages = messages.into();
+            let mut m = Into::<VecDeque<ui_adapter::Message>>::into(messages);
+            let mut n = std::mem::take(&mut chat.messages);
+            m.append(&mut n);
+            chat.messages = m;
         }
     }
 

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -898,16 +898,13 @@ impl State {
             .cloned()
     }
     // assumes the messages are sorted by most recent to oldest
-    pub fn prepend_chat_messages(
+    pub fn update_chat_messages(
         &mut self,
         conversation_id: Uuid,
         messages: Vec<ui_adapter::Message>,
     ) {
         if let Some(chat) = self.chats.all.get_mut(&conversation_id) {
-            let mut m = Into::<VecDeque<ui_adapter::Message>>::into(messages);
-            let mut n = std::mem::take(&mut chat.messages);
-            m.append(&mut n);
-            chat.messages = m;
+            chat.messages = messages.into();
         }
     }
 

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -898,15 +898,13 @@ impl State {
             .cloned()
     }
     // assumes the messages are sorted by most recent to oldest
-    pub fn prepend_messages_to_chat(
+    pub fn update_chat_messages(
         &mut self,
         conversation_id: Uuid,
-        mut messages: Vec<ui_adapter::Message>,
+        messages: Vec<ui_adapter::Message>,
     ) {
         if let Some(chat) = self.chats.all.get_mut(&conversation_id) {
-            for message in messages.drain(..) {
-                chat.messages.push_front(message.clone());
-            }
+            chat.messages = messages.into();
         }
     }
 

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -1518,23 +1518,21 @@ impl<'a> GroupedMessage<'a> {
 
 pub fn group_messages<'a>(
     my_did: DID,
-    num: usize,
     when_to_fetch_more: usize,
+    // true if the chat has more messages to fetch
+    has_more: bool,
     input: &'a VecDeque<ui_adapter::Message>,
 ) -> Vec<MessageGroup<'a>> {
     let mut messages: Vec<MessageGroup<'a>> = vec![];
-    let to_skip = input.len().saturating_sub(num);
-    // the most recent message appears last in the list.
-    let iter = input.iter().skip(to_skip);
     let mut need_to_fetch_more = when_to_fetch_more;
 
     let mut need_more = || {
         let r = need_to_fetch_more > 0;
         need_to_fetch_more = need_to_fetch_more.saturating_sub(1);
-        r
+        r && has_more
     };
 
-    for msg in iter {
+    for msg in input.iter() {
         if let Some(group) = messages.iter_mut().last() {
             if group.sender == msg.inner.sender() {
                 let g = GroupedMessage {

--- a/common/src/warp_runner/manager/commands/raygun_commands.rs
+++ b/common/src/warp_runner/manager/commands/raygun_commands.rs
@@ -209,7 +209,9 @@ pub async fn handle_raygun_cmd(
             current_len,
             rsp,
         } => {
-            let r = fetch_messages_from_chat(conv_id, messaging, to_fetch + current_len).await;
+            let r =
+                fetch_messages_from_chat(conv_id, messaging, current_len, to_fetch + current_len)
+                    .await;
             let _ = rsp.send(r);
         }
         RayGunCmd::SendMessage {

--- a/common/src/warp_runner/manager/commands/raygun_commands.rs
+++ b/common/src/warp_runner/manager/commands/raygun_commands.rs
@@ -209,9 +209,7 @@ pub async fn handle_raygun_cmd(
             current_len,
             rsp,
         } => {
-            let r =
-                fetch_messages_from_chat(conv_id, messaging, current_len, to_fetch + current_len)
-                    .await;
+            let r = fetch_messages_from_chat(conv_id, messaging, to_fetch + current_len).await;
             let _ = rsp.send(r);
         }
         RayGunCmd::SendMessage {

--- a/common/src/warp_runner/manager/commands/raygun_commands.rs
+++ b/common/src/warp_runner/manager/commands/raygun_commands.rs
@@ -75,7 +75,7 @@ pub enum RayGunCmd {
         to_fetch: usize,
         // the current size of the conversation
         current_len: usize,
-        rsp: oneshot::Sender<Result<Vec<ui_adapter::Message>, warp::error::Error>>,
+        rsp: oneshot::Sender<Result<(Vec<ui_adapter::Message>, bool), warp::error::Error>>,
     },
     #[display(fmt = "SendMessage")]
     SendMessage {

--- a/common/src/warp_runner/manager/commands/raygun_commands.rs
+++ b/common/src/warp_runner/manager/commands/raygun_commands.rs
@@ -68,11 +68,11 @@ pub enum RayGunCmd {
         conv_id: Uuid,
         rsp: oneshot::Sender<Result<Uuid, warp::error::Error>>,
     },
-    #[display(fmt = "FetchMessages {{ req_len: {new_len}, current_len: {current_len} }} ")]
+    #[display(fmt = "FetchMessages {{ req: {to_fetch}, current_len: {current_len} }} ")]
     FetchMessages {
         conv_id: Uuid,
         // the total number of messages that should be in the conversation
-        new_len: usize,
+        to_fetch: usize,
         // the current size of the conversation
         current_len: usize,
         rsp: oneshot::Sender<Result<Vec<ui_adapter::Message>, warp::error::Error>>,
@@ -205,13 +205,11 @@ pub async fn handle_raygun_cmd(
         }
         RayGunCmd::FetchMessages {
             conv_id,
-            new_len,
+            to_fetch,
             current_len,
             rsp,
         } => {
-            let to_skip = current_len;
-            let to_add = new_len - current_len;
-            let r = fetch_messages_from_chat(conv_id, messaging, to_skip, to_add).await;
+            let r = fetch_messages_from_chat(conv_id, messaging, to_fetch + current_len).await;
             let _ = rsp.send(r);
         }
         RayGunCmd::SendMessage {

--- a/common/src/warp_runner/ui_adapter/mod.rs
+++ b/common/src/warp_runner/ui_adapter/mod.rs
@@ -154,16 +154,17 @@ pub async fn dids_to_identity(
 pub async fn fetch_messages_from_chat(
     conv_id: Uuid,
     messaging: &mut super::Messaging,
-    current_len: usize,
     to_take: usize,
 ) -> Result<Vec<Message>, Error> {
     let total_messages = messaging.get_message_count(conv_id).await?;
     let to_take = std::cmp::min(total_messages, to_take);
     let to_skip = total_messages.saturating_sub(to_take + 1);
-    let end = total_messages.saturating_sub(current_len);
 
     let messages = messaging
-        .get_messages(conv_id, MessageOptions::default().set_range(to_skip..end))
+        .get_messages(
+            conv_id,
+            MessageOptions::default().set_range(to_skip..total_messages),
+        )
         .await
         .and_then(Vec::<_>::try_from)?;
 

--- a/common/src/warp_runner/ui_adapter/mod.rs
+++ b/common/src/warp_runner/ui_adapter/mod.rs
@@ -154,17 +154,16 @@ pub async fn dids_to_identity(
 pub async fn fetch_messages_from_chat(
     conv_id: Uuid,
     messaging: &mut super::Messaging,
+    current_len: usize,
     to_take: usize,
 ) -> Result<Vec<Message>, Error> {
     let total_messages = messaging.get_message_count(conv_id).await?;
     let to_take = std::cmp::min(total_messages, to_take);
     let to_skip = total_messages.saturating_sub(to_take + 1);
+    let end = total_messages.saturating_sub(current_len);
 
     let messages = messaging
-        .get_messages(
-            conv_id,
-            MessageOptions::default().set_range(to_skip..total_messages),
-        )
+        .get_messages(conv_id, MessageOptions::default().set_range(to_skip..end))
         .await
         .and_then(Vec::<_>::try_from)?;
 

--- a/ui/src/components/chat/compose/messages.rs
+++ b/ui/src/components/chat/compose/messages.rs
@@ -116,7 +116,7 @@ pub fn get_messages(cx: Scope, data: Rc<super::ComposeData>) -> Element {
             state.write().finished_loading_chat(id);
         } else {
             num_to_take.with_mut(|x| *x = x.saturating_add(m.len()));
-            state.write().prepend_chat_messages(id, m);
+            state.write().update_chat_messages(id, m);
         }
     }
 

--- a/ui/src/components/chat/compose/messages.rs
+++ b/ui/src/components/chat/compose/messages.rs
@@ -97,26 +97,24 @@ const DEFAULT_NUM_TO_TAKE: usize = 20;
 #[inline_props]
 pub fn get_messages(cx: Scope, data: Rc<super::ComposeData>) -> Element {
     log::trace!("get_messages");
+    log::debug!("has more: {}", data.active_chat.has_more_messages);
     use_shared_state_provider(cx, || -> DownloadTracker { HashMap::new() });
     let state = use_shared_state::<State>(cx)?;
     let pending_downloads = use_shared_state::<DownloadTracker>(cx)?;
 
-    let num_to_take = use_state(cx, || DEFAULT_NUM_TO_TAKE);
     let prev_chat_id = use_ref(cx, || data.active_chat.id);
-    let newely_fetched_messages: &UseRef<Option<(Uuid, Vec<ui_adapter::Message>)>> =
+    let newely_fetched_messages: &UseRef<Option<(Uuid, Vec<ui_adapter::Message>, bool)>> =
         use_ref(cx, || None);
 
     let quick_profile_uuid = &*cx.use_hook(|| Uuid::new_v4().to_string());
     let identity_profile = use_state(cx, Identity::default);
     let update_script = use_state(cx, String::new);
 
-    if let Some((id, m)) = newely_fetched_messages.write_silent().take() {
-        if m.is_empty() {
+    if let Some((id, m, has_more)) = newely_fetched_messages.write_silent().take() {
+        state.write().update_chat_messages(id, m);
+        if !has_more {
             log::debug!("finished loading chat: {id}");
             state.write().finished_loading_chat(id);
-        } else {
-            num_to_take.with_mut(|x| *x = x.saturating_add(m.len()));
-            state.write().update_chat_messages(id, m);
         }
     }
 
@@ -135,7 +133,6 @@ pub fn get_messages(cx: Scope, data: Rc<super::ComposeData>) -> Element {
     let eval = use_eval(cx);
     if *active_chat.read() != currently_active {
         *active_chat.write_silent() = currently_active;
-        num_to_take.set(DEFAULT_NUM_TO_TAKE);
     }
 
     use_effect(cx, &data.active_chat.id, |id| {
@@ -280,8 +277,8 @@ pub fn get_messages(cx: Scope, data: Rc<super::ComposeData>) -> Element {
                         }
 
                         match rx.await.expect("command canceled") {
-                            Ok(m) => {
-                                newely_fetched_messages.set(Some((conv_id, m)));
+                            Ok((m, has_more)) => {
+                                newely_fetched_messages.set(Some((conv_id, m, has_more)));
                             }
                             Err(e) => {
                                 log::error!("failed to fetch more message: {}", e);
@@ -327,11 +324,9 @@ pub fn get_messages(cx: Scope, data: Rc<super::ComposeData>) -> Element {
                 rsx!(
                     msg_container_end,
                     render_message_groups{
-                        groups: group_messages(data.my_id.did_key(), *num_to_take.get(), DEFAULT_NUM_TO_TAKE, &data.active_chat.messages),
+                        groups: group_messages(data.my_id.did_key(), DEFAULT_NUM_TO_TAKE, data.active_chat.has_more_messages, &data.active_chat.messages),
                         active_chat_id: data.active_chat.id,
                         num_messages_in_conversation: data.active_chat.messages.len(),
-                        num_to_take: num_to_take.clone(),
-                        has_more: data.active_chat.has_more_messages,
                         on_context_menu_action: move |(e, id): (Event<MouseData>, Identity)| {
                             let own = state.read().get_own_identity().did_key().eq(&id.did_key());
                             if !identity_profile.get().eq(&id) {
@@ -392,8 +387,6 @@ struct AllMessageGroupsProps<'a> {
     groups: Vec<MessageGroup<'a>>,
     active_chat_id: Uuid,
     num_messages_in_conversation: usize,
-    num_to_take: UseState<usize>,
-    has_more: bool,
     on_context_menu_action: EventHandler<'a, (Event<MouseData>, Identity)>,
 }
 
@@ -406,8 +399,6 @@ fn render_message_groups<'a>(cx: Scope<'a, AllMessageGroupsProps<'a>>) -> Elemen
             group: _group,
             active_chat_id: cx.props.active_chat_id,
             num_messages_in_conversation: cx.props.num_messages_in_conversation,
-            num_to_take: cx.props.num_to_take.clone(),
-            has_more: cx.props.has_more,
             on_context_menu_action: move |e| cx.props.on_context_menu_action.call(e)
         },)
     })))
@@ -445,13 +436,11 @@ struct PendingWrapperProps<'a> {
 
 //We need to do it this way due to reference ownership
 fn pending_wrapper<'a>(cx: Scope<'a, PendingWrapperProps>) -> Element<'a> {
-    let num_to_take = use_state(cx, || cx.props.msg.len());
     cx.render(rsx!(render_pending_messages {
         pending_outgoing_message: pending_group_messages(
             &cx.props.msg,
             cx.props.data.my_id.did_key(),
         ),
-        num_to_take: num_to_take.clone(),
         active: cx.props.data.active_chat.id,
         on_context_menu_action: move |e| cx.props.on_context_menu_action.call(e)
     }))
@@ -462,7 +451,6 @@ struct PendingMessagesProps<'a> {
     #[props(!optional)]
     pending_outgoing_message: Option<MessageGroup<'a>>,
     active: Uuid,
-    num_to_take: UseState<usize>,
     on_context_menu_action: EventHandler<'a, (Event<MouseData>, Identity)>,
 }
 
@@ -473,8 +461,6 @@ fn render_pending_messages<'a>(cx: Scope<'a, PendingMessagesProps>) -> Element<'
                 group: group,
                 active_chat_id: cx.props.active,
                 num_messages_in_conversation: group.messages.len(),
-                num_to_take: cx.props.num_to_take.clone(),
-                has_more: false,
                 on_context_menu_action: move |e| cx.props.on_context_menu_action.call(e),
                 pending: true
             },)
@@ -487,8 +473,6 @@ struct MessageGroupProps<'a> {
     group: &'a MessageGroup<'a>,
     active_chat_id: Uuid,
     num_messages_in_conversation: usize,
-    num_to_take: UseState<usize>,
-    has_more: bool,
     on_context_menu_action: EventHandler<'a, (Event<MouseData>, Identity)>,
     pending: Option<bool>,
 }
@@ -500,8 +484,6 @@ fn render_message_group<'a>(cx: Scope<'a, MessageGroupProps<'a>>) -> Element<'a>
         group,
         active_chat_id: _,
         num_messages_in_conversation: _,
-        num_to_take: _,
-        has_more: _,
         on_context_menu_action: _,
         pending: _,
     } = cx.props;
@@ -594,9 +576,7 @@ fn render_message_group<'a>(cx: Scope<'a, MessageGroupProps<'a>>) -> Element<'a>
                 messages: &group.messages,
                 active_chat_id: cx.props.active_chat_id,
                 is_remote: group.remote,
-                has_more: cx.props.has_more,
                 num_messages_in_conversation: cx.props.num_messages_in_conversation,
-                num_to_take: cx.props.num_to_take.clone(),
                 pending: cx.props.pending.unwrap_or_default()
             }))
         },
@@ -608,9 +588,7 @@ struct MessagesProps<'a> {
     messages: &'a Vec<GroupedMessage<'a>>,
     active_chat_id: Uuid,
     num_messages_in_conversation: usize,
-    num_to_take: UseState<usize>,
     is_remote: bool,
-    has_more: bool,
     pending: bool,
 }
 fn render_messages<'a>(cx: Scope<'a, MessagesProps<'a>>) -> Element<'a> {
@@ -649,23 +627,11 @@ fn render_messages<'a>(cx: Scope<'a, MessagesProps<'a>>) -> Element<'a> {
             id: context_key,
             on_mouseenter: move |_| {
                 if should_fetch_more {
-                    let new_num_to_take = cx
-                        .props
-                        .num_to_take
-                        .get()
-                        .saturating_add(DEFAULT_NUM_TO_TAKE * 2);
-
-                    // lazily render
-                    if new_num_to_take <= cx.props.num_messages_in_conversation {
-                        cx.props.num_to_take.set(new_num_to_take);
-                    } else if cx.props.has_more {
-                        // lazily add more messages to conversation, then render
-                        ch.send(MessagesCommand::FetchMore {
-                            conv_id: cx.props.active_chat_id,
-                            to_fetch: DEFAULT_NUM_TO_TAKE * 2,
-                            current_len: cx.props.num_messages_in_conversation,
-                        })
-                    }
+                    ch.send(MessagesCommand::FetchMore {
+                        conv_id: cx.props.active_chat_id,
+                        to_fetch: DEFAULT_NUM_TO_TAKE * 2,
+                        current_len: cx.props.num_messages_in_conversation,
+                    });
                 }
             },
             children: cx.render(rsx!(render_message {

--- a/ui/src/components/chat/compose/messages.rs
+++ b/ui/src/components/chat/compose/messages.rs
@@ -116,7 +116,7 @@ pub fn get_messages(cx: Scope, data: Rc<super::ComposeData>) -> Element {
             state.write().finished_loading_chat(id);
         } else {
             num_to_take.with_mut(|x| *x = x.saturating_add(m.len()));
-            state.write().update_chat_messages(id, m);
+            state.write().prepend_chat_messages(id, m);
         }
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- fixes the lazy loading of messages. Chats are still only initialized with a few messages at first but now as more messages are fetched, they are displayed in order. 
- This fix isn't as lazy as it could be, but doing it this way prevents bugs arising from extra events getting triggered. 
- This may be good for a temporary solution, until we figure out how to determine when the user has scrolled to the end of a container. Without that, infinite scrolling will be hacky at best. 

### Which issue(s) this PR fixes 🔨

- Resolve #1024 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

