### PR TITLE
fix(chat): Scroll to time ago element

### DIFF
--- a/ui/src/layouts/chats/scripts/scroll_to_bottom.js
+++ b/ui/src/layouts/chats/scripts/scroll_to_bottom.js
@@ -1,4 +1,10 @@
 // returns for eval
 var message = document.getElementById("$MESSAGE_ID");
+var time = message.parentElement.parentElement.getElementsByClassName("time-ago")[0];
+// try find the time-ago element
+if (time) {
+    message = time;
+}
+console.log("msg ", message);
 message.scrollIntoView({ behavior: 'instant', block: 'end' });
 return "done";

--- a/ui/src/layouts/chats/scripts/scroll_to_bottom.js
+++ b/ui/src/layouts/chats/scripts/scroll_to_bottom.js
@@ -5,6 +5,5 @@ var time = message.parentElement.parentElement.getElementsByClassName("time-ago"
 if (time) {
     message = time;
 }
-console.log("msg ", message);
 message.scrollIntoView({ behavior: 'instant', block: 'end' });
 return "done";


### PR DESCRIPTION
### What this PR does 📖

- Fixes chat to bottom scroll not including the timestamp element

### Which issue(s) this PR fixes 🔨

- Resolve #1333