### PR TITLE
chore(appium): update appium workflow to copy missing extensions assets

### DIFF
--- a/.github/workflows/ui-test-automation.yml
+++ b/.github/workflows/ui-test-automation.yml
@@ -92,7 +92,11 @@ jobs:
       - name: Copy Extensions 🗳️
         run: |
           mkdir ./ui/extra/extensions
+          cp -r ./target/release/emoji_selector.d ./ui/extra/extensions/
           cp -r ./target/release/emoji_selector.dll ./ui/extra/extensions/
+          cp -r ./target/release/emoji_selector.dll.exp ./ui/extra/extensions/
+          cp -r ./target/release/emoji_selector.dll.lib ./ui/extra/extensions/
+          cp -r ./target/release/emoji_selector.dll.pdb ./ui/extra/extensions/
 
       - name: Upload Executable ⬆️
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
### What this PR does 📖

- In my previous PR to copy windows extensions assets, I did not added all the emoji extensions files required to use the emoji picker on Uplink, so I am just updating the appium workflow to copy the remaining files on the workflow

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

