### PR TITLE
chore(chats): make unreads a HashSet ans rename messages functions

### DIFF
--- a/common/src/state/chats.rs
+++ b/common/src/state/chats.rs
@@ -3,7 +3,6 @@ use std::{
     time::Instant,
 };
 
-use chrono::{DateTime, Utc};
 use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
 use uuid::Uuid;
 use warp::{
@@ -52,7 +51,8 @@ pub struct Chat {
     #[serde(default)]
     pub messages: VecDeque<ui_adapter::Message>,
     // Unread count for this chat, should be cleared when we view the chat.
-    pub unreads: u32,
+    #[serde(default)]
+    unreads: HashSet<Uuid>,
     // If a value exists, we will render the message we're replying to above the chatbar
     #[serde(skip)]
     pub replying_to: Option<raygun::Message>,
@@ -78,6 +78,34 @@ pub struct Chat {
 }
 
 impl Chat {
+    pub fn new(
+        id: Uuid,
+        participants: HashSet<DID>,
+        conversation_type: ConversationType,
+        conversation_name: Option<String>,
+        creator: Option<DID>,
+        messages: VecDeque<ui_adapter::Message>,
+        pinned_messages: Vec<raygun::Message>,
+    ) -> Self {
+        Self {
+            id,
+            participants,
+            conversation_type,
+            conversation_name,
+            creator,
+            messages,
+            unreads: HashSet::new(),
+            replying_to: None,
+            typing_indicator: HashMap::new(),
+            draft: None,
+            has_more_messages: false,
+            pending_outgoing_messages: vec![],
+            files_attached_to_send: Vec::new(),
+            scroll_value: None,
+            pinned_messages,
+            scroll_to: None,
+        }
+    }
     pub fn append_pending_msg(
         &mut self,
         chat_id: Uuid,
@@ -119,20 +147,20 @@ impl Chat {
         }
     }
 
-    // take the timestamp of a message and determine if it occurs at or after the time of the earliest unread message
-    // WARNING: a chat is loaded with 10 or 20 messages by default. if there are more unread messages in RayGun, then
-    // this function could return a false negative. This is unlikely.
-    pub fn is_msg_unread(&self, message_time: DateTime<Utc>) -> bool {
-        if self.unreads == 0 {
-            return false;
-        }
-        // if you have 1 unread message, skip 0 messages and take the next one.
-        // if you have 2 unread messages, skip 1 and take the next one.
-        let to_skip = self.unreads.saturating_sub(1);
-        match self.messages.iter().rev().nth(to_skip as usize) {
-            Some(msg) => msg.inner.date() <= message_time,
-            _ => false,
-        }
+    pub fn unreads(&self) -> u32 {
+        self.unreads.len() as _
+    }
+
+    pub fn clear_unreads(&mut self) {
+        self.unreads.clear();
+    }
+
+    pub fn remove_unread(&mut self, id: &Uuid) -> bool {
+        self.unreads.remove(id)
+    }
+
+    pub fn add_unread(&mut self, id: Uuid) {
+        self.unreads.insert(id);
     }
 }
 
@@ -161,7 +189,7 @@ impl Chats {
         };
 
         match self.all.get(&id) {
-            Some(c) => c.unreads > 0,
+            Some(c) => c.unreads() > 0,
             None => false,
         }
     }

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -1750,7 +1750,7 @@ impl<'a> GroupedMessage<'a> {
     }
 }
 
-pub fn group_messages<'a>(
+pub fn create_message_groups<'a>(
     my_did: DID,
     when_to_fetch_more: usize,
     // true if the chat has more messages to fetch

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -529,20 +529,8 @@ impl State {
                 // can't have 2 mutable borrows
                 let mut should_decrement_notifications = false;
                 if let Some(chat) = self.chats.all.get_mut(&conversation_id) {
-                    // can't fetch the deleted message from RayGun because it no longer exists there.
-                    // Not going to ask that the RayGun event be updated at this time because having this
-                    // information doesn't guarantee we can determine if the deleted message was unread.
-                    // Knowing this basically requires that RayGun  or warp_runner knows how many
-                    // unread messages there are. But that information is in State.
-                    if let Some(msg) = chat
-                        .messages
-                        .iter()
-                        .find(|msg| msg.inner.id() == message_id)
-                    {
-                        if chat.is_msg_unread(msg.inner.date()) {
-                            chat.unreads = chat.unreads.saturating_sub(1);
-                            should_decrement_notifications = true;
-                        }
+                    if chat.remove_unread(&message_id) {
+                        should_decrement_notifications = true;
                     }
                     chat.messages.retain(|msg| msg.inner.id() != message_id);
                     chat.pinned_messages.retain(|msg| msg.id() != message_id);
@@ -849,6 +837,7 @@ impl State {
             .collect()
     }
     fn add_msg_to_chat(&mut self, conversation_id: Uuid, message: ui_adapter::Message) {
+        let msg_id = message.inner.id();
         if let Some(chat) = self.chats.all.get_mut(&conversation_id) {
             chat.typing_indicator.remove(&message.inner.sender());
             chat.messages.push_back(message);
@@ -856,7 +845,7 @@ impl State {
             if self.ui.current_layout != ui::Layout::Compose
                 || self.chats.active != Some(conversation_id)
             {
-                chat.unreads += 1;
+                chat.add_unread(msg_id);
             }
         }
     }
@@ -947,7 +936,7 @@ impl State {
     ///
     fn clear_unreads(&mut self, chat_id: Uuid) {
         if let Some(chat) = self.chats.all.get_mut(&chat_id) {
-            chat.unreads = 0;
+            chat.clear_unreads();
         }
     }
     /// Adds the given chat to the user's favorites.
@@ -1143,7 +1132,7 @@ impl State {
             self.chats.in_sidebar.push_front(*chat);
         }
         if let Some(chat) = self.chats.all.get_mut(chat) {
-            chat.unreads = 0;
+            chat.clear_unreads();
         }
     }
 

--- a/common/src/testing/mock.rs
+++ b/common/src/testing/mock.rs
@@ -121,27 +121,18 @@ fn generate_fake_chat(participants: Vec<Identity>, conversation: Uuid) -> Chat {
         .rev()
         .collect();
 
-    Chat {
-        id: conversation,
-        participants: HashSet::from_iter(participants.iter().map(|x| x.did_key())),
-        conversation_type: match participants.len() {
+    Chat::new(
+        conversation,
+        HashSet::from_iter(participants.iter().map(|x| x.did_key())),
+        match participants.len() {
             0..=2 => ConversationType::Direct,
             _ => ConversationType::Group,
         },
-        conversation_name: None,
-        creator: None,
+        None,
+        None,
         messages,
-        unreads: rng.gen_range(0..2),
-        replying_to: None,
-        typing_indicator: HashMap::new(),
-        draft: None,
-        has_more_messages: false,
-        pending_outgoing_messages: vec![],
-        files_attached_to_send: Vec::new(),
-        scroll_value: None,
         pinned_messages,
-        scroll_to: None,
-    }
+    )
 }
 
 // Generate a random chat with the specified DID key as one of the participants

--- a/common/src/warp_runner/ui_adapter/mod.rs
+++ b/common/src/warp_runner/ui_adapter/mod.rs
@@ -16,7 +16,7 @@ use crate::state::{self, chats, MAX_PINNED_MESSAGES};
 use futures::{stream::FuturesOrdered, FutureExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{HashSet, VecDeque},
     ops::Range,
 };
 use warp::{
@@ -279,24 +279,17 @@ pub async fn conversation_to_chat(
         .and_then(Vec::<_>::try_from)?;
 
     let has_more_messages = total_messages > to_take;
-    Ok(chats::Chat {
-        id: conv.id(),
-        conversation_type: conv.conversation_type(),
-        conversation_name: conv.name(),
-        participants: HashSet::from_iter(conv.recipients()),
-        creator: conv.creator(),
+    let mut chat = chats::Chat::new(
+        conv.id(),
+        HashSet::from_iter(conv.recipients()),
+        conv.conversation_type(),
+        conv.name(),
+        conv.creator(),
         messages,
-        unreads: total_messages as u32,
-        replying_to: None,
-        typing_indicator: HashMap::new(),
-        draft: None,
-        has_more_messages,
-        pending_outgoing_messages: vec![],
-        files_attached_to_send: vec![],
-        scroll_value: None,
         pinned_messages,
-        scroll_to: None,
-    })
+    );
+    chat.has_more_messages = has_more_messages;
+    Ok(chat)
 }
 
 pub async fn init_conversation(

--- a/ui/src/components/chat/compose/messages/mod.rs
+++ b/ui/src/components/chat/compose/messages/mod.rs
@@ -137,7 +137,7 @@ pub fn get_messages(cx: Scope, data: Rc<super::ComposeData>) -> Element {
         cx,
         data.active_chat.scroll_value,
         eval,
-        data.active_chat.unreads,
+        data.active_chat.unreads(),
         data.active_chat.id,
         prev_chat_id,
     );

--- a/ui/src/components/chat/sidebar.rs
+++ b/ui/src/components/chat/sidebar.rs
@@ -547,8 +547,8 @@ pub fn Sidebar(cx: Scope<SidebarProps>) -> Element {
 
                     let datetime = unwrapped_message.date();
 
-                    let badge = if chat.unreads > 0 {
-                        chat.unreads.to_string()
+                    let badge = if chat.unreads() > 0 {
+                        chat.unreads().to_string()
                     } else { "".into() };
                     let key = chat.id;
 

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -985,7 +985,12 @@ fn AppNav<'a>(
     let state = use_shared_state::<State>(cx)?;
     let navigator = use_navigator(cx);
     let pending_friends = state.read().friends().incoming_requests.len();
-    let unreads: u32 = state.read().chats_sidebar().iter().map(|c| c.unreads).sum();
+    let unreads: u32 = state
+        .read()
+        .chats_sidebar()
+        .iter()
+        .map(|c| c.unreads())
+        .sum();
 
     let chat_route = UIRoute {
         to: "/chat",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- rename some functions in `compose/messages/mod.rs` to make it easier to read. 
- in preparation for adding infinite scrolling to chats, change `unreads` from a `u32` to a HashSet. This will allow uplink to properly update the "unreads" badge for a chat even when the chat view doesn't contain the message being deleted. `unreads` was made private to force the UI to use utility functions. This necessitated adding a `new()` function because the struct syntax could no longer be used to create a `Chat`. 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
testing:
- receive new message in a chat that isn't selected. unreads should increment. 
- switching chats should clear unreads
- receiving a message in the active chat should not increment unreads
- if a conversation has unread messages, quitting uplink and re-starting the app should not affect the unread count. 
