### PR TITLE
fix(sidebar): Fix sidebar being hidden/shown during undesired actions

### DIFF
--- a/ui/src/components/chat/sidebar.rs
+++ b/ui/src/components/chat/sidebar.rs
@@ -3,7 +3,6 @@ use common::state::{self, identity_search_result, Action, State};
 use common::warp_runner::{RayGunCmd, WarpCmd};
 use common::{icons::outline::Shape as Icon, WARP_CMD_CH};
 use dioxus::prelude::*;
-use dioxus_desktop::use_window;
 use dioxus_router::*;
 use futures::channel::oneshot;
 use futures::StreamExt;
@@ -99,8 +98,6 @@ fn search_friends<'a>(cx: Scope<'a, SearchProps<'a>>) -> Element<'a> {
 pub fn Sidebar(cx: Scope<Props>) -> Element {
     log::trace!("rendering chats sidebar layout");
     let state = use_shared_state::<State>(cx)?;
-    let desktop = use_window(cx);
-    let size = desktop.webview.inner_size();
     let search_results = use_state(cx, Vec::<identity_search_result::Entry>::new);
     let chat_with: &UseState<Option<Uuid>> = use_state(cx, || None);
     let reset_searchbar = use_state(cx, || false);
@@ -514,7 +511,7 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
                                 onpress: move |_| {
                                     state.write().mutate(Action::ChatWith(&chat_with.id, false));
 
-                                    if size.width <= 1200 {
+                                    if state.read().ui.is_minimal_view() {
                                         state.write().mutate(Action::SidebarHidden(true));
                                     }
                                     if cx.props.route_info.active.to != UPLINK_ROUTES.chat {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -412,7 +412,12 @@ pub fn app_bootstrap(cx: Scope, identity: multipass::identity::Identity) -> Elem
     }
 
     let size = desktop.webview.inner_size();
+    #[cfg(target_os = "macos")]
     let mut minimal_width = 600;
+
+    #[cfg(not(target_os = "macos"))]
+    let minimal_width = 600;
+
     #[cfg(target_os = "macos")]
     {
         minimal_width = (minimal_width as f64 * desktop.webview.window().scale_factor()) as u32;
@@ -619,7 +624,12 @@ fn app(cx: Scope) -> Element {
                     *first_resize.write_silent() = false;
                 }
                 let size = webview.inner_size();
+
+                #[cfg(target_os = "macos")]
                 let mut minimal_width = 600;
+
+                #[cfg(not(target_os = "macos"))]
+                let minimal_width = 600;
                 // On Mac window sizes are kinda funky.
                 // They are scaled with the window scale factor so they dont correspond to app pixels
                 #[cfg(target_os = "macos")]

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -613,7 +613,7 @@ fn app(cx: Scope) -> Element {
                     desktop.set_inner_size(LogicalSize::new(950.0, 600.0));
                     *first_resize.write_silent() = false;
                 }
-                let size = webview.inner_size();
+                let size = webview.window().inner_size();
 
                 //log::trace!(
                 //    "Resized - PhysicalSize: {:?}, Minimal: {:?}",

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1310,6 +1310,11 @@ fn get_router(cx: Scope) -> Element {
                     }
                 }
             },
+            onchange: move |_| {
+                if state.read().ui.is_minimal_view() {
+                    state.write().mutate(Action::SidebarHidden(true));
+                }
+            },
             notification_action_handler {
                 friend_state: initial_friend_page
             }


### PR DESCRIPTION
### What this PR does 📖

- Fix sidebar collapsing when not in minimal view and selecting a chat
- Fix sidebar not collapsing when switching between friend/chat/files etc. when in minimal view
- Fixes resize event using different window size value on mac which causes sidebar issues

### Which issue(s) this PR fixes 🔨

- Resolve #1126 (first point)
- Resolve #972 (second point)
- Resolve #971 (3rd point)

### Special notes for reviewers 🗒️

~~Minimal view is set differently on mac so this will not work there. Solution is in #1131~~

