### PR TITLE
fix(groups): Remove status indicator for group images

### DIFF
--- a/kit/src/components/user_image_group/mod.rs
+++ b/kit/src/components/user_image_group/mod.rs
@@ -65,7 +65,6 @@ pub fn UserImageGroup<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                                 rsx!(
                                     UserImage {
                                         platform: user.platform,
-                                        status: user.status,
                                         image: user.photo.clone(),
                                         on_press: move |e| { let _ = cx.props.onpress.as_ref().map(|f| f.call(e)); },
                                     }


### PR DESCRIPTION
### What this PR does 📖

- Removes the online/offline indicator for grouped profile images

### Which issue(s) this PR fixes 🔨

- Resolve #1293

