### PR TITLE
feat(AppWindow): Add borders to the app window

### DIFF
--- a/kit/src/style.scss
+++ b/kit/src/style.scss
@@ -220,6 +220,7 @@ pre code {
   --border-radius: 4px;
   --border-radius-less: 2px;
   --border-radius-more: 20px;
+  --border-radius-app-window: 10px;
 
   --border-color: #141414;
   --border-subtle-color: #212529;

--- a/ui/src/style.scss
+++ b/ui/src/style.scss
@@ -5,7 +5,8 @@ body {
   overscroll-behavior-y: none;
   overscroll-behavior-x: none;
   overflow: hidden;
-  border-radius: var(--border-radius);
+  border-radius: var(--border-radius-app-window);
+  border: 0.5px solid var(--secondary);
 }
 #main,
 #app-wrap {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
### 1. Add borders to the app window
<img width="952" alt="image" src="https://github.com/Satellite-im/Uplink/assets/63157656/f3c31323-178c-4022-91ae-afbe74f36fed">


### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

