### PR TITLE
fix(chat): Fix send button disabled in chat file modal

### DIFF
--- a/ui/src/layouts/storage/send_files_layout/mod.rs
+++ b/ui/src/layouts/storage/send_files_layout/mod.rs
@@ -50,7 +50,7 @@ pub fn SendFilesLayout<'a>(cx: Scope<'a, SendFilesProps<'a>>) -> Element<'a> {
     let storage_controller = StorageController::new(cx, state);
     let first_render = use_ref(cx, || true);
     let ch: &Coroutine<ChanCmd> = functions::init_coroutine(cx, storage_controller);
-
+    let in_files = send_files_start_location.eq(&SendFilesStartLocation::Storage);
     functions::get_items_from_current_directory(cx, ch);
 
     functions::run_verifications_and_update_storage(state, storage_controller, vec![]);
@@ -77,9 +77,10 @@ pub fn SendFilesLayout<'a>(cx: Scope<'a, SendFilesProps<'a>>) -> Element<'a> {
                 storage_controller: storage_controller.clone(),
                 on_send: move |files_location_path| {
                     cx.props.on_files_attached.call((files_location_path, storage_controller.with(|f| f.chats_selected_to_send.clone())));
-                }
+                },
+                in_files: in_files
             }
-            if send_files_start_location.eq(&SendFilesStartLocation::Storage) {
+            if in_files {
                 rsx!(ChatsToSelect {
                     storage_controller: storage_controller,
                 })

--- a/ui/src/layouts/storage/send_files_layout/send_files_components.rs
+++ b/ui/src/layouts/storage/send_files_layout/send_files_components.rs
@@ -44,6 +44,7 @@ pub fn SendFilesTopbar<'a>(
     send_files_start_location: SendFilesStartLocation,
     storage_controller: UseRef<StorageController>,
     on_send: EventHandler<'a, Vec<Location>>,
+    in_files: bool,
 ) -> Element<'a> {
     let router = use_navigator(cx);
 
@@ -66,7 +67,7 @@ pub fn SendFilesTopbar<'a>(
                 Button {
                     text: get_local_text_with_args("files.send-files-text-amount", vec![("amount", format!("{}/{}", storage_controller.with(|f| f.files_selected_to_send.clone()).len(), MAX_FILES_PER_MESSAGE).into())]),
                     aria_label: "send_files_modal_send_button".into(),
-                    disabled: storage_controller.with(|f| f.files_selected_to_send.is_empty() || f.chats_selected_to_send.is_empty()),
+                    disabled: storage_controller.with(|f| f.files_selected_to_send.is_empty() || (*in_files && f.chats_selected_to_send.is_empty())),
                     appearance: Appearance::Primary,
                     icon: Icon::ChevronRight,
                     onpress: move |_| {


### PR DESCRIPTION
### What this PR does 📖

- Fixes send button in chat upload browsing always disabled

### Which issue(s) this PR fixes 🔨

- Resolve #1311