### PR TITLE
chore(debugger): add a launch profile to run cargo

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,10 +1,26 @@
 {
     // Debug runs using breakpoints.
     // Needs the CodeLLDB plugin for vsc
-    "version": "0.2.0",
+    "version": "0.2.1",
     "configurations": [
         {
-            "name": "UI Debug",
+            "name": "Cargo Based UI Debug",
+            "type": "lldb",
+            "request": "launch",
+            "cargo": {
+                "args": [
+                    "run",
+                    // "--bin=example",
+                    // "--package=example"
+                ],
+            },
+            "args": [
+                "debug"
+            ],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "name": "UI Debug (running target/debug/uplink)",
             "type": "lldb",
             "request": "launch",
             "program": "${workspaceRoot}/target/debug/uplink",
@@ -14,7 +30,7 @@
             "cwd": "${workspaceRoot}"
         },
         {
-            "name": "UI Debug With Mock",
+            "name": "UI Debug With Mock (running target/debug/uplink)",
             "type": "lldb",
             "request": "launch",
             "program": "${workspaceRoot}/target/debug/uplink",


### PR DESCRIPTION
 instead of having to first compile and then run the exe and debugger

### What this PR does 📖

- just another debugger profile that runs cargo run instead of ,/target/debug/uplink

### Which issue(s) this PR fixes 🔨

- none

### Special notes for reviewers 🗒️

### Additional comments 🎤

