### PR TITLE
fix(sidebar): Fix resize using different value on mac

### DIFF
--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -613,7 +613,7 @@ fn app(cx: Scope) -> Element {
                     desktop.set_inner_size(LogicalSize::new(950.0, 600.0));
                     *first_resize.write_silent() = false;
                 }
-                let size = webview.inner_size();
+                let size = webview.window().inner_size();
 
                 //log::trace!(
                 //    "Resized - PhysicalSize: {:?}, Minimal: {:?}",


### PR DESCRIPTION
### What this PR does 📖

- Fixes resize event using different window size value on mac which causes sidebar issues
- Seems to also be an issue on windows? Please verify again with this PR

### Which issue(s) this PR fixes 🔨

- Resolve #971
