### PR TITLE
fix(chat): Remove padding for image preview modal

### DIFF
--- a/kit/src/layout/modal/style.scss
+++ b/kit/src/layout/modal/style.scss
@@ -23,6 +23,7 @@
     }
 
     .modal {
+      display: flex;
       background-color: var(--secondary-dark);
       padding: var(--gap);
       border-radius: var(--border-radius);


### PR DESCRIPTION

### What this PR does 📖

- Remove the padding in image preview modals

### Which issue(s) this PR fixes 🔨

- Resolve #1256

