### PR TITLE
update(ui): aria labels for emojis extensions and edit group chats

### DIFF
--- a/native_extensions/emoji_selector/src/lib.rs
+++ b/native_extensions/emoji_selector/src/lib.rs
@@ -218,7 +218,7 @@ fn render_selector<'a>(
                                 group.emojis().map(|emoji| {
                                     rsx!(
                                         div {
-                                            aria_label: "emoji",
+                                            aria_label: emoji.as_str(),
                                             class: "emoji",
                                             onclick: move |_| {
                                                 let destination = state.read().ui.emoji_destination.clone().unwrap_or(EmojiDestination::Chatbar);

--- a/ui/src/components/chat/compose/mod.rs
+++ b/ui/src/components/chat/compose/mod.rs
@@ -642,10 +642,12 @@ fn get_topbar_children(cx: Scope<ComposeProps>) -> Element {
                 })
             } else {rsx!(
                 p {
+                    aria_label: "user-info-username",
                     class: "username",
                     "{conversation_title}"
                 },
                 p {
+                    aria_label: "user-info-status",
                     class: "status",
                     if direct_message {
                         rsx! (span {

--- a/ui/src/components/chat/edit_group.rs
+++ b/ui/src/components/chat/edit_group.rs
@@ -59,6 +59,7 @@ pub fn EditGroup(cx: Scope) -> Element {
 
     let add_friends = rsx!(a {
         class: "float-right-link",
+        aria_label: "edit-group-add-members",
         onclick: move |_| {
             edit_group_action.set(EditGroupAction::Add);
         },
@@ -67,6 +68,7 @@ pub fn EditGroup(cx: Scope) -> Element {
 
     let remove_friends = rsx!(a {
         class: "float-right-link",
+        aria_label: "edit-group-current-members",
         onclick: move |_| {
             edit_group_action.set(EditGroupAction::Remove);
         },

--- a/ui/src/components/emoji_group/mod.rs
+++ b/ui/src/components/emoji_group/mod.rs
@@ -22,6 +22,7 @@ pub fn EmojiGroup<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             class: "emoji-group",
             for emoji in sorted_list {
                 Button {
+                    aria_label: "frequent-emoji".into(),
                     key: "{emoji.0}",
                     text: emoji.0.clone(),
                     appearance: Appearance::Secondary,
@@ -31,6 +32,7 @@ pub fn EmojiGroup<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 }
             }
             Button {
+                aria_label: "open-emoji-picker".into(),
                 key: "open-picker",
                 icon: Icon::Plus,
                 appearance: Appearance::Secondary,

--- a/ui/src/components/settings/mod.rs
+++ b/ui/src/components/settings/mod.rs
@@ -81,6 +81,7 @@ pub fn ExtensionSetting<'a>(cx: Scope<'a, ExtensionProps<'a>>) -> Element<'a> {
     cx.render(rsx!(
         div {
             class: "extension-setting",
+            aria_label: "extension-setting-element",
             div {
                 class: "heading",
                 IconElement {
@@ -89,10 +90,12 @@ pub fn ExtensionSetting<'a>(cx: Scope<'a, ExtensionProps<'a>>) -> Element<'a> {
                 div {
                     class: "text",
                     p {
+                        aria_label: "extension-setting-title",
                         class: "title",
                         "{cx.props.title}"
                     },
                     Label {
+                        aria_label: "extension-setting-author".into(),
                         text: cx.props.author.clone(),
                     }
                 },
@@ -103,6 +106,7 @@ pub fn ExtensionSetting<'a>(cx: Scope<'a, ExtensionProps<'a>>) -> Element<'a> {
             },
             p {
                 class: "description",
+                aria_label: "extension-setting-description",
                 "{cx.props.description}"
             }
         }


### PR DESCRIPTION
### What this PR does 📖

- Adding aria labels for Settings Extensions
- Updating aria labels for Emoji Selector so it can be easier to add emojis on automated tests
- Updating aria labels from Edit Group recent changes applied to the app
- All these changes are required to keep updating the tests skipped for now and to add tests for emojis/reactions

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

