### PR TITLE
chore(attachments): hide file download button when not hovering

### DIFF
--- a/kit/src/components/embeds/file_embed/style.scss
+++ b/kit/src/components/embeds/file_embed/style.scss
@@ -17,7 +17,9 @@
   color: var(--text-color);
   align-content: center;
   align-self: flex-end;
-
+  .btn {
+    display: none;
+  }
   .image-container {
     display: flex;
     position: relative;
@@ -65,6 +67,10 @@
 }
 .file-embed:hover {
   cursor: pointer;
+  .btn {
+    display: inline-flex;
+    border: 1px solid var(--text-color-dark);
+  }
 }
 
 .icon {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

Small CSS update to show download button on hover
![image](https://github.com/Satellite-im/Uplink/assets/2993032/89f5e0e0-1ef4-49bb-8dd1-7ff267847ef6)
![Screenshot from 2023-09-19 13-56-35](https://github.com/Satellite-im/Uplink/assets/2993032/515d87b6-3b74-47e2-b79e-f7ddefa08e81)

Resolves part of #1189 but not the context menu piece, that requires a lot of re-work, since the context menu is currently on the outside container, and I am not sure how to get the nested image info from the attachments array that gets shown a few elements down

- 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

