### PR TITLE
chore(appium): copy windows assets on appium workflow

### DIFF
--- a/.github/workflows/ui-test-automation.yml
+++ b/.github/workflows/ui-test-automation.yml
@@ -86,7 +86,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Build executable 🖥️
-        run: cargo build --release --package uplink -F production_mode
+        run: cargo build --release -F production_mode
         continue-on-error: true
 
       - name: Upload Executable ⬆️
@@ -96,6 +96,16 @@ jobs:
           if-no-files-found: error
           path: |
             target/release/uplink.exe
+
+      - name: Upload Windows Assets
+        uses: actions/upload-artifact@v3
+        with:
+          name: uplink-windows-assets
+          path: |
+            ui/extra/images/
+            ui/extra/prism_langs/
+            ui/extra/themes/
+            ui/extra/extensions/
 
       - name: Add label if any of build or test jobs failed
         if: failure()
@@ -232,10 +242,27 @@ jobs:
           name: Uplink-Windows
           path: ./appium-tests/apps
 
+      - name: Download the Windows app assets
+        uses: actions/download-artifact@v3
+        with:
+          name: uplink-windows-assets
+          path: ./appium-tests/apps
+
       - name: Copy app to have two instances 💿
         working-directory: ./appium-tests/apps
         run: |
           cp -r ./uplink.exe ./uplink2.exe
+
+      - name: Move Windows assets to correct locations 💿
+        working-directory: ./appium-tests/apps
+        run: |
+          mkdir ./bin/extra
+          mkdir ./extra
+          mv ./uplink.exe ./bin/
+          mv ./uplink2.exe ./bin/
+          mv ./images/ ./bin/extra/
+          mv ./prism_langs/ ./bin/extra/
+          mv ./themes/ ./extra/
 
       - name: Setup Node.js 🔨
         uses: actions/setup-node@v3
@@ -330,6 +357,22 @@ jobs:
         with:
           name: Uplink-Windows
           path: ./appium-tests/apps
+
+      - name: Download the Windows app assets
+        uses: actions/download-artifact@v3
+        with:
+          name: uplink-windows-assets
+          path: ./appium-tests/apps
+
+      - name: Move Windows assets to correct locations 💿
+        working-directory: ./appium-tests/apps
+        run: |
+          mkdir ./bin/extra
+          mkdir ./extra
+          mv ./uplink.exe ./bin/
+          mv ./images/ ./bin/extra/
+          mv ./prism_langs/ ./bin/extra/
+          mv ./themes/ ./extra/
 
       - name: Install and Run Appium Server 💻
         run: |
@@ -507,6 +550,7 @@ jobs:
         with:
           name: |
             Uplink-windows-latest
+            uplink-windows-assets
             Uplink-macos-latest
             test-report-macos-ci
             test-report-windows-ci


### PR DESCRIPTION
### What this PR does 📖

- Only for the appium github workflow: Copy Windows build assets correctly when building the app with cargo build, in order to avoid having to automate the wix installer part (doesn't make sense to create test automation on third party products).

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

