### PR TITLE
feat(settings): make the settings page remember where you were

### DIFF
--- a/ui/src/bootstrap.rs
+++ b/ui/src/bootstrap.rs
@@ -28,6 +28,7 @@ pub(crate) fn use_boostrap<'a>(
 ) -> Option<&'a UseSharedState<State>> {
     let desktop = use_window(cx);
     use_shared_state_provider(cx, DownloadState::default);
+    use_shared_state_provider(cx, || components::settings::sidebar::Page::Profile);
     use_shared_state_provider(cx, || {
         let mut state = State::load();
 

--- a/ui/src/components/settings/sidebar.rs
+++ b/ui/src/components/settings/sidebar.rs
@@ -12,6 +12,7 @@ use kit::{
     layout::sidebar::Sidebar as ReusableSidebar,
 };
 
+#[derive(Clone, Eq, PartialEq)]
 pub enum Page {
     About,
     Audio,
@@ -24,6 +25,22 @@ pub enum Page {
     Notifications,
     Accessibility,
     Licenses,
+}
+
+impl Page {
+    pub fn set(&mut self, p: Page) {
+        *self = p;
+    }
+    pub fn get(&self) -> Self {
+        self.clone()
+    }
+    pub fn matches_str(&self, s: &str) -> bool {
+        let other = match Self::from_str(s) {
+            Ok(x) => x,
+            Err(_) => return false,
+        };
+        self == &other
+    }
 }
 
 impl FromStr for Page {
@@ -63,6 +80,7 @@ pub fn emit(cx: &Scope<Props>, e: Page) {
 #[allow(non_snake_case)]
 pub fn Sidebar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let state = use_shared_state::<State>(cx)?;
+    let page = use_shared_state::<Page>(cx)?;
     let _router = dioxus_router::hooks::use_navigator(cx);
 
     let profile = UIRoute {
@@ -151,7 +169,13 @@ pub fn Sidebar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
         routes.push(developer);
     }
 
-    let active_route = routes[0].clone();
+    // not the prettiest but matches the current code design.
+    let active_page = page.read().get();
+    let active_route = routes
+        .iter()
+        .find(|x| active_page.matches_str(x.to))
+        .cloned()
+        .unwrap_or(routes[0].clone());
 
     cx.render(rsx!(
         ReusableSidebar {

--- a/ui/src/components/settings/sidebar.rs
+++ b/ui/src/components/settings/sidebar.rs
@@ -12,7 +12,7 @@ use kit::{
     layout::sidebar::Sidebar as ReusableSidebar,
 };
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 pub enum Page {
     About,
     Audio,
@@ -32,7 +32,7 @@ impl Page {
         *self = p;
     }
     pub fn get(&self) -> Self {
-        self.clone()
+        *self
     }
     pub fn matches_str(&self, s: &str) -> bool {
         let other = match Self::from_str(s) {

--- a/ui/src/layouts/chats/presentation/quick_profile/mod.rs
+++ b/ui/src/layouts/chats/presentation/quick_profile/mod.rs
@@ -23,7 +23,7 @@ use common::language::get_local_text;
 use uuid::Uuid;
 use warp::{crypto::DID, logging::tracing::log};
 
-use crate::UplinkRoute;
+use crate::{components::settings::sidebar::Page, UplinkRoute};
 
 pub const USER_VOL_MIN: f32 = 0.25;
 pub const USER_VOL_MAX: f32 = 5.0;
@@ -51,6 +51,7 @@ enum QuickProfileCmd {
 #[allow(non_snake_case)]
 pub fn QuickProfileContext<'a>(cx: Scope<'a, QuickProfileProps<'a>>) -> Element<'a> {
     let state = use_shared_state::<State>(cx)?;
+    let settings_page = use_shared_state::<Page>(cx)?;
     let id = cx.props.id;
 
     let identity = state
@@ -313,6 +314,7 @@ pub fn QuickProfileContext<'a>(cx: Scope<'a, QuickProfileProps<'a>>) -> Element<
                         aria_label: "quick-profile-self-edit".into(),
                         text: get_local_text("quickprofile.self-edit"),
                         onpress: move |_| {
+                            settings_page.write().set(Page::Profile);
                             router.replace(UplinkRoute::SettingsLayout {});
                         }
                     })

--- a/ui/src/layouts/settings.rs
+++ b/ui/src/layouts/settings.rs
@@ -39,6 +39,20 @@ pub fn SettingsLayout(cx: Scope) -> Element {
         first_render.set(false);
     }
 
+    let settings = match to.read().get() {
+        Page::About => rsx!(AboutPage {}),
+        Page::General => rsx!(GeneralSettings {}),
+        Page::Accessibility => rsx!(AccessibilitySettings {}),
+        Page::Profile => rsx!(ProfileSettings {}),
+        Page::Audio => rsx!(AudioSettings {}),
+        // Page::Privacy => rsx!(PrivacySettings {}),
+        // Page::Files => rsx!(FilesSettings {}),
+        Page::Extensions => rsx!(ExtensionSettings {}),
+        Page::Developer => rsx!(DeveloperSettings {}),
+        Page::Notifications => rsx!(NotificationSettings {}),
+        Page::Licenses => rsx!(Licenses {}),
+    };
+
     cx.render(rsx!(
         div {
             id: "settings-layout",
@@ -67,19 +81,7 @@ pub fn SettingsLayout(cx: Scope) -> Element {
                 div {
                     id: "content",
                     class: "full-width",
-                    match to.read().get() {
-                        Page::About => rsx!(AboutPage {}),
-                        Page::General => rsx!(GeneralSettings {}),
-                        Page::Accessibility => rsx!(AccessibilitySettings {}),
-                        Page::Profile => rsx!(ProfileSettings {}),
-                        Page::Audio => rsx!(AudioSettings {}),
-                        // Page::Privacy => rsx!(PrivacySettings {}),
-                        // Page::Files => rsx!(FilesSettings {}),
-                        Page::Extensions => rsx!(ExtensionSettings {}),
-                        Page::Developer => rsx!(DeveloperSettings {}),
-                        Page::Notifications => rsx!(NotificationSettings {}),
-                        Page::Licenses => rsx!(Licenses {}),
-                    }
+                    settings,
                 },
                  (state.read().ui.sidebar_hidden && state.read().ui.metadata.minimal_view).then(|| rsx!(
                     crate::AppNav {

--- a/ui/src/layouts/settings.rs
+++ b/ui/src/layouts/settings.rs
@@ -27,7 +27,7 @@ use kit::layout::topbar::Topbar;
 #[allow(non_snake_case)]
 pub fn SettingsLayout(cx: Scope) -> Element {
     let state = use_shared_state::<State>(cx)?;
-    let to = use_state(cx, || Page::Profile);
+    let to = use_shared_state::<Page>(cx)?;
 
     state.write_silent().ui.current_layout = ui::Layout::Settings;
 
@@ -39,20 +39,6 @@ pub fn SettingsLayout(cx: Scope) -> Element {
         first_render.set(false);
     }
 
-    let settings_page = match to.get() {
-        Page::About => rsx!(AboutPage {}),
-        Page::General => rsx!(GeneralSettings {}),
-        Page::Accessibility => rsx!(AccessibilitySettings {}),
-        Page::Profile => rsx!(ProfileSettings {}),
-        Page::Audio => rsx!(AudioSettings {}),
-        // Page::Privacy => rsx!(PrivacySettings {}),
-        // Page::Files => rsx!(FilesSettings {}),
-        Page::Extensions => rsx!(ExtensionSettings {}),
-        Page::Developer => rsx!(DeveloperSettings {}),
-        Page::Notifications => rsx!(NotificationSettings {}),
-        Page::Licenses => rsx!(Licenses {}),
-    };
-
     cx.render(rsx!(
         div {
             id: "settings-layout",
@@ -60,11 +46,11 @@ pub fn SettingsLayout(cx: Scope) -> Element {
             SlimbarLayout { active: crate::UplinkRoute::SettingsLayout{} },
             Sidebar {
                 onpress: move |p| {
+                    to.write().set(p);
                     // If on mobile, we should hide the sidebar here.
                     if state.read().ui.is_minimal_view() {
                         state.write().mutate(Action::SidebarHidden(true));
                     }
-                    to.set(p);
                 },
             },
             div {
@@ -81,7 +67,19 @@ pub fn SettingsLayout(cx: Scope) -> Element {
                 div {
                     id: "content",
                     class: "full-width",
-                    settings_page
+                    match to.read().get() {
+                        Page::About => rsx!(AboutPage {}),
+                        Page::General => rsx!(GeneralSettings {}),
+                        Page::Accessibility => rsx!(AccessibilitySettings {}),
+                        Page::Profile => rsx!(ProfileSettings {}),
+                        Page::Audio => rsx!(AudioSettings {}),
+                        // Page::Privacy => rsx!(PrivacySettings {}),
+                        // Page::Files => rsx!(FilesSettings {}),
+                        Page::Extensions => rsx!(ExtensionSettings {}),
+                        Page::Developer => rsx!(DeveloperSettings {}),
+                        Page::Notifications => rsx!(NotificationSettings {}),
+                        Page::Licenses => rsx!(Licenses {}),
+                    }
                 },
                  (state.read().ui.sidebar_hidden && state.read().ui.metadata.minimal_view).then(|| rsx!(
                     crate::AppNav {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- go to the settings page, should init to `Profile`.
- click on a different settings page.
- leave the settings page
- return to the settings page - should remember where you left off. 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

