### PR TITLE
fix(BugModal): bugchat opening image previews highlights chat list avatars

### DIFF
--- a/kit/src/components/embeds/file_embed/mod.rs
+++ b/kit/src/components/embeds/file_embed/mod.rs
@@ -1,12 +1,15 @@
 use std::ffi::OsStr;
 use std::path::PathBuf;
 
+use crate::components::context_menu::ContextItem;
+use crate::components::context_menu::ContextMenu;
 use crate::elements::button::Button;
 use crate::elements::Appearance;
 use crate::layout::modal::Modal;
 use common::icons::outline::Shape as Icon;
 use common::icons::Icon as IconElement;
 
+use common::language::get_local_text;
 use dioxus::prelude::*;
 
 use humansize::format_size;
@@ -171,10 +174,32 @@ pub fn FileEmbed<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                         Modal {
                             open: *fullscreen_preview.clone(),
                             onclose: move |_| fullscreen_preview.set(false),
-                            img {
-                                aria_label: "image-preview-modal",
-                                src: "{large_thumbnail}",
-                                onclick: move |e| e.stop_propagation(),
+                            div {
+                                ContextMenu {
+                                    id: "file-embed-preview-context-menu".into(),
+                                    items: cx.render(rsx!(
+                                        ContextItem {
+                                            icon: Icon::ArrowDownCircle,
+                                            aria_label: "file-embed-download-context-item".into(),
+                                            text: get_local_text("files.download"),
+                                            onpress: move |_| {
+                                                cx.props.on_press.call(());
+                                            }
+                                        },
+                                    )),
+                                img {
+                                        id: "image-preview-modal-file-embed",
+                                        aria_label: "image-preview-modal-file-embed",
+                                        src: "{large_thumbnail}",
+                                        position: "absolute",
+                                        top: "50%",
+                                        left: "50%",
+                                        transform: "translate(-50%, -50%)",
+                                        max_height: "80%",
+                                        max_width: "80%",
+                                        onclick: move |e| e.stop_propagation(),
+                                    },
+                                },
                             }
                         }
                     )),

