### PR TITLE
fix(chat): Fix message reply not working

### DIFF
--- a/common/src/state/chats.rs
+++ b/common/src/state/chats.rs
@@ -11,7 +11,10 @@ use warp::{
     raygun::{self, ConversationType, Location},
 };
 
-use crate::{warp_runner::ui_adapter, STATIC_ARGS};
+use crate::{
+    warp_runner::ui_adapter::{self},
+    STATIC_ARGS,
+};
 
 use super::pending_message::{progress_file, PendingMessage};
 
@@ -217,12 +220,9 @@ impl Chats {
     }
 
     /// returns the UUID of the message being replied to by the active chat
-    pub fn get_replying_to(&self) -> Option<Uuid> {
-        self.active.and_then(|id| {
-            self.all
-                .get(&id)
-                .and_then(|chat| chat.replying_to.as_ref().map(|msg| msg.id()))
-        })
+    pub fn get_replying_to(&self) -> Option<&raygun::Message> {
+        self.active
+            .and_then(|id| self.all.get(&id).and_then(|chat| chat.replying_to.as_ref()))
     }
 }
 

--- a/ui/src/layouts/chats/data/chat_data/active_chat/metadata.rs
+++ b/ui/src/layouts/chats/data/chat_data/active_chat/metadata.rs
@@ -1,10 +1,7 @@
 use common::state::{self, Identity, State};
 use kit::components::indicator::Platform;
 use uuid::Uuid;
-use warp::{
-    crypto::DID,
-    raygun::{self, ConversationType},
-};
+use warp::{crypto::DID, raygun::ConversationType};
 
 #[derive(Debug, Default, Clone)]
 pub struct Metadata {
@@ -20,7 +17,6 @@ pub struct Metadata {
     pub conversation_name: Option<String>,
     pub conversation_type: Option<ConversationType>,
     pub creator: Option<DID>,
-    pub replying_to: Option<raygun::Message>,
     pub unreads: usize,
 }
 
@@ -59,7 +55,6 @@ impl Metadata {
             conversation_name: chat.conversation_name.clone(),
             conversation_type: Some(chat.conversation_type),
             creator: chat.creator.clone(),
-            replying_to: chat.replying_to.clone(),
             unreads: chat.unreads() as _,
         }
     }

--- a/ui/src/layouts/chats/data/chat_data/active_chat/mod.rs
+++ b/ui/src/layouts/chats/data/chat_data/active_chat/mod.rs
@@ -120,10 +120,6 @@ impl ActiveChat {
         self.metadata.creator.clone()
     }
 
-    pub fn replying_to(&self) -> Option<raygun::Message> {
-        self.metadata.replying_to.clone()
-    }
-
     pub fn unreads(&self) -> usize {
         self.metadata.unreads
     }

--- a/ui/src/layouts/chats/presentation/chatbar.rs
+++ b/ui/src/layouts/chats/presentation/chatbar.rs
@@ -404,14 +404,15 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, ChatProps>) -> Element<'a> {
         if STATIC_ARGS.use_mock {
             state.write().mutate(Action::MockSend(active_chat_id, msg));
         } else {
-            let replying_to = state.read().chats().get_replying_to();
+            let read = state.read();
+            let replying_to = read.chats().get_replying_to();
             if replying_to.is_some() {
                 state.write().mutate(Action::CancelReply(active_chat_id));
             }
             let ui_id = state
                 .write()
                 .increment_outgoing_messages(msg.clone(), &files_to_upload);
-            msg_ch.send((msg, active_chat_id, ui_id, replying_to));
+            msg_ch.send((msg, active_chat_id, ui_id, replying_to.map(|m| m.id())));
         }
     };
 
@@ -551,7 +552,7 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, ChatProps>) -> Element<'a> {
             with_replying_to: (!disabled).then(|| {
                 cx.render(
                     rsx!(
-                        chat_data.read().active_chat.replying_to().map(|msg| {
+                        state.read().chats().get_replying_to().map(|msg| {
                             let our_did = state.read().did_key();
                             let msg_owner = if chat_data.read().active_chat.my_id().did_key() == msg.sender() {
                                 Some(chat_data.read().active_chat.my_id())


### PR DESCRIPTION
### What this PR does 📖

- This PR fixes message replying not working anymore
- The way messages (or chat in general) was obtained changed with #1307. For now i made it so replying goes back to the state field that is set (the way it was previously used). Im not sure if this is a good way though. Another way i see it is similar to how the new `ChatData` listens to warp event to also make a new channel that listens to state changes. 
    We would need to create a new enum for it possibility duplicating some things due to `Action` having some enum values containing non thread safe values making the usage of it directly in as a new channel command input not possible. Do we want to do it that way? 

Edit:
Adding on to it this also affects favorite chats not updating correctly (#1319) and possibly other things so we might need an additional channel after all.

### Which issue(s) this PR fixes 🔨

- Resolve #1321