### PR TITLE
chore(appium): close update alert from gh runner before tests

### DIFF
--- a/.github/workflows/ui-test-automation.yml
+++ b/.github/workflows/ui-test-automation.yml
@@ -186,6 +186,12 @@ jobs:
           mkdir ./appium-tests/tests/fixtures/users/mac2
           cp -r ./appium-tests/tests/fixtures/users/FriendsTestUser/ ./appium-tests/tests/fixtures/users/mac2/FriendsTestUser
 
+      - name: Close Native Alerts on macOS 🚫
+        run: |
+          # Close any open system alerts using AppleScript
+          osascript -e 'tell application "System Events" to keystroke return'
+        continue-on-error: true
+
       - name: Run Tests on MacOS 🧪
         run: |
           cd ./appium-tests


### PR DESCRIPTION
### What this PR does 📖

- Recently the MacOS GH runners started to show an alert for update available on the OS that is being positioned in front of the application
- The problem is that webdriverio is not ignoring this alert and its failing test execution when trying to interact with elements located behind of this alert
- Asked to chatgpt for an applescript that could close these alerts before starting tests, so trying adding a new step before running tests. Example of the alert displayed on GH runner:
<img width="810" alt="image" src="https://github.com/Satellite-im/Uplink/assets/35935591/d91ae84b-0f34-4d6e-a95c-883edfaeea78">



### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

