### PR TITLE
fix(chatbar): unintentional sends

### DIFF
--- a/kit/src/elements/textarea/event_listeners.js
+++ b/kit/src/elements/textarea/event_listeners.js
@@ -1,0 +1,51 @@
+var MULTI_LINE = $MULTI_LINE;
+
+var sendButton = document.getElementsByClassName("controls")
+var textareas = document.getElementsByClassName("input_textarea")
+for (let i = 0; i < textareas.length; i++) {
+    var txt = textareas[i];
+    //Update the height on load
+    updateHeight(txt);
+    if (!txt.event_listener) {
+        txt.addEventListener("input", inputListener);
+        txt.addEventListener("keypress", keyPressListener);
+        txt.addEventListener("keydown", arrowHandlerListener);
+        txt.event_listener = true;
+        if (i == 0) {
+            txt.addEventListener("keypress", (event) => {
+            if (event.keyCode === 13 && !event.shiftKey) {
+              textareas[0].style.height = "22px";
+              textareas[0].value = "";
+            }
+          });
+        }
+    }
+}
+
+sendButton[1].addEventListener("click", (event) => {
+    textareas[0].style.height = "22px";
+    textareas[0].value = "";
+})
+
+function inputListener(e) {
+    updateHeight(this);
+}
+
+function updateHeight(element) {
+    element.style.height = "auto";
+    if (!element.value || MULTI_LINE) {
+        element.style.height = "0px";
+    }
+    element.style.height = element.scrollHeight + "px";
+}
+function keyPressListener(e) {
+    if (e.key == "Enter" && MULTI_LINE && !e.shiftKey) {
+        e.preventDefault();
+    } 
+}
+
+function arrowHandlerListener(e) {
+    if (this.classList.contains("up-down-disabled") && (e.key == "ArrowUp" || e.key == "ArrowDown")) {
+        e.preventDefault();
+    } 
+}

