### PR TITLE
chore(search): show all available friends on clear

### DIFF
--- a/ui/src/components/chat/group_users.rs
+++ b/ui/src/components/chat/group_users.rs
@@ -61,6 +61,7 @@ pub fn GroupUsers(cx: Scope<Props>) -> Element {
                     options: Options {
                         with_clear_btn: true,
                         react_to_esc_key: true,
+                        clear_on_submit: false,
                         ..Options::default()
                     },
                     onchange: move |(v, _): (String, _)| {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
Clicking X on group (that you are not owner) will now show all friends available again
- 

### Which issue(s) this PR fixes 🔨

- Resolve #1113

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

