### PR TITLE
fix(files): Disable share button if no chat selected

### DIFF
--- a/ui/src/layouts/storage/send_files_layout/send_files_components.rs
+++ b/ui/src/layouts/storage/send_files_layout/send_files_components.rs
@@ -66,7 +66,7 @@ pub fn SendFilesTopbar<'a>(
                 Button {
                     text: get_local_text_with_args("files.send-files-text-amount", vec![("amount", format!("{}/{}", storage_controller.with(|f| f.files_selected_to_send.clone()).len(), MAX_FILES_PER_MESSAGE).into())]),
                     aria_label: "send_files_modal_send_button".into(),
-                    disabled: storage_controller.with(|f| f.files_selected_to_send.clone()).is_empty(),
+                    disabled: storage_controller.with(|f| f.files_selected_to_send.is_empty() || f.chats_selected_to_send.is_empty()),
                     appearance: Appearance::Primary,
                     icon: Icon::ChevronRight,
                     onpress: move |_| {


### PR DESCRIPTION
### What this PR does 📖

- Disable the share button in files modal if no chat is selected

### Which issue(s) this PR fixes 🔨

- Resolve #1298