### PR TITLE
chore(appium): add retry step on macos CI test execution

### DIFF
--- a/.github/workflows/ui-test-automation.yml
+++ b/.github/workflows/ui-test-automation.yml
@@ -189,7 +189,7 @@ jobs:
       - name: Run Tests on MacOS 🧪
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 20
+          timeout_minutes: 30
           max_attempts: 2
           command: |
             cd ./appium-tests

--- a/.github/workflows/ui-test-automation.yml
+++ b/.github/workflows/ui-test-automation.yml
@@ -127,7 +127,7 @@ jobs:
 
   test-mac:
     needs: build-mac
-    runs-on: macos-13
+    runs-on: macos-latest
 
     steps:
       - name: Checkout working directory 🔖

--- a/.github/workflows/ui-test-automation.yml
+++ b/.github/workflows/ui-test-automation.yml
@@ -187,8 +187,13 @@ jobs:
           cp -r ./appium-tests/tests/fixtures/users/FriendsTestUser/ ./appium-tests/tests/fixtures/users/mac2/FriendsTestUser
 
       - name: Run Tests on MacOS 🧪
-        working-directory: ./appium-tests
-        run: npm run mac.ci
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 20
+          max_attempts: 2
+          command: |
+            cd ./appium-tests
+            npm run mac.ci
 
       - name: Upload Test Report - MacOS CI
         if: always()


### PR DESCRIPTION
### What this PR does 📖

- Using retry gh action to retry automated tests only on MacOS CI job, instead of using retry from webdriverio configuration

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

