### PR TITLE
chore(appium): remove retry step from macos appium automated tests

### DIFF
--- a/.github/workflows/ui-test-automation.yml
+++ b/.github/workflows/ui-test-automation.yml
@@ -187,13 +187,9 @@ jobs:
           cp -r ./appium-tests/tests/fixtures/users/FriendsTestUser/ ./appium-tests/tests/fixtures/users/mac2/FriendsTestUser
 
       - name: Run Tests on MacOS 🧪
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 30
-          max_attempts: 2
-          command: |
-            cd ./appium-tests
-            npm run mac.ci
+        run: |
+          cd ./appium-tests
+          npm run mac.ci
 
       - name: Upload Test Report - MacOS CI
         if: always()


### PR DESCRIPTION
### What this PR does 📖

- Retry action is no longer needed on macos automated tests, since the retry is already handled in the appium configuration repository. Removing this from the workflow on uplink

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

