### PR TITLE
fix(dioxus): use a different fork of dioxus to fix the windows crashing bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2103,7 +2103,7 @@ dependencies = [
 [[package]]
 name = "dioxus"
 version = "0.4.2"
-source = "git+https://github.com/DioxusLabs/dioxus?rev=60ee829#60ee82942c4decf67b6ad263f639553d9b7e28a9"
+source = "git+https://github.com/ealmloff/dioxus?branch=fix-event-bubbling#c30dc25293fc38eb5a937843364e5a53ae802a9f"
 dependencies = [
  "dioxus-core",
  "dioxus-core-macro",
@@ -2116,7 +2116,7 @@ dependencies = [
 [[package]]
 name = "dioxus-core"
 version = "0.4.2"
-source = "git+https://github.com/DioxusLabs/dioxus?rev=60ee829#60ee82942c4decf67b6ad263f639553d9b7e28a9"
+source = "git+https://github.com/ealmloff/dioxus?branch=fix-event-bubbling#c30dc25293fc38eb5a937843364e5a53ae802a9f"
 dependencies = [
  "bumpalo",
  "futures-channel",
@@ -2132,7 +2132,7 @@ dependencies = [
 [[package]]
 name = "dioxus-core-macro"
 version = "0.4.2"
-source = "git+https://github.com/DioxusLabs/dioxus?rev=60ee829#60ee82942c4decf67b6ad263f639553d9b7e28a9"
+source = "git+https://github.com/ealmloff/dioxus?branch=fix-event-bubbling#c30dc25293fc38eb5a937843364e5a53ae802a9f"
 dependencies = [
  "constcat",
  "dioxus-core",
@@ -2151,7 +2151,7 @@ checksum = "2ea539174bb236e0e7dc9c12b19b88eae3cb574dedbd0252a2d43ea7e6de13e2"
 [[package]]
 name = "dioxus-desktop"
 version = "0.4.2"
-source = "git+https://github.com/DioxusLabs/dioxus?rev=60ee829#60ee82942c4decf67b6ad263f639553d9b7e28a9"
+source = "git+https://github.com/ealmloff/dioxus?branch=fix-event-bubbling#c30dc25293fc38eb5a937843364e5a53ae802a9f"
 dependencies = [
  "async-trait",
  "core-foundation",
@@ -2180,7 +2180,7 @@ dependencies = [
 [[package]]
 name = "dioxus-hooks"
 version = "0.4.2"
-source = "git+https://github.com/DioxusLabs/dioxus?rev=60ee829#60ee82942c4decf67b6ad263f639553d9b7e28a9"
+source = "git+https://github.com/ealmloff/dioxus?branch=fix-event-bubbling#c30dc25293fc38eb5a937843364e5a53ae802a9f"
 dependencies = [
  "dioxus-core",
  "dioxus-debug-cell",
@@ -2193,7 +2193,7 @@ dependencies = [
 [[package]]
 name = "dioxus-hot-reload"
 version = "0.4.2"
-source = "git+https://github.com/DioxusLabs/dioxus?rev=60ee829#60ee82942c4decf67b6ad263f639553d9b7e28a9"
+source = "git+https://github.com/ealmloff/dioxus?branch=fix-event-bubbling#c30dc25293fc38eb5a937843364e5a53ae802a9f"
 dependencies = [
  "dioxus-core",
  "dioxus-html",
@@ -2206,7 +2206,7 @@ dependencies = [
 [[package]]
 name = "dioxus-html"
 version = "0.4.2"
-source = "git+https://github.com/DioxusLabs/dioxus?rev=60ee829#60ee82942c4decf67b6ad263f639553d9b7e28a9"
+source = "git+https://github.com/ealmloff/dioxus?branch=fix-event-bubbling#c30dc25293fc38eb5a937843364e5a53ae802a9f"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -2225,12 +2225,12 @@ dependencies = [
 [[package]]
 name = "dioxus-interpreter-js"
 version = "0.4.2"
-source = "git+https://github.com/DioxusLabs/dioxus?rev=60ee829#60ee82942c4decf67b6ad263f639553d9b7e28a9"
+source = "git+https://github.com/ealmloff/dioxus?branch=fix-event-bubbling#c30dc25293fc38eb5a937843364e5a53ae802a9f"
 
 [[package]]
 name = "dioxus-router"
 version = "0.4.2"
-source = "git+https://github.com/DioxusLabs/dioxus?rev=60ee829#60ee82942c4decf67b6ad263f639553d9b7e28a9"
+source = "git+https://github.com/ealmloff/dioxus?branch=fix-event-bubbling#c30dc25293fc38eb5a937843364e5a53ae802a9f"
 dependencies = [
  "anyhow",
  "dioxus",
@@ -2250,7 +2250,7 @@ dependencies = [
 [[package]]
 name = "dioxus-router-macro"
 version = "0.4.2"
-source = "git+https://github.com/DioxusLabs/dioxus?rev=60ee829#60ee82942c4decf67b6ad263f639553d9b7e28a9"
+source = "git+https://github.com/ealmloff/dioxus?branch=fix-event-bubbling#c30dc25293fc38eb5a937843364e5a53ae802a9f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2261,7 +2261,7 @@ dependencies = [
 [[package]]
 name = "dioxus-rsx"
 version = "0.4.2"
-source = "git+https://github.com/DioxusLabs/dioxus?rev=60ee829#60ee82942c4decf67b6ad263f639553d9b7e28a9"
+source = "git+https://github.com/ealmloff/dioxus?branch=fix-event-bubbling#c30dc25293fc38eb5a937843364e5a53ae802a9f"
 dependencies = [
  "dioxus-core",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,14 +28,14 @@ version = "0.1.6"
 rust-version = "1.70"
 
 [workspace.dependencies]
-dioxus = { git = "https://github.com/DioxusLabs/dioxus", rev = "60ee829" }
-dioxus-hooks = { git = "https://github.com/DioxusLabs/dioxus", rev = "60ee829" }
-dioxus-html = { git = "https://github.com/DioxusLabs/dioxus", rev = "60ee829" }
-dioxus-router = { git = "https://github.com/DioxusLabs/dioxus", rev = "60ee829" }
-dioxus-desktop = { git = "https://github.com/DioxusLabs/dioxus", rev = "60ee829", features = ["transparent"] }
+dioxus = { git = "https://github.com/ealmloff/dioxus", branch = "fix-event-bubbling" }
+dioxus-hooks = { git = "https://github.com/ealmloff/dioxus", branch = "fix-event-bubbling" }
+dioxus-html = { git = "https://github.com/ealmloff/dioxus", branch = "fix-event-bubbling" }
+dioxus-router= { git = "https://github.com/ealmloff/dioxus", branch = "fix-event-bubbling" }
+dioxus-desktop = { git = "https://github.com/ealmloff/dioxus", branch = "fix-event-bubbling", features = ["transparent"] }
 raw-window-handle = "0.5"
-dioxus-core = { git = "https://github.com/DioxusLabs/dioxus", rev = "60ee829" }
-fermi = { git = "https://github.com/DioxusLabs/dioxus", rev = "60ee829" }
+dioxus-core = { git = "https://github.com/ealmloff/dioxus", branch = "fix-event-bubbling" }
+fermi = { git = "https://github.com/ealmloff/dioxus", branch = "fix-event-bubbling" }
 tokio-util = { version = "0.7", features = ["full"] }
 arboard = "3.2"
 humansize = "2.1.3"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- use a different fork of dioxus to fix the windows crashing bug
- This one specifically: https://github.com/ealmloff/dioxus/tree/fix-event-bubbling

### Which issue(s) this PR fixes 🔨

- Resolve #1243

### Special notes for reviewers 🗒️

Note that this PR adds in old bugs that were solved with other updates to dioxus . . . like you can't close the app using the X at the top right. And that's just the beginning. Probably shouldn't merge this. 

### Additional comments 🎤

