### PR TITLE
Unify dioxus dependencies for signals in new state branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,15 +26,15 @@ version = "0.1.6"
 rust-version = "1.70"
 
 [workspace.dependencies]
-dioxus = { version = "0.4" }
-dioxus-hooks = { version = "0.4" }
-dioxus-html = { version = "0.4" }
-dioxus-router = { version = "0.4" }
-dioxus-desktop = { version = "0.4", features = ["transparent"] }
+dioxus = { git = "https://github.com/ealmloff/dioxus", branch = "improved-signals" }
+dioxus-hooks = { git = "https://github.com/ealmloff/dioxus", branch = "improved-signals" }
+dioxus-html = { git = "https://github.com/ealmloff/dioxus", branch = "improved-signals" }
+dioxus-router = { git = "https://github.com/ealmloff/dioxus", branch = "improved-signals" }
+dioxus-desktop = { git = "https://github.com/ealmloff/dioxus", branch = "improved-signals", features = ["transparent"] }
 dioxus-signals = { git = "https://github.com/ealmloff/dioxus", branch = "improved-signals", features = ["serde"]}
 raw-window-handle = "0.5"
-dioxus-core = { version = "0.4" }
-fermi = { version = "0.4" }
+dioxus-core = { git = "https://github.com/ealmloff/dioxus", branch = "improved-signals" }
+fermi = { git = "https://github.com/ealmloff/dioxus", branch = "improved-signals" }
 tokio-util = { version = "0.7", features = ["full"] }
 arboard = "3.2"
 humansize = "2.1.3"


### PR DESCRIPTION
### What this PR does 📖

Fixes signal creation in Uplink. Dioxus signals uses globals from dioxus core. The new state branch has two versions of dioxus core. One used for rendering with, and one that dioxus-signals uses. Because the two version are different, the version dioxus-signals uses never gets updated which makes the current scope always unset causing signal creation to panic

### Special notes for reviewers 🗒️

### Additional comments 🎤
