### PR TITLE
chore(appium): fix appium workflow for windows build copy assets

### DIFF
--- a/.github/workflows/ui-test-automation.yml
+++ b/.github/workflows/ui-test-automation.yml
@@ -96,7 +96,7 @@ jobs:
           cp -r ./target/release/emoji_selector.dll ./ui/extra/extensions/
           cp -r ./target/release/emoji_selector.dll.exp ./ui/extra/extensions/
           cp -r ./target/release/emoji_selector.dll.lib ./ui/extra/extensions/
-          cp -r ./target/release/emoji_selector.dll.pdb ./ui/extra/extensions/
+          cp -r ./target/release/emoji_selector.pdb ./ui/extra/extensions/
 
       - name: Upload Executable ⬆️
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
### What this PR does 📖

- Fixing an error introduced on my previous PR to the appium workflow in order to copy correctly the extensions assets during automated tests CI execution

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

