### PR TITLE
fix(quickprofile): Only show user volume in vc

### DIFF
--- a/common/locales/en-US/main.ftl
+++ b/common/locales/en-US/main.ftl
@@ -341,6 +341,7 @@ quickprofile = Quick Profile
     .unblock = Unblock User
     .chat-placeholder = Message
     .self-edit = Edit Profile
+    .volume = User Volume
 
 toast_actions = Toast Actions
     .DisplayChat = Open Chat

--- a/ui/src/layouts/chats/presentation/quick_profile/mod.rs
+++ b/ui/src/layouts/chats/presentation/quick_profile/mod.rs
@@ -86,6 +86,11 @@ pub fn QuickProfileContext<'a>(cx: Scope<'a, QuickProfileProps<'a>>) -> Element<
 
     let is_self = state.read().get_own_identity().did_key().eq(did);
     let is_friend = state.read().has_friend_with_did(did);
+    let in_vc = state
+        .read()
+        .get_active_chat()
+        .map(|call| call.participants.contains(did))
+        .unwrap_or_default();
     let blocked = state.read().is_blocked(did);
     let volume = state
         .read()
@@ -338,8 +343,13 @@ pub fn QuickProfileContext<'a>(cx: Scope<'a, QuickProfileProps<'a>>) -> Element<
                             }*/
                         )
                     }
-                    if state.read().configuration.developer.experimental_features {
+                    if state.read().configuration.developer.experimental_features && in_vc {
                         rsx!(
+                            p {
+                                class: "text",
+                                aria_label: "user-volume-label",
+                                get_local_text("quickprofile.volume")
+                            },
                             Range {
                                 aria_label: "range-quick-profile-speaker".into(),
                                 initial_value: volume,


### PR DESCRIPTION
### What this PR does 📖

- Makes it so user volume setting is only shown if the other user is in same vc with as the user

### Which issue(s) this PR fixes 🔨

- Resolve #1310

