### PR TITLE
update(Storage): Adjust padding of select chats

### DIFF
--- a/kit/src/elements/file/mod.rs
+++ b/kit/src/elements/file/mod.rs
@@ -158,6 +158,7 @@ pub fn File<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     label {
                         class: "file-name item-alignment",
                         padding_top: "8px",
+                        height: "24px",
                         title: "{&file_name}",
                         "{file_name}"
                     }

--- a/ui/src/layouts/storage/send_files_layout/mod.rs
+++ b/ui/src/layouts/storage/send_files_layout/mod.rs
@@ -119,6 +119,7 @@ fn ChatsToSelect<'a>(cx: Scope<'a, ChatsToSelectProps<'a>>) -> Element<'a> {
     cx.render(rsx!(div {
         id: "all_chats",
         div {
+            padding_top: "16px",
             padding_left: "16px",
             Label {
                 text: get_local_text("files.select-chats"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
### 1. Adjust padding of select chats

<img width="835" alt="image" src="https://github.com/Satellite-im/Uplink/assets/63157656/5bdb05d8-a607-49d3-8d56-7fd41042ccc1">




### Which issue(s) this PR fixes 🔨

- Resolve #1279 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

