### PR TITLE
chore(appium): use macos 13 on tests workflow

### DIFF
--- a/.github/workflows/ui-test-automation.yml
+++ b/.github/workflows/ui-test-automation.yml
@@ -127,7 +127,7 @@ jobs:
 
   test-mac:
     needs: build-mac
-    runs-on: macos-latest
+    runs-on: macos-13
 
     steps:
       - name: Checkout working directory 🔖


### PR DESCRIPTION
### What this PR does 📖

- Use macos 13 instead of macos-latest (macos-12) on tests workflow to execute macos tests. Attempting this solution to solve the update available modal issue failing the tooltips tests. Considering that friends tests are now fixed, it should not hang on the execution as before, so it might be a good option to give it a try. Sending as draft for now

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