--- a/kit/src/elements/textarea/mod.rs
+++ b/kit/src/elements/textarea/mod.rs
@@ -172,7 +172,7 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     onkeyup: move |evt| {
                         let enter_pressed = evt.code() == Code::Enter || evt.code() == Code::NumpadEnter;
                         // this is now redundant
-                        let shift_key_as_modifier = false; // evt.data.modifiers().contains(Modifiers::SHIFT);
+                        let shift_key_as_modifier = evt.data.modifiers().contains(Modifiers::SHIFT);
 
                         if evt.code() == Code::ShiftLeft {
                             left_shift_pressed.set(false);

--- a/kit/src/elements/textarea/mod.rs
+++ b/kit/src/elements/textarea/mod.rs
@@ -56,8 +56,8 @@ pub struct Props<'a> {
 pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     log::trace!("render input");
     let eval = use_eval(cx);
-    let left_shift_pressed = use_ref(cx, || false);
-    let right_shift_pressed = use_ref(cx, || false);
+    let left_shift_pressed = use_state(cx, || false);
+    let right_shift_pressed = use_state(cx, || false);
     let cursor_position = use_ref(cx, || None);
 
     let Props {
@@ -166,18 +166,19 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                         if evt.code() == Code::ShiftLeft {
                             left_shift_pressed.set(true);
                         } else if evt.code() == Code::ShiftRight {
-                            right_shift_pressed.set(false);
+                            right_shift_pressed.set(true);
                         }
                     },
                     onkeyup: move |evt| {
                         let enter_pressed = evt.code() == Code::Enter || evt.code() == Code::NumpadEnter;
+                        // this is now redundant
                         let shift_key_as_modifier = false; // evt.data.modifiers().contains(Modifiers::SHIFT);
 
                         if evt.code() == Code::ShiftLeft {
-                            *left_shift_pressed.write_silent() = false;
+                            left_shift_pressed.set(false);
                         } else if evt.code() == Code::ShiftRight {
-                            *right_shift_pressed.write_silent() = false;
-                        } else if enter_pressed && !(shift_key_as_modifier || *right_shift_pressed.read() || *left_shift_pressed.read()) {
+                            right_shift_pressed.set(false);
+                        } else if enter_pressed && !(shift_key_as_modifier || *right_shift_pressed.get() || *left_shift_pressed.get()) {
                             if *show_char_counter {
                                 let _ = eval(&clear_counter_script);
                             }

--- a/kit/src/elements/textarea/mod.rs
+++ b/kit/src/elements/textarea/mod.rs
@@ -162,11 +162,11 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                             }
                         }
                     },
-                    onkeypress: move |evt| {
+                    onkeydown: move |evt| {
                         if evt.code() == Code::ShiftLeft {
-                            *left_shift_pressed.write_silent() = true;
+                            left_shift_pressed.set(true);
                         } else if evt.code() == Code::ShiftRight {
-                            *right_shift_pressed.write_silent() = true;
+                            right_shift_pressed.set(false);
                         }
                     },
                     onkeyup: move |evt| {

--- a/kit/src/elements/textarea/mod.rs
+++ b/kit/src/elements/textarea/mod.rs
@@ -103,7 +103,7 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let clear_counter_script =
         r#"document.getElementById('$UUID-char-counter').innerText = "0";"#.replace("$UUID", &id);
 
-    let cursor_eval = include_str!("./cursor_script.js").replace("$ID", &id2);
+    let cursor_script = include_str!("./cursor_script.js").replace("$ID", &id2);
 
     let text_value = use_ref(cx, || value.clone());
     use_future(cx, value, |val| {
@@ -146,15 +146,15 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                         onreturn.call((text_value.read().to_string(), false, Code::Enter));
                     },
                     oninput: {
-                        to_owned![eval, cursor_eval];
+                        to_owned![eval, cursor_script];
                         move |evt| {
                             let current_val = evt.value.clone();
                             *text_value.write_silent() = current_val.clone();
                             onchange.call((current_val, true));
-                            to_owned![eval, cursor_eval, cursor_position];
+                            to_owned![eval, cursor_script, cursor_position];
                             async move {
                                 if do_cursor_update {
-                                    if let Ok(r) = eval(&cursor_eval) {
+                                    if let Ok(r) = eval(&cursor_script) {
                                         if let Ok(val) = r.join().await {
                                             *cursor_position.write() = Some(val.as_i64().unwrap_or_default());
                                         }
@@ -173,12 +173,12 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                         };
                     },
                     onmousedown: {
-                        to_owned![eval, cursor_eval];
+                        to_owned![eval, cursor_script];
                         move |_| {
-                            to_owned![eval, cursor_eval, cursor_position];
+                            to_owned![eval, cursor_script, cursor_position];
                             async move {
                                 if do_cursor_update {
-                                    if let Ok(r) = eval(&cursor_eval) {
+                                    if let Ok(r) = eval(&cursor_script) {
                                         if let Ok(val) = r.join().await {
                                             *cursor_position.write() = Some(val.as_i64().unwrap_or_default());
                                         }
@@ -188,7 +188,7 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                         }
                     },
                     onkeydown: {
-                        to_owned![eval, cursor_eval];
+                        to_owned![eval, cursor_script];
                         move |evt| {
                             // special codepath to handle onreturn
                             let old_enter_pressed = *enter_pressed.current();
@@ -225,10 +225,10 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                                     false
                                 }
                             };
-                            to_owned![eval, cursor_eval, cursor_position];
+                            to_owned![eval, cursor_script, cursor_position];
                             async move {
                                 if do_cursor_update && arrow {
-                                    if let Ok(r) = eval(&cursor_eval) {
+                                    if let Ok(r) = eval(&cursor_script) {
                                         if let Ok(val) = r.join().await {
                                             *cursor_position.write() = Some(val.as_i64().unwrap_or_default());
                                         }

--- a/kit/src/elements/textarea/mod.rs
+++ b/kit/src/elements/textarea/mod.rs
@@ -177,7 +177,7 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                             *left_shift_pressed.write_silent() = false;
                         } else if evt.code() == Code::ShiftRight {
                             *right_shift_pressed.write_silent() = false;
-                        } else if enter_pressed && (shift_key_as_modifier || *right_shift_pressed.read() || *left_shift_pressed.read()) {
+                        } else if enter_pressed && !(shift_key_as_modifier || *right_shift_pressed.read() || *left_shift_pressed.read()) {
                             if *show_char_counter {
                                 let _ = eval(&clear_counter_script);
                             }

--- a/kit/src/elements/textarea/mod.rs
+++ b/kit/src/elements/textarea/mod.rs
@@ -3,6 +3,7 @@
 //! that might helpful if a textarea needed to perform input validation.
 
 use dioxus::prelude::*;
+use dioxus_elements::input_data::keyboard_types::Modifiers;
 use dioxus_html::input_data::keyboard_types::Code;
 use uuid::Uuid;
 use warp::logging::tracing::log;
@@ -161,7 +162,7 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                             }
                         }
                     },
-                    onkeydown: move |evt| {
+                    onkeypress: move |evt| {
                         if evt.code() == Code::ShiftLeft {
                             *left_shift_pressed.write_silent() = true;
                         } else if evt.code() == Code::ShiftRight {
@@ -170,12 +171,13 @@ pub fn Input<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     },
                     onkeyup: move |evt| {
                         let enter_pressed = evt.code() == Code::Enter || evt.code() == Code::NumpadEnter;
+                        let shift_key_as_modifier = false; // evt.data.modifiers().contains(Modifiers::SHIFT);
 
                         if evt.code() == Code::ShiftLeft {
                             *left_shift_pressed.write_silent() = false;
                         } else if evt.code() == Code::ShiftRight {
                             *right_shift_pressed.write_silent() = false;
-                        } else if enter_pressed && (*right_shift_pressed.read() || *left_shift_pressed.read()) {
+                        } else if enter_pressed && (shift_key_as_modifier || *right_shift_pressed.read() || *left_shift_pressed.read()) {
                             if *show_char_counter {
                                 let _ = eval(&clear_counter_script);
                             }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

-  when typing fast, i get caught up because in uplink, the enter key works on keyup instead of on keydown. This PR makes the enter key work on keydown. Hopefully this results in a nicer typing experience. 

testing:
-  It should prevent extra sends resulting from holding down the enter key. 
- It should allow one to enter a  newline in a message and release the shift key before the enter key, and not send the message. 
- this should work with the left and right shift keys and the enter key and numpad enter key. 
- the arrow key functionality should be unaffected. 

### Which issue(s) this PR fixes 🔨

- Resolve #1315

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

