### PR TITLE
fix(files): Hide file sharing button if sidebar chats are empty

### DIFF
--- a/ui/src/layouts/storage/shared_component.rs
+++ b/ui/src/layouts/storage/shared_component.rs
@@ -207,7 +207,7 @@ pub fn FilesAndFolders<'a>(cx: Scope<'a, FilesAndFoldersProps<'a>>) -> Element<'
                         key: "{key}-menu",
                         id: file.id().to_string(),
                         items: cx.render(rsx!(
-                        if !send_files_mode {
+                        if !send_files_mode && !state.read().chats_sidebar().is_empty() {
                             rsx!(
                             ContextItem {
                                 icon: Icon::Share,


### PR DESCRIPTION
### What this PR does 📖

- Hides the share file button in files if sidebar chats are empty

### Which issue(s) this PR fixes 🔨

- Resolve #1296