### PR TITLE
fix(clippy): fix the clippy warnings on windows

### DIFF
--- a/common/src/notifications.rs
+++ b/common/src/notifications.rs
@@ -17,7 +17,7 @@ use tokio::sync::{
 };
 
 #[cfg(target_os = "windows")]
-pub const POWERSHELL_APP_ID: &'static str = "{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\
+pub const POWERSHELL_APP_ID: &str = "{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\
 \\WindowsPowerShell\\v1.0\\powershell.exe";
 
 #[derive(Debug, Clone, Display)]

--- a/ui/src/components/chat/compose/mod.rs
+++ b/ui/src/components/chat/compose/mod.rs
@@ -144,8 +144,7 @@ pub fn Compose(cx: Scope) -> Element {
                     let new_files = drag_and_drop_function(&window, &drag_event).await;
                     let mut new_files_to_upload: Vec<_> = state
                         .read()
-                        .get_active_chat()
-                        .and_then(|f| Some(f.files_attached_to_send))
+                        .get_active_chat().map(|f| f.files_attached_to_send)
                         .unwrap_or_default()
                         .iter()
                         .filter(|file_name| !new_files.contains(file_name))

--- a/ui/src/components/chat/compose/mod.rs
+++ b/ui/src/components/chat/compose/mod.rs
@@ -144,7 +144,8 @@ pub fn Compose(cx: Scope) -> Element {
                     let new_files = drag_and_drop_function(&window, &drag_event).await;
                     let mut new_files_to_upload: Vec<_> = state
                         .read()
-                        .get_active_chat().map(|f| f.files_attached_to_send)
+                        .get_active_chat()
+                        .map(|f| f.files_attached_to_send)
                         .unwrap_or_default()
                         .iter()
                         .filter(|file_name| !new_files.contains(file_name))

--- a/ui/src/utils/clipboard/clipboard_data.rs
+++ b/ui/src/utils/clipboard/clipboard_data.rs
@@ -5,7 +5,7 @@ use crate::utils::verify_valid_paths::decoded_pathbufs;
 
 use arboard::Clipboard as Arboard;
 #[cfg(target_os = "windows")]
-use clipboard_win::{formats, get_clipboard, set_clipboard};
+use clipboard_win::{formats, get_clipboard};
 use image::DynamicImage;
 use image::ImageBuffer;
 use image::ImageOutputFormat;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- just ran cargo clippy --fix to see what it does and these all seem reasonable right? I know @Flemmli97 mentioned there was a reason for how the string looked in notifications.rs but now I forget and figured this could start the conversaton

### Which issue(s) this PR fixes 🔨

- None. Just been bothering me

### Special notes for reviewers 🗒️

This is Windows only. Specifically I wonder if notifications still work. 

### Additional comments 🎤

