### PR TITLE
fix(ui): Restrict context menu to the main component

### DIFF
--- a/kit/src/components/context_menu/context.js
+++ b/kit/src/components/context_menu/context.js
@@ -18,8 +18,15 @@ document.getElementById("UUID").addEventListener(
     let screenHeight = ev.view.innerHeight
     let overFlowY = screenHeight < height + offsetY
     let overFlowX = screenWidth < width + offsetX
-    context_menu.style.top = `${overFlowY ? offsetY - height : offsetY}px`
-    context_menu.style.left = `${overFlowX ? offsetX - width : offsetX}px`
+    let topY = Math.max(5, overFlowY ? offsetY - height : offsetY)
+    let minX = 5
+    let compose = document.getElementsByClassName("slimbar")[0]
+    if (compose) {
+      minX = compose.getBoundingClientRect().right
+    }
+    let topX = Math.max(compose.getBoundingClientRect().right, overFlowX ? offsetX - width : offsetX)
+    context_menu.style.top = `${topY}px`
+    context_menu.style.left = `${topX}px`
     return false
   },
   false,


### PR DESCRIPTION
### What this PR does 📖

- Restricts the context menu to the screen and also not overlapping the slimbar.
  - The slimbar defines a z-index value (which seems to be kinda necessary for some things) making it not possible for context menus to render above it.

### Which issue(s) this PR fixes 🔨

- Resolve #1323