### PR TITLE
chore(calling): hook up reject_call blink method so receiver can decline a call and sender call ends too

### DIFF
--- a/common/src/state/action.rs
+++ b/common/src/state/action.rs
@@ -57,6 +57,8 @@ pub enum Action<'a> {
     /// Sets the active call and active media id
     #[display(fmt = "AnswerCall")]
     AnswerCall(Uuid),
+    #[display(fmt = "RejectCall")]
+    RejectCall(Uuid),
     /// creates a Call struct and joins the call
     #[display(fmt = "OfferCall")]
     OfferCall(call::Call),

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -283,6 +283,7 @@ impl State {
                     log::error!("failed to answer call: {e}");
                 }
             },
+            Action::RejectCall(id) => self.ui.call_info.reject_call(id),
             Action::OfferCall(call) => {
                 let _ = self.ui.call_info.pending_call(
                     call.id,

--- a/common/src/warp_runner/manager/commands/blink_commands.rs
+++ b/common/src/warp_runner/manager/commands/blink_commands.rs
@@ -19,7 +19,7 @@ pub enum BlinkCmd {
         call_id: Uuid,
         rsp: oneshot::Sender<Result<(), warp::error::Error>>,
     },
-    #[display(fmt = "Reject")]
+    #[display(fmt = "RejectCall")]
     RejectCall {
         call_id: Uuid,
         rsp: oneshot::Sender<Result<(), warp::error::Error>>,

--- a/common/src/warp_runner/manager/commands/blink_commands.rs
+++ b/common/src/warp_runner/manager/commands/blink_commands.rs
@@ -19,6 +19,11 @@ pub enum BlinkCmd {
         call_id: Uuid,
         rsp: oneshot::Sender<Result<(), warp::error::Error>>,
     },
+    #[display(fmt = "Reject")]
+    RejectCall {
+        call_id: Uuid,
+        rsp: oneshot::Sender<Result<(), warp::error::Error>>,
+    },
     #[display(fmt = "LeaveCall")]
     LeaveCall {
         rsp: oneshot::Sender<Result<(), warp::error::Error>>,
@@ -49,6 +54,9 @@ pub async fn handle_blink_cmd(cmd: BlinkCmd, blink: &mut Calling) {
         }
         BlinkCmd::AnswerCall { call_id, rsp } => {
             let _ = rsp.send(blink.answer_call(call_id).await);
+        }
+        BlinkCmd::RejectCall { call_id, rsp } => {
+            let _ = rsp.send(blink.reject_call(call_id).await);
         }
         BlinkCmd::LeaveCall { rsp } => {
             let _ = rsp.send(blink.leave_call().await);

--- a/common/src/warp_runner/mod.rs
+++ b/common/src/warp_runner/mod.rs
@@ -371,7 +371,7 @@ async fn warp_initialization(tesseract: Tesseract) -> Result<manager::Warp, warp
         .await?;
 
     let blink = warp_blink_wrtc::BlinkImpl::new(multipass.clone()).await?;
-
+    println!("initializing blink!,");
     Ok(manager::Warp {
         tesseract,
         multipass,

--- a/common/src/warp_runner/mod.rs
+++ b/common/src/warp_runner/mod.rs
@@ -371,7 +371,7 @@ async fn warp_initialization(tesseract: Tesseract) -> Result<manager::Warp, warp
         .await?;
 
     let blink = warp_blink_wrtc::BlinkImpl::new(multipass.clone()).await?;
-    println!("initializing blink!,");
+
     Ok(manager::Warp {
         tesseract,
         multipass,

--- a/ui/src/components/media/remote_control.rs
+++ b/ui/src/components/media/remote_control.rs
@@ -42,10 +42,6 @@ pub fn RemoteControls(cx: Scope<Props>) -> Element {
     let active_call = state.read().ui.call_info.active_call();
     let active_call_id = active_call.as_ref().map(|x| x.call.id);
     let active_call_answer_time = active_call.as_ref().map(|x| x.answer_time);
-    let active_call_participants_joined = active_call
-        .as_ref()
-        .map(|x| x.call.participants_joined.len());
-
     let scope_id = cx.scope_id();
     let update_fn = cx.schedule_update_any();
 
@@ -197,34 +193,14 @@ pub fn RemoteControls(cx: Scope<Props>) -> Element {
                     // todo: send command
                 }
             },
-
-            // TODO: This needs a a signal sent when you terminate a call before the other user joins
-            //   Once the signal is added, this part will either need to be updated to show a different button with different method
-            //   (how it is configured below), or changed to fire both events on click (no more if/else, a single button with two things happening on press)
-            if active_call_participants_joined.is_some() && active_call_participants_joined.unwrap_or_default() > 0 {
-                // This button is shown where there are more than 1 person in the call
-                rsx!(
-                    Button {
-                        icon: Icon::PhoneXMark,
-                        appearance: Appearance::Danger,
-                        text: cx.props.end_text.clone(),
-                        onpress: move |_| {
-                            ch.send(CallDialogCmd::Hangup(call.id));
-                        },
-                    }
-                )
-            } else {
-                rsx!(
-                    // This button is shown where there are no people in the call/it is calling
-                    Button {
-                        icon: Icon::PhoneXMark,
-                        appearance: Appearance::Success,
-                        text: "Cancel".into(),
-                        onpress: move |_| {
-                            ch.send(CallDialogCmd::Hangup(call.id));
-                        },
-                    }
-                )
+            Button {
+                icon: Icon::PhoneXMark,
+                appearance: Appearance::Danger,
+                text: cx.props.end_text.clone(),
+                onpress: move |_| {
+                    // TODO: This needs a a signal sent when you terminate a call before the other user joins
+                    ch.send(CallDialogCmd::Hangup(call.id));
+                },
             }
 
         }

--- a/ui/src/components/media/remote_control.rs
+++ b/ui/src/components/media/remote_control.rs
@@ -198,7 +198,6 @@ pub fn RemoteControls(cx: Scope<Props>) -> Element {
                 appearance: Appearance::Danger,
                 text: cx.props.end_text.clone(),
                 onpress: move |_| {
-                    // TODO: This needs a a signal sent when you terminate a call before the other user joins
                     ch.send(CallDialogCmd::Hangup(call.id));
                 },
             }

--- a/ui/src/components/media/remote_control.rs
+++ b/ui/src/components/media/remote_control.rs
@@ -201,7 +201,7 @@ pub fn RemoteControls(cx: Scope<Props>) -> Element {
             // TODO: This needs a a signal sent when you terminate a call before the other user joins
             //   Once the signal is added, this part will either need to be updated to show a different button with different method
             //   (how it is configured below), or changed to fire both events on click (no more if/else, a single button with two things happening on press)
-            if active_call_participants_joined.is_some() && active_call_participants_joined.unwrap() > 0 {
+            if active_call_participants_joined.is_some() && active_call_participants_joined.unwrap_or_default() > 0 {
                 // This button is shown where there are more than 1 person in the call
                 rsx!(
                     Button {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1198,7 +1198,24 @@ fn get_call_dialog(cx: Scope) -> Element {
                         }
                     }
                     CallDialogCmd::Reject(id) => {
-                        state.write().ui.call_info.reject_call(id);
+                        let (tx, rx) = oneshot::channel();
+                        if let Err(_e) = warp_cmd_tx.send(WarpCmd::Blink(BlinkCmd::RejectCall {
+                            call_id: id,
+                            rsp: tx,
+                        })) {
+                            log::error!("failed to send blink command");
+                            continue;
+                        }
+
+                        match rx.await {
+                            Ok(_) => {
+                                state.write().mutate(Action::RejectCall(id));
+                                state.write().ui.call_info.reject_call(id);
+                            }
+                            Err(e) => {
+                                log::error!("warp_runner failed to answer call: {e}");
+                            }
+                        }
                     }
                 }
             }

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1209,7 +1209,6 @@ fn get_call_dialog(cx: Scope) -> Element {
 
                         match rx.await {
                             Ok(_) => {
-                                state.write().mutate(Action::RejectCall(id));
                                 state.write().ui.call_info.reject_call(id);
                             }
                             Err(e) => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
When you make a call, receiver can decline it and sender knows whats up

https://github.com/Satellite-im/Uplink/assets/2993032/eebfbd4b-1c29-4d8d-9120-ff216310d2e3


Video will show you being able to end call and decline the call from the other side, which will end the call for both people.
You will also see an issue (will create a ticket for Stu) that you cant end the call as a caller (before the other user picks up)
That will require another blink method.

- 

### Which issue(s) this PR fixes 🔨

- Resolve #1130

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️
Can you test this in a group call if you get a chance? I was not able to test that on my end yet.

### Additional comments 🎤

