### PR TITLE
feat(GroupChats): improve warning

### DIFF
--- a/common/locales/de/main.ftl
+++ b/common/locales/de/main.ftl
@@ -24,7 +24,7 @@ uplink = Uplink
 warning-messages = Warnungen
     .please-enter-at-least = Mindestens
     .maximum-of = Maximum an
-    .only-alpha-chars = Nur alphanumerische Zeichen sind erlaubt.
+    .disallowed-characters = todo
     .spaces-not-allowed = Leerzeichen sind nicht erlaubt.
 
 messages = Nachrichten

--- a/common/locales/en-US/main.ftl
+++ b/common/locales/en-US/main.ftl
@@ -54,7 +54,7 @@ updates = Updates
 warning-messages = Warning Messages
     .please-enter-at-least = Please enter at least
     .maximum-of = Maximum of
-    .only-alpha-chars = Only alphanumeric characters are accepted.
+    .disallowed-characters = Disallowed character(s)
     .spaces-not-allowed = Spaces are not allowed.
     .error = Error
 

--- a/common/locales/es-MX/main.ftl
+++ b/common/locales/es-MX/main.ftl
@@ -54,7 +54,7 @@ updates = Updates
 warning-messages = Warning Messages
     .please-enter-at-least = Por favor, ingrese al menos
     .maximum-of = Máximo de
-    .only-alpha-chars = Solo se aceptan caracteres alfanuméricos.
+    .disallowed-characters = todo
     .spaces-not-allowed = Los espacios no están permitidos.
     .error = Error
 

--- a/common/locales/pt-BR/main.ftl
+++ b/common/locales/pt-BR/main.ftl
@@ -24,7 +24,7 @@ uplink = Uplink
 warning-messages = Warning Messages
     .please-enter-at-least = Por favor, insira pelo menos
     .maximum-of = Máximo de
-    .only-alpha-chars = Somente caracteres alfanuméricos são aceitos.
+    .disallowed-characters = todo
     .spaces-not-allowed = Espaços não são permitidos.
 
 messages = Messages

--- a/common/locales/pt-PT/main.ftl
+++ b/common/locales/pt-PT/main.ftl
@@ -53,7 +53,7 @@ updates = Actualizações
 warning-messages = Mensagens de aviso
     .please-enter-at-least = Por favor, introduza pelo menos
     .maximum-of = Máximo de
-    .only-alpha-chars = Só são aceites caracteres alfanuméricos.
+    .disallowed-characters = todo
     .spaces-not-allowed = Não são permitidos espaços.
     .error = Erro
 

--- a/kit/src/elements/input/mod.rs
+++ b/kit/src/elements/input/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use common::language::get_local_text;
 use dioxus::prelude::*;
 use dioxus_desktop::use_eval;
@@ -207,7 +209,18 @@ fn validate_alphanumeric(
     }
 
     if !val.chars().all(char::is_alphanumeric) {
-        return Some(get_local_text("warning-messages.only-alpha-chars"));
+        let invalid_chars = val.chars().filter(|x| !char::is_alphanumeric(*x));
+        let mut s: HashSet<char> = HashSet::new();
+        let mut t = String::new();
+        for x in invalid_chars {
+            if s.insert(x) {
+                t.push(x);
+            }
+        }
+        return Some(format!(
+            "{}: {t}",
+            get_local_text("warning-messages.disallowed-characters")
+        ));
     }
 
     None


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

![image](https://github.com/Satellite-im/Uplink/assets/8636602/b1383424-2d79-42b1-80cc-97fa6c96ff59)


### Which issue(s) this PR fixes 🔨

- Resolve #1048

I think it better to tell the user which characters are disallowed. This message appears when they enter a disallowed character. Showing only the disallowed characters results in less text to read and I think will make it easier for them to correct their error. 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

