### PR TITLE
fix(chatbar): use typing indicator from State

### DIFF
--- a/ui/src/layouts/chats/data/chat_data/active_chat/mod.rs
+++ b/ui/src/layouts/chats/data/chat_data/active_chat/mod.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashMap, VecDeque},
-    time::Instant,
-};
+use std::collections::VecDeque;
 
 use common::{
     state::{self, Identity, State},
@@ -28,7 +25,6 @@ pub struct ActiveChat {
     metadata: Metadata,
     pub messages: Messages,
     pub is_initialized: bool,
-    pub typing_indicator: HashMap<DID, Instant>,
     pub key: Uuid,
 }
 
@@ -42,7 +38,6 @@ impl ActiveChat {
             metadata: Metadata::new(s, chat),
             messages: Messages::new(messages),
             is_initialized: true,
-            typing_indicator: HashMap::new(),
             key: Uuid::new_v4(),
         }
     }

--- a/ui/src/layouts/chats/presentation/chatbar.rs
+++ b/ui/src/layouts/chats/presentation/chatbar.rs
@@ -132,16 +132,18 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, ChatProps>) -> Element<'a> {
             .mutate(Action::SetChatAttachments(chat_id, files_attached));
     }
 
-    // todo: update the typing indicator in a coroutine
     let my_id = state.read().did_key();
-    let users_typing: Vec<DID> = chat_data
+    let users_typing: Vec<DID> = state
         .read()
-        .active_chat
-        .typing_indicator
-        .iter()
-        .filter(|(did, _)| *did != &my_id)
-        .map(|(did, _)| did.clone())
-        .collect();
+        .get_active_chat()
+        .map(|x| {
+            x.typing_indicator
+                .keys()
+                .cloned()
+                .filter(|did| *did != my_id)
+                .collect()
+        })
+        .unwrap_or_default();
     let users_typing = state.read().get_identities(&users_typing);
 
     // this is used to scroll to the bottom of the chat.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- fixes a bug introduced in the chats refactor. 
- the typing indicator should once again appear on the chatbar. 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

