### PR TITLE
feat(chat): Overhaul typing indicator

### DIFF
--- a/common/locales/en-US/main.ftl
+++ b/common/locales/en-US/main.ftl
@@ -81,6 +81,9 @@ messages = Messages
     .participants = Participants
     .fetching = Fetching more messages...
     .group-creator-label = Group Creator
+    .user-typing = { $user } is typing
+    .users-typing = { $users } are typing
+    .users-multiple-typing = Multiple users are typing
     
 favorites = Favorites
     .favorites = Favorites

--- a/kit/src/components/message_typing/mod.rs
+++ b/kit/src/components/message_typing/mod.rs
@@ -13,19 +13,12 @@ pub struct Props {
 pub fn MessageTyping(cx: Scope<Props>) -> Element {
     let typing_users = if cx.props.typing_users.len() > 3 {
         get_local_text("messages.users-multiple-typing")
-    } else if cx.props.typing_users.len() == 1 {
-        let mut user = cx.props.typing_users.first().unwrap().to_string();
-        let user = if user.len() > MAX_LEN {
-            let mut user: String = user.drain(..(MAX_LEN - 3)).collect();
-            user.push_str("...");
-            user
-        } else {
-            user
-        };
-        get_local_text_args_builder("messages.user-typing", |m| {
-            m.insert("user", user.into());
-        })
     } else {
+        let translation = if cx.props.typing_users.len() == 1 {
+            "messages.user-typing"
+        } else {
+            "messages.users-typing"
+        };
         let mut users = cx.props.typing_users.join(", ");
         let users = if users.len() > MAX_LEN {
             let mut users: String = users.drain(..(MAX_LEN - 3)).collect();
@@ -34,7 +27,7 @@ pub fn MessageTyping(cx: Scope<Props>) -> Element {
         } else {
             users
         };
-        get_local_text_args_builder("messages.users-typing", |m| {
+        get_local_text_args_builder(translation, |m| {
             m.insert("users", users.into());
         })
     };

--- a/kit/src/components/message_typing/mod.rs
+++ b/kit/src/components/message_typing/mod.rs
@@ -1,24 +1,63 @@
+use common::language::{get_local_text, get_local_text_args_builder};
 use dioxus::prelude::*;
 
-#[derive(Props)]
-pub struct Props<'a> {
+const MAX_LEN: usize = 17;
+
+#[derive(Props, PartialEq)]
+pub struct Props {
     // Represents the image of the user who is typing
-    user_image: Element<'a>,
+    typing_users: Vec<String>,
 }
 
 #[allow(non_snake_case)]
-pub fn MessageTyping<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
+pub fn MessageTyping(cx: Scope<Props>) -> Element {
+    let typing_users = if cx.props.typing_users.len() > 3 {
+        get_local_text("messages.users-multiple-typing")
+    } else if cx.props.typing_users.len() == 1 {
+        let mut user = cx.props.typing_users.first().unwrap().to_string();
+        let user = if user.len() > MAX_LEN {
+            let mut user: String = user.drain(..(MAX_LEN - 3)).collect();
+            user.push_str("...");
+            user
+        } else {
+            user
+        };
+        get_local_text_args_builder("messages.user-typing", |m| {
+            m.insert("user", user.into());
+        })
+    } else {
+        let mut users = cx.props.typing_users.join(", ");
+        let users = if users.len() > MAX_LEN {
+            let mut users: String = users.drain(..(MAX_LEN - 3)).collect();
+            users.push_str("...");
+            users
+        } else {
+            users
+        };
+        get_local_text_args_builder("messages.users-typing", |m| {
+            m.insert("users", users.into());
+        })
+    };
+
     cx.render(rsx! (
         div {
             class: "message-typing-wrap",
             // TODO: Support a vec of user images in case multiple are typing
-            &cx.props.user_image,
             div {
                 class: "message-typing",
                 aria_label: "message-typing-indicator",
-                div { class: "dot dot-1" },
-                div { class: "dot dot-2" },
-                div { class: "dot dot-3" }
+                p {
+                    class: "typing-message",
+                    aria_label: "typing-message",
+                    typing_users,
+                }
+                div {
+                    display: "flex",
+                    gap: "var(--gap-less)",
+                    div { class: "dot dot-1" },
+                    div { class: "dot dot-2" },
+                    div { class: "dot dot-3" }
+                }
             }
         }
     ))

--- a/kit/src/components/message_typing/style.scss
+++ b/kit/src/components/message_typing/style.scss
@@ -1,19 +1,22 @@
 .message-typing-wrap {
 	display: inline-flex;
 	gap: var(--gap);
-	padding: var(--padding-less);
+	//padding: var(--padding-less);
+	//padding-top: var(--padding-less);
 }
 .message-typing {
-	min-height: var(--height-input);
+	//min-height: var(--height-input);
+	padding-right: 40px;
 	display: inline-flex;
 	align-items: center;
-	padding: var(--padding-less) var(--padding);
+	//padding: var(--padding-less) var(--padding);
+	padding: 0 var(--padding-less);
 	width: fit-content;
 	align-self: flex-start;
-	background: var(--secondary);
+	//background: var(--secondary);
 	border-radius: var(--border-radius-more);
 	border-bottom-left-radius: var(--border-radius);
-	gap: var(--gap);
+	gap: var(--gap-less);
 	.dot {
 		height: var(--text-size-less);
 		width: var(--text-size-less);
@@ -29,4 +32,15 @@
 	.dot-3 {
 		animation: 1s pulse 0.66s infinite;
 	}
+}
+.typing-message {
+	color: var(--text-color);
+	font-size: var(--text-size-less);
+	gap: var(--gap-less);
+	display: -webkit-box;
+	-webkit-line-clamp: 1;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	word-wrap: anywhere;
 }

--- a/kit/src/components/message_typing/style.scss
+++ b/kit/src/components/message_typing/style.scss
@@ -6,11 +6,11 @@
 }
 .message-typing {
 	//min-height: var(--height-input);
-	padding-right: 40px;
 	display: inline-flex;
 	align-items: center;
 	//padding: var(--padding-less) var(--padding);
 	padding: 0 var(--padding-less);
+	padding-right: 40px;
 	width: fit-content;
 	align-self: flex-start;
 	//background: var(--secondary);

--- a/kit/src/layout/chatbar/mod.rs
+++ b/kit/src/layout/chatbar/mod.rs
@@ -2,7 +2,7 @@ use dioxus::prelude::*;
 use warp::constellation::file::File;
 
 use crate::{
-    components::embeds::file_embed::FileEmbed,
+    components::{embeds::file_embed::FileEmbed, message_typing::MessageTyping},
     elements::{button::Button, label::Label, textarea, Appearance},
 };
 
@@ -27,6 +27,7 @@ pub struct ReplyInfo<'a> {
 pub struct Props<'a> {
     id: String,
     placeholder: String,
+    typing_users: Vec<String>,
     with_replying_to: Option<Element<'a>>,
     with_file_upload: Option<Element<'a>>,
     extensions: Option<Element<'a>>,
@@ -121,27 +122,37 @@ pub fn Reply<'a>(cx: Scope<'a, ReplyProps<'a>>) -> Element<'a> {
 #[allow(non_snake_case)]
 pub fn Chatbar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let controlled_input_id = &cx.props.id;
+    let is_typing = !cx.props.typing_users.is_empty();
+
     cx.render(rsx!(
         div {
             class: "chatbar disable-select",
             cx.props.with_replying_to.as_ref(),
             cx.props.with_file_upload.as_ref(),
-            textarea::Input {
-                key: "{controlled_input_id}",
-                id: controlled_input_id.clone(),
-                loading: cx.props.loading.unwrap_or_default(),
-                placeholder: cx.props.placeholder.clone(),
-                ignore_focus: cx.props.ignore_focus,
-                show_char_counter: true,
-                value: if cx.props.is_disabled { get_local_text("messages.not-friends")} else { cx.props.value.clone().unwrap_or_default()},
-                onchange: move |(v, _)| cx.props.onchange.call(v),
-                onreturn: move |(v, is_valid, _)| {
-                    if is_valid {
-                        cx.props.onreturn.call(v);
-                    }
+            div{
+                class: "chatbar-group",
+                textarea::Input {
+                    key: "{controlled_input_id}",
+                    id: controlled_input_id.clone(),
+                    loading: cx.props.loading.unwrap_or_default(),
+                    placeholder: cx.props.placeholder.clone(),
+                    ignore_focus: cx.props.ignore_focus,
+                    show_char_counter: true,
+                    value: if cx.props.is_disabled { get_local_text("messages.not-friends")} else { cx.props.value.clone().unwrap_or_default()},
+                    onchange: move |(v, _)| cx.props.onchange.call(v),
+                    onreturn: move |(v, is_valid, _)| {
+                        if is_valid {
+                            cx.props.onreturn.call(v);
+                        }
+                    },
+                    is_disabled: cx.props.is_disabled,
                 },
-                is_disabled: cx.props.is_disabled,
-            },
+                is_typing.then(|| {
+                    rsx!(MessageTyping {
+                        typing_users: cx.props.typing_users.clone()
+                    })
+                })
+            }
             cx.props.extensions.as_ref(),
             div {
                 class: "controls",

--- a/kit/src/layout/chatbar/style.scss
+++ b/kit/src/layout/chatbar/style.scss
@@ -14,6 +14,11 @@
 		}
 	}
 }
+.chatbar-group {
+	flex-direction: column;
+	display: flex;
+	width: 100%;
+}
 .inline-reply {
 	position: absolute;
 	left: var(--gap);

--- a/ui/src/components/chat/compose/chatbar.rs
+++ b/ui/src/components/chat/compose/chatbar.rs
@@ -16,7 +16,6 @@ use kit::{
     components::{
         embeds::file_embed::FileEmbed,
         indicator::{Platform, Status},
-        message_typing::MessageTyping,
         user_image::UserImage,
     },
     elements::{
@@ -28,12 +27,7 @@ use kit::{
 };
 use rfd::FileDialog;
 use uuid::Uuid;
-use warp::{
-    crypto::DID,
-    logging::tracing::log,
-    multipass::identity::{self, IdentityStatus},
-    raygun,
-};
+use warp::{crypto::DID, logging::tracing::log, raygun};
 
 const MAX_CHARS_LIMIT: usize = 1024;
 
@@ -99,8 +93,8 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
                 .collect()
         })
         .unwrap_or_default();
-    let is_typing = !users_typing.is_empty();
-    let users_typing = state.read().get_identities(&users_typing);
+    let mut users_typing = state.read().get_identities(&users_typing);
+    users_typing.push(state.read().get_own_identity());
 
     let msg_ch = use_coroutine(cx, |mut rx: UnboundedReceiver<ChatInput>| {
         to_owned![files_to_upload, state];
@@ -364,12 +358,15 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
         }
     };
 
+    let typing_users: Vec<String> = users_typing.iter().map(|id| (*id).username()).collect();
+
     let chatbar = cx.render(rsx!(
         Chatbar {
             key: "{id}",
             id: id.to_string(),
             loading: is_loading,
             placeholder: get_local_text("messages.say-something-placeholder"),
+            typing_users: typing_users,
             is_disabled: disabled,
             ignore_focus: cx.props.ignore_focus,
             onchange: move |v: String| {
@@ -483,28 +480,7 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
         ))
     ));
 
-    // todo: possibly show more if multiple users are typing
-    let (platform, status, profile_picture) = match users_typing.first() {
-        Some(u) => (u.platform(), u.identity_status(), u.profile_picture()),
-        None => (
-            identity::Platform::Unknown,
-            IdentityStatus::Online,
-            String::new(),
-        ),
-    };
-
     cx.render(rsx!(
-        is_typing.then(|| {
-            rsx!(MessageTyping {
-                user_image: cx.render(rsx!(
-                    UserImage {
-                        image: profile_picture,
-                        platform: platform.into(),
-                        status: status.into()
-                    }
-                ))
-            })
-        }),
         if state.read().ui.metadata.focused && *enable_paste_shortcut.read() {
             rsx!(paste_files_with_shortcut::PasteFilesShortcut {
                 on_paste: move |files_local_path: Vec<PathBuf>| {

--- a/ui/src/components/chat/compose/chatbar.rs
+++ b/ui/src/components/chat/compose/chatbar.rs
@@ -116,8 +116,7 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, super::ComposeProps>) -> Element<'a> {
                 .collect()
         })
         .unwrap_or_default();
-    let mut users_typing = state.read().get_identities(&users_typing);
-    users_typing.push(state.read().get_own_identity());
+    let users_typing = state.read().get_identities(&users_typing);
 
     let msg_ch = use_coroutine(cx, |mut rx: UnboundedReceiver<ChatInput>| {
         to_owned![state];


### PR DESCRIPTION
### What this PR does 📖

- Overhauls the typing indicator:
    - Shows the typing indicator below the chatbar as:
    - <user> is typing / <users> are typing 
    - Multiple user are typing if more than 3 are typing

- Currently if the user(s) name(s) are too long (bigger than 17 chars) they are shortened with 3 dots.
- Despite this though it still looks a bit weird if the app is shrunk just before going into minimal view as the message in general is so "big". I am unsure how we should solve this.

If sufficient big no problem:
<img width="520" alt="Screenshot 2023-08-02 at 14 23 51" src="https://github.com/Satellite-im/Uplink/assets/34157027/157a5bc0-7ecb-4d4c-9e0a-d0503c92df4d">
If small the whole message will currently get cut off (not sure if this is fine or not)
<img width="372" alt="Screenshot 2023-08-02 at 14 27 13" src="https://github.com/Satellite-im/Uplink/assets/34157027/e0605d47-63fa-4546-a8dc-450a2ec8f0c7">

### Which issue(s) this PR fixes 🔨

- Resolve #1054
