### PR TITLE
chore(ui): start unifying window sizes

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -20,6 +20,8 @@ use warp_runner::{WarpCmdChannels, WarpEventChannels};
 
 use fluent_templates::static_loader;
 
+pub const DEFAULT_DIMENSIONS: (f64, f64) = (1200.0, 750.0);
+
 static_loader! {
     static LOCALES = {
         locales: "./locales",

--- a/common/src/state/ui.rs
+++ b/common/src/state/ui.rs
@@ -10,6 +10,8 @@ use uuid::Uuid;
 use warp::logging::tracing::log;
 use wry::webview::WebView;
 
+use crate::DEFAULT_DIMENSIONS;
+
 use super::{call, notifications::Notifications};
 
 pub type EmojiList = HashMap<String, u64>;
@@ -66,7 +68,9 @@ pub struct WindowMeta {
     pub focused: bool,
     pub maximized: bool,
     pub minimized: bool,
-    pub minimal_view: bool, // We can use this to detect mobile or portrait mode
+    pub minimal_view: bool,
+    pub height: u32,
+    pub width: u32, // We can use this to detect mobile or portrait mode
 }
 
 #[derive(Clone, Deserialize, Serialize, Eq, PartialEq)]
@@ -132,9 +136,9 @@ pub struct UI {
     pub enable_overlay: bool,
     pub active_welcome: bool,
     pub sidebar_hidden: bool,
-    pub window_maximized: bool,
-    pub window_width: u32,
-    pub window_height: u32,
+    pub window_maximized: bool, // TODO: Duplicate value, should be removed in favor of metadata.maximized
+    pub window_width: f64,      // TODO: Move this to WindowMeta
+    pub window_height: f64,     // TODO: Move this to WindowMeta
     pub metadata: WindowMeta,
     #[serde(default = "default_emojis")]
     pub emojis: EmojiCounter,
@@ -172,8 +176,8 @@ impl Default for UI {
             active_welcome: Default::default(),
             sidebar_hidden: Default::default(),
             window_maximized: Default::default(),
-            window_width: Default::default(),
-            window_height: Default::default(),
+            window_width: DEFAULT_DIMENSIONS.0,
+            window_height: DEFAULT_DIMENSIONS.1,
             metadata: Default::default(),
             emojis: default_emojis(),
             emoji_destination: Default::default(),

--- a/ui/src/layouts/loading.rs
+++ b/ui/src/layouts/loading.rs
@@ -1,4 +1,4 @@
-use common::{get_images_dir, state::State};
+use common::{get_images_dir, state::State, DEFAULT_DIMENSIONS};
 use dioxus::prelude::*;
 use dioxus_desktop::{use_window, LogicalSize};
 use dioxus_router::use_router;
@@ -13,6 +13,11 @@ pub fn LoadingLayout(cx: Scope) -> Element {
     let router = use_router(cx);
     let desktop = use_window(cx);
 
+    let window_size = (
+        state.read().ui.metadata.width,
+        state.read().ui.metadata.height,
+    );
+
     let desktop_resized = use_future(cx, (), |_| {
         to_owned![desktop, state];
         async move {
@@ -21,7 +26,7 @@ pub fn LoadingLayout(cx: Scope) -> Element {
                 desktop.set_outer_position(LogicalPosition::new(0, 0));
                 desktop.set_maximized(true);
             } else {
-                desktop.set_inner_size(LogicalSize::new(950.0, 600.0));
+                desktop.set_inner_size(LogicalSize::new(window_size.0, window_size.1));
             }
             desktop.set_min_inner_size(Some(LogicalSize::new(300.0, 500.0)));
         }

--- a/ui/src/layouts/unlock.rs
+++ b/ui/src/layouts/unlock.rs
@@ -226,8 +226,9 @@ pub fn UnlockLayout(cx: Scope, page: UseState<AuthPages>, pin: UseRef<String>) -
                             if validation_passed {
                                 let outer_size = desktop.outer_size();
                                 let is_maximized = desktop.is_maximized();
-                                state.write_silent().ui.window_height = outer_size.height;
-                                state.write_silent().ui.window_width = outer_size.width;
+                                // TODO: What is the point of this on the input field?
+                                state.write_silent().ui.window_height = outer_size.height as f64;
+                                state.write_silent().ui.window_width = outer_size.width  as f64;
                                 state.write_silent().ui.window_maximized = is_maximized;
                                 let _ = state.write_silent().save();
                                 cmd_in_progress.set(true);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

In progress, works to maintain window size between resets as well as unifying the usage of `window_height` and `window_width` to use the WindowMeta fields instead