### PR TITLE
fix(modals): Remove line-height 0

### DIFF
--- a/kit/src/layout/modal/style.scss
+++ b/kit/src/layout/modal/style.scss
@@ -1,7 +1,6 @@
 
 .modal-wrap {
     display: inline-flex;
-    line-height: 0;
     justify-content: center;
     align-items: center;
     position: fixed;


### PR DESCRIPTION
### What this PR does 📖

- Fix line height being 0 for modals causing issues. Idk if it is important or not but from my testing it didnt affect other modals

### Which issue(s) this PR fixes 🔨

- Resolve #1295
- Resolve #1297
