### PR TITLE
chore(favorites): favorites showing groups with wrong count

### DIFF
--- a/ui/src/components/chat/sidebar.rs
+++ b/ui/src/components/chat/sidebar.rs
@@ -343,7 +343,7 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
                                         }
                                     )),
                                     UserImageGroup {
-                                        participants: build_participants(&other_participants),
+                                        participants: build_participants(&participants),
                                         with_username: participants_name,
                                         typing: users_typing,
                                         onpress: move |_| {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!-->

### What this PR does 📖
This passes the entire participants list over, before it was sending participants list without yourself, which made it appear to miss 1 every time

- 

### Which issue(s) this PR fixes 🔨

- Resolve #1086 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

