### PR TITLE
fix(counter): lock moving character counter to bottom of textarea

### DIFF
--- a/kit/src/elements/textarea/style.scss
+++ b/kit/src/elements/textarea/style.scss
@@ -32,8 +32,8 @@ textarea::-webkit-scrollbar-thumb:horizontal {
 
 .input-char-counter {
 	padding: 2px 9px;
-	position: absolute;
-	font-size: var(--text-size-less);
-	right: 0;
-	top: var(--height-input);
+    position: absolute;
+    font-size: var(--text-size-less);
+    right: 0;
+    bottom: -17px;
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Not my favorite fix, but, using -int on bottom css property was able to work with the differing heights of the input area

### Which issue(s) this PR fixes 🔨

- Resolve #1104 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

