### PR TITLE
chore(group-images): make group profile image default cursor

### DIFF
--- a/kit/src/components/user_image/style.scss
+++ b/kit/src/components/user_image/style.scss
@@ -8,6 +8,10 @@
 	background-color: var(--secondary);
 }
 
+.user-image-group-wrap * {
+	cursor: default;
+}
+
 .user-image {
 	width: fit-content;
 	height: var(--height-input);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
makes clustered group images have default cursor instead of clickable cursor
- 

### Which issue(s) this PR fixes 🔨

- Resolve #1087 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

