### PR TITLE
fix(SearchDropdown): Let search groups as non case sensitive

### DIFF
--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -1364,7 +1364,7 @@ impl State {
             if v.len() < name_prefix.len() {
                 false
             } else {
-                &v[..(name_prefix.len())] == name_prefix
+                v[..(name_prefix.len())].eq_ignore_ascii_case(name_prefix)
             }
         };
 

--- a/ui/src/layouts/unlock.rs
+++ b/ui/src/layouts/unlock.rs
@@ -57,6 +57,7 @@ pub fn UnlockLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -
 
     let error: &UseState<Option<UnlockError>> = use_state(cx, || None);
     let shown_error = use_state(cx, String::new);
+    let desktop = use_window(cx);
 
     let account_exists: &UseState<Option<bool>> = use_state(cx, || None);
     let cmd_in_progress = use_state(cx, || false);
@@ -223,7 +224,6 @@ pub fn UnlockLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -
                                 shown_error.set(String::new());
                             }
                             if validation_passed {
-                                let desktop = use_window(cx);
                                 let outer_size = desktop.outer_size();
                                 let is_maximized = desktop.is_maximized();
                                 state.write_silent().ui.window_height = outer_size.height;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
### 1. Let search groups as non case sensitive
<img width="286" alt="image" src="https://github.com/Satellite-im/Uplink/assets/63157656/53ee171c-6a63-4183-865f-3d8a9b39f18f">


### Which issue(s) this PR fixes 🔨

- Resolve #1072 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

