### PR TITLE
add(aria): aria labels for crop tool and range elements

### DIFF
--- a/kit/src/elements/range/mod.rs
+++ b/kit/src/elements/range/mod.rs
@@ -13,6 +13,7 @@ pub struct Props<'a> {
     no_num: Option<bool>,
     icon_left: Option<Icon>,
     icon_right: Option<Icon>,
+    aria_label: Option<String>,
 }
 
 #[allow(non_snake_case)]
@@ -25,10 +26,12 @@ pub fn Range<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
         }
     });
     let step = cx.props.step.unwrap_or(1_f32);
+    let aria_label = cx.props.aria_label.clone().unwrap_or_default();
 
     cx.render(rsx!(
         div {
             class: "range",
+            aria_label: "{aria_label}",
             cx.props.icon_left.is_some().then(|| rsx! {
                 IconElement {
                     icon: cx.props.icon_left.unwrap_or(Icon::NoSymbol),
@@ -39,6 +42,7 @@ pub fn Range<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 "type": "range",
                 min: "{cx.props.min}",
                 max: "{cx.props.max}",
+                aria_label: "range-input",
                 step: "{step}",
                 value: "{internal_state}",
                 oninput: move |event| {
@@ -54,6 +58,7 @@ pub fn Range<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             }),
             (!cx.props.no_num.unwrap_or_default()).then(||rsx!(
                 p {
+                    aria_label: "range-value",
                     class: "range-value",
                     "{internal_state.get()}"
                 }

--- a/ui/src/components/crop_image_tool/mod.rs
+++ b/ui/src/components/crop_image_tool/mod.rs
@@ -83,6 +83,7 @@ pub fn CropImageModal<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 onclick: move |_| {},
                 div {
                     id: "crop-image-topbar", 
+                    aria_label: "crop-image-topbar",
                     background: "var(--secondary)",
                     height: "70px",
                     border_radius: "12px",
@@ -94,11 +95,13 @@ pub fn CropImageModal<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                         div {
                             class: "crop-image-topbar-left-title",
                             Label {
-                                text: get_local_text("settings.please-select-area-you-want-to-crop")
+                                text: get_local_text("settings.please-select-area-you-want-to-crop"),
+                                aria_label: "crop-image-topbar-label".into(),
                             }
                         },
                         Button {
                             appearance: Appearance::DangerAlternative,
+                            aria_label: "crop-image-cancel-button".into(),
                             icon: Shape::XMark,
                             onpress: move |_| {
                                 *first_render.write_silent() = true;
@@ -111,6 +114,7 @@ pub fn CropImageModal<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                         }
                         Button {
                             appearance: Appearance::Success,
+                            aria_label: "crop-image-confirm-button".into(),
                             icon: Shape::Check,
                             onpress: move |_| {
                                 *first_render.write_silent() = false;
@@ -186,6 +190,7 @@ pub fn CropImageModal<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     }
                 }
                 Range {
+                    aria_label: "range-crop-image".into(),
                     initial_value: 1.0,
                     min: 1.0,
                     max: 5.0,

--- a/ui/src/components/settings/sub_pages/audio.rs
+++ b/ui/src/components/settings/sub_pages/audio.rs
@@ -152,6 +152,7 @@ pub fn AudioSettings(cx: Scope) -> Element {
             },
             SettingSectionSimple {
                 Range {
+                    aria_label: "range-input-device".into(),
                     initial_value: 100.0,
                     min: VOL_MIN,
                     max: VOL_MAX,
@@ -174,6 +175,7 @@ pub fn AudioSettings(cx: Scope) -> Element {
             },
             SettingSectionSimple {
                 Range {
+                    aria_label: "range-output-device".into(),
                     initial_value: VOL_MIN,
                     min: 0.0,
                     max: VOL_MAX,

--- a/ui/src/layouts/chats/presentation/quick_profile/mod.rs
+++ b/ui/src/layouts/chats/presentation/quick_profile/mod.rs
@@ -341,6 +341,7 @@ pub fn QuickProfileContext<'a>(cx: Scope<'a, QuickProfileProps<'a>>) -> Element<
                     if state.read().configuration.developer.experimental_features {
                         rsx!(
                             Range {
+                                aria_label: "range-quick-profile-speaker".into(),
                                 initial_value: volume,
                                 min: USER_VOL_MIN,
                                 max: USER_VOL_MAX,


### PR DESCRIPTION
### What this PR does 📖

- Adding aria label property for Range elements on Kit/src
- Adding aria label properties for existing range elements in app (quick profile speaker volume, input/output device range on settings audio and crop image size selector)
- Adding aria labels for crop image tool elements (buttons and labels)

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