--- a/kit/src/components/embeds/file_embed/mod.rs
+++ b/kit/src/components/embeds/file_embed/mod.rs
@@ -174,33 +174,18 @@ pub fn FileEmbed<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                         Modal {
                             open: *fullscreen_preview.clone(),
                             onclose: move |_| fullscreen_preview.set(false),
-                            div {
-                                ContextMenu {
-                                    id: "file-embed-preview-context-menu".into(),
-                                    items: cx.render(rsx!(
-                                        ContextItem {
-                                            icon: Icon::ArrowDownCircle,
-                                            aria_label: "file-embed-download-context-item".into(),
-                                            text: get_local_text("files.download"),
-                                            onpress: move |_| {
-                                                cx.props.on_press.call(());
-                                            }
-                                        },
-                                    )),
-                                img {
-                                        id: "image-preview-modal-file-embed",
-                                        aria_label: "image-preview-modal-file-embed",
-                                        src: "{large_thumbnail}",
-                                        position: "absolute",
-                                        top: "50%",
-                                        left: "50%",
-                                        transform: "translate(-50%, -50%)",
-                                        max_height: "80%",
-                                        max_width: "80%",
-                                        onclick: move |e| e.stop_propagation(),
-                                    },
-                                },
-                            }
+                            img {
+                                id: "image-preview-modal-file-embed",
+                                aria_label: "image-preview-modal-file-embed",
+                                src: "{large_thumbnail}",
+                                position: "absolute",
+                                top: "50%",
+                                left: "50%",
+                                transform: "translate(-50%, -50%)",
+                                max_height: "80%",
+                                max_width: "80%",
+                                onclick: move |e| e.stop_propagation(),
+                            },
                         }
                     )),
                     div {

--- a/kit/src/components/embeds/file_embed/mod.rs
+++ b/kit/src/components/embeds/file_embed/mod.rs
@@ -1,15 +1,12 @@
 use std::ffi::OsStr;
 use std::path::PathBuf;
 
-use crate::components::context_menu::ContextItem;
-use crate::components::context_menu::ContextMenu;
 use crate::elements::button::Button;
 use crate::elements::Appearance;
 use crate::layout::modal::Modal;
 use common::icons::outline::Shape as Icon;
 use common::icons::Icon as IconElement;
 
-use common::language::get_local_text;
 use dioxus::prelude::*;
 
 use humansize::format_size;

--- a/kit/src/components/user_image_group/styles.scss
+++ b/kit/src/components/user_image_group/styles.scss
@@ -65,6 +65,7 @@
 }
 
 .user-image-group {
+    z-index: 0;
     display: inline-flex;
 	flex-direction: column;
 	gap: var(--gap);

--- a/kit/src/layout/modal/mod.rs
+++ b/kit/src/layout/modal/mod.rs
@@ -1,3 +1,4 @@
+use crate::components::context_menu::ContextMenu;
 use crate::elements::button::Button;
 use crate::elements::Appearance;
 use common::icons::outline::Shape as Icon;
@@ -14,16 +15,23 @@ pub struct Props<'a> {
 #[allow(non_snake_case)]
 pub fn Modal<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     cx.render(rsx!(cx.props.open.then(|| rsx!(
-        div {
-            class: "modal",
-            aria_label: "modal",
-            onclick: move |_| cx.props.onclose.call(()),
-            Button {
-                icon: Icon::XMark,
-                appearance: Appearance::Primary,
-                onpress: move |_| cx.props.onclose.call(()),
+        ContextMenu {
+            key: "modal-test",
+            id: "file-embed-preview-context-menu".into(),
+            items: cx.render(rsx!(
+                div {},
+            )),
+            div {
+                class: "modal",
+                aria_label: "modal",
+                onclick: move |_| cx.props.onclose.call(()),
+                Button {
+                    icon: Icon::XMark,
+                    appearance: Appearance::Primary,
+                    onpress: move |_| cx.props.onclose.call(()),
+                },
+                &cx.props.children
             },
-            &cx.props.children
-        },
+        }
     ))))
 }

--- a/kit/src/layout/modal/mod.rs
+++ b/kit/src/layout/modal/mod.rs
@@ -15,6 +15,8 @@ pub struct Props<'a> {
 #[allow(non_snake_case)]
 pub fn Modal<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     cx.render(rsx!(cx.props.open.then(|| rsx!(
+        // HACK: Necessay to avoid unwanted context menu
+        // from message when modal is open
         ContextMenu {
             key: "modal-test",
             id: "file-embed-preview-context-menu".into(),

--- a/kit/src/layout/modal/style.scss
+++ b/kit/src/layout/modal/style.scss
@@ -8,7 +8,7 @@
     left: 0;
     bottom: 0;
     right: 0;
-    background: rgba(0,0,0, 0.8);
+    background: rgba(0,0,0, 0.9);
 
     .btn-wrap {
       position: absolute;

--- a/ui/src/components/files/file_preview.rs
+++ b/ui/src/components/files/file_preview.rs
@@ -38,16 +38,6 @@ pub fn FilePreview<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 max_height: "80%",
                 max_width: "80%",
             },
-            img {
-                id: "file_preview_img",
-                src: format_args!("{}", image_from_clipboard.read()),
-                position: "absolute",
-                top: "50%",
-                left: "50%",
-                transform: "translate(-50%, -50%)",
-                max_height: "80%",
-                max_width: "80%",
-            },
         },
     }))
 }

--- a/ui/src/components/files/file_preview.rs
+++ b/ui/src/components/files/file_preview.rs
@@ -13,7 +13,6 @@ pub struct Props<'a> {
 #[allow(non_snake_case)]
 pub fn FilePreview<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let thumbnail = thumbnail_to_base64(cx.props.file);
-    let image_from_clipboard = use_ref(cx, String::new);
 
     cx.render(rsx!(div {
         ContextMenu {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
### 1. Fix bugchat opening image previews highlights chat list avatars
### 2. Fix context menu from message when context menu is opened
### 3. Remove unnecessary code
- 

### Which issue(s) this PR fixes 🔨

- Resolve #1061 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

