### PR TITLE
add(aria): labels for call image modals and emoji suggestions

### DIFF
--- a/kit/src/layout/chatbar/mod.rs
+++ b/kit/src/layout/chatbar/mod.rs
@@ -229,6 +229,7 @@ pub struct EmojiSuggestionProps<'a> {
 fn EmojiSuggesions<'a>(cx: Scope<'a, EmojiSuggestionProps<'a>>) -> Element<'a> {
     cx.render(rsx!(div {
         class: "emoji-suggestions",
+        aria_label: "emoji-suggestions-container",
         onmouseenter: move |_| {
             *cx.props.selected.write() = None;
         },
@@ -241,6 +242,11 @@ fn EmojiSuggesions<'a>(cx: Scope<'a, EmojiSuggestionProps<'a>>) -> Element<'a> {
                     Some(v) => if *v == num {"emoji-selected"} else {""},
                     None => ""
                 }),
+                aria_label: {
+                    format_args!(
+                        "emoji-suggested-{emoji}",
+                    )
+                },
                 onclick: move |_| {
                     cx.props.on_emoji_click.call((emoji.clone(), alias.clone()))
                 },

--- a/kit/src/layout/modal/mod.rs
+++ b/kit/src/layout/modal/mod.rs
@@ -48,6 +48,7 @@ pub fn Modal<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 (!cx.props.transparent).then(|| rsx!(
                     div {
                         class: "close-btn",
+                        aria_label: "close-modal-button",
                         z_index: "10",
                         Button {
                             icon: Icon::XMark,

--- a/ui/src/components/files/file_preview.rs
+++ b/ui/src/components/files/file_preview.rs
@@ -32,6 +32,7 @@ pub fn FilePreview<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             )),
             img {
                 id: "file_preview_img",
+                aria_label: "file-preview-image",
                 src: "{thumbnail}",
             },
         },

--- a/ui/src/components/media/calling.rs
+++ b/ui/src/components/media/calling.rs
@@ -288,6 +288,7 @@ fn ActiveCallControl(cx: Scope<ActiveCallProps>) -> Element {
 
     cx.render(rsx!(div {
         id: "remote-controls",
+        aria_label: "remote-controls",
         class: format_args!("{}", if cx.props.in_chat {"in-chat"} else {""}),
         (*recording.read()).then(||{
             rsx!(
@@ -310,10 +311,12 @@ fn ActiveCallControl(cx: Scope<ActiveCallProps>) -> Element {
             class: format_args!("call-label {}", if cx.props.in_chat {"in-chat"} else {""}),
             outgoing.then(|| rsx!(Label {
                 text: get_local_text("remote-controls.outgoing-call"),
+                aria_label: "outgoing-call-label".into(),
             }))
         }
         div {
             class: "call-info",
+            aria_label: "call-info",
             div {
                 class: format_args!("calling {}", if cx.props.in_chat {"in-chat"} else {""}),
                 div {
@@ -341,18 +344,22 @@ fn ActiveCallControl(cx: Scope<ActiveCallProps>) -> Element {
             (!cx.props.in_chat).then(||rsx!(
                 p {
                     class: "call-name",
+                    aria_label: "call-name",
                     "{participants_name}"
                 }
             )),
             p {
                 class: format_args!("call-time {}", if cx.props.in_chat {"in-chat"} else {""}),
+                aria_label: "call-time",
                 format_timestamp_timeago(active_call.answer_time.into(), &state.read().settings.language_id()),
             }
         },
         div {
             class: "controls",
+            aria_label: "call-controls",
             Button {
                 icon: Icon::Microphone,
+                aria_label: "call-mic-button".into(),
                 appearance: if call.self_muted { Appearance::Danger } else { Appearance::Secondary },
                 tooltip: cx.render(rsx!(
                     Tooltip {
@@ -366,6 +373,7 @@ fn ActiveCallControl(cx: Scope<ActiveCallProps>) -> Element {
             },
             Button {
                 icon: if call.call_silenced { Icon::SignalSlash } else { Icon::Signal },
+                aria_label: "call-speaker-button".into(),
                 appearance: if call.call_silenced { Appearance::Danger } else { Appearance::Secondary },
                 tooltip: cx.render(rsx!(
                     Tooltip {
@@ -398,6 +406,7 @@ fn ActiveCallControl(cx: Scope<ActiveCallProps>) -> Element {
             }),
             Button {
                 icon: Icon::PhoneXMark,
+                aria_label: "call-hangup-button".into(),
                 appearance: Appearance::Danger,
                 onpress: move |_| {
                     ch.send(CallDialogCmd::Hangup(call.id));

--- a/ui/src/layouts/storage/shared_component.rs
+++ b/ui/src/layouts/storage/shared_component.rs
@@ -211,7 +211,7 @@ pub fn FilesAndFolders<'a>(cx: Scope<'a, FilesAndFoldersProps<'a>>) -> Element<'
                             rsx!(
                             ContextItem {
                                 icon: Icon::Share,
-                                aria_label: "files-download".into(),
+                                aria_label: "files-share".into(),
                                 text: get_local_text("files.share-files"),
                                 onpress: move |_| {
                                     if let Some(f) = &cx.props.on_click_share_files {


### PR DESCRIPTION
### What this PR does 📖

- Add aria labels for call modals so we can start adding tests for experimental features
- Add aria labels for emoji auto suggestions container
- Add aria labels for preview image modals
- Fixing aria label for context menu Share Files on Files section

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

