### PR TITLE
feat(markdown): big emoji, ascii emoji, and new settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,13 +2512,22 @@ dependencies = [
  "common",
  "dioxus",
  "dioxus-desktop",
- "emojis",
+ "emojis 0.6.1",
  "extensions",
  "futures",
  "kit",
  "once_cell",
  "uuid",
  "warp",
+]
+
+[[package]]
+name = "emojis"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3407bc749191827d456a282321770847daf4b0a1128fde02597a8ed2e987b95d"
+dependencies = [
+ "phf 0.11.2",
 ]
 
 [[package]]
@@ -4440,6 +4449,7 @@ dependencies = [
  "dioxus-desktop",
  "dioxus-hooks",
  "dioxus-html",
+ "emojis 0.5.3",
  "glob",
  "humansize",
  "linkify",
@@ -4450,6 +4460,8 @@ dependencies = [
  "rsass",
  "scraper 0.17.1",
  "timeago",
+ "unic-emoji-char",
+ "unic-segment",
  "uuid",
  "warp",
 ]
@@ -8986,6 +8998,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "unic-char-property"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221"
+dependencies = [
+ "unic-char-range",
+]
+
+[[package]]
+name = "unic-char-range"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc"
+
+[[package]]
+name = "unic-common"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc"
+
+[[package]]
+name = "unic-emoji-char"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b07221e68897210270a38bde4babb655869637af0f69407f96053a34f76494d"
+dependencies = [
+ "unic-char-property",
+ "unic-char-range",
+ "unic-ucd-version",
+]
+
+[[package]]
 name = "unic-langid"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9026,6 +9070,35 @@ dependencies = [
  "quote",
  "syn 1.0.109",
  "unic-langid-impl",
+]
+
+[[package]]
+name = "unic-segment"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ed5d26be57f84f176157270c112ef57b86debac9cd21daaabbe56db0f88f23"
+dependencies = [
+ "unic-ucd-segment",
+]
+
+[[package]]
+name = "unic-ucd-segment"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2079c122a62205b421f499da10f3ee0f7697f012f55b675e002483c73ea34700"
+dependencies = [
+ "unic-char-property",
+ "unic-char-range",
+ "unic-ucd-version",
+]
+
+[[package]]
+name = "unic-ucd-version"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
+dependencies = [
+ "unic-common",
 ]
 
 [[package]]

--- a/common/locales/en-US/main.ftl
+++ b/common/locales/en-US/main.ftl
@@ -173,6 +173,7 @@ settings = Settings
     .settings = Settings
     .profile = Profile
     .general = General 
+    .messages = Messages
     .privacy = Privacy
     .audio = Sounds & Audio
     .files = Files
@@ -209,6 +210,12 @@ settings-general = General Settings
     .font = Font
     .font-description = Change the font of the app.
     .clear-accent = Clear accent color
+
+settings-messages = Message Settings
+    .emoji-conversion = Convert Emoji
+    .emoji-conversion-description = Convert Emoji text like ':)' into an emoji symbol like '😊'.
+    .markdown-support = Markdown support
+    .markdown-support-description = Enables the support of the Markdown markup language in messaging. 
 
 settings-privacy = Settings Privacy 
     .backup-recovery-phrase = Backup Recovery Phrase

--- a/common/src/state/action.rs
+++ b/common/src/state/action.rs
@@ -56,6 +56,10 @@ pub enum Action<'a> {
     TrackEmojiUsage(String),
     #[display(fmt = "SetEmojiPickerVisible")]
     SetEmojiPickerVisible(bool),
+    #[display(fmt = "SetTransformMarkdownText")]
+    SetTransformMarkdownText(bool),
+    #[display(fmt = "SetTransformAsciiEmojis")]
+    SetTransformAsciiEmojis(bool),
     // RemoveToastNotification,
     /// Sets the active call and active media id
     #[display(fmt = "AnswerCall")]

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -235,6 +235,8 @@ impl State {
             Action::TrackEmojiUsage(emoji) => self.ui.track_emoji_usage(emoji),
             Action::SetEmojiDestination(destination) => self.ui.emoji_destination = destination,
             Action::SetEmojiPickerVisible(visible) => self.ui.emoji_picker_visible = visible,
+            Action::SetTransformMarkdownText(flag) => self.ui.transform_markdown_text(flag),
+            Action::SetTransformAsciiEmojis(flag) => self.ui.transform_ascii_emojis(flag),
             // Themes
             Action::SetTheme(theme) => self.set_theme(theme),
             // Fonts

--- a/common/src/state/ui.rs
+++ b/common/src/state/ui.rs
@@ -203,6 +203,10 @@ pub struct UI {
     pub emojis: EmojiCounter,
     pub emoji_destination: Option<EmojiDestination>,
     pub emoji_picker_visible: bool,
+    #[serde(default = "bool_true")]
+    transform_markdown_text: bool,
+    #[serde(default = "bool_true")]
+    transform_ascii_emojis: bool,
     #[serde(skip)]
     pub current_layout: Layout,
     // overlays or other windows are created via DesktopContext::new_window. they are stored here so they can be closed later.
@@ -250,6 +254,8 @@ impl Default for UI {
             show_dev_settings: false,
             cached_username: Default::default(),
             ignore_focus: Default::default(),
+            transform_markdown_text: true,
+            transform_ascii_emojis: true,
         }
     }
 }
@@ -313,6 +319,22 @@ impl UI {
 
     pub fn get_meta(&self) -> WindowMeta {
         self.metadata.clone()
+    }
+
+    pub fn should_transform_markdown_text(&self) -> bool {
+        self.transform_markdown_text
+    }
+
+    pub fn transform_markdown_text(&mut self, flag: bool) {
+        self.transform_markdown_text = flag;
+    }
+
+    pub fn should_transform_ascii_emojis(&self) -> bool {
+        self.transform_ascii_emojis
+    }
+
+    pub fn transform_ascii_emojis(&mut self, flag: bool) {
+        self.transform_ascii_emojis = flag;
     }
 
     pub fn is_minimal_view(&self) -> bool {

--- a/kit/Cargo.toml
+++ b/kit/Cargo.toml
@@ -25,6 +25,9 @@ linkify = { workspace = true }
 reqwest = { workspace = true }
 base64 = { workspace = true }
 mime = { workspace = true }
+emojis = "0.5"
+unic-segment = "0.9"
+unic-emoji-char = "0.9"
 
 [dependencies.uuid]
 workspace = true

--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -377,14 +377,14 @@ pub fn format_text(text: &str, should_markdown: bool, emojis: bool) -> String {
     if should_markdown {
         markdown(text, emojis)
     } else if emojis {
-        let s = replace_emojis(text);
+        let s = replace_emojis(text.trim());
         if is_only_emojis(&s) {
             format!("<span class=\"big-emoji\">{s}</span>")
         } else {
             format!("<p>{s}</p>")
         }
     } else {
-        format!("<p>{text}</p>")
+        format!("<p>{}</p>", text.trim())
     }
 }
 

--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -389,7 +389,7 @@ pub fn format_text(text: &str, should_markdown: bool, emojis: bool) -> String {
 }
 
 pub fn replace_emojis(input: &str) -> String {
-    fn process_stack<'a>(stack: &'a str) -> &'a str {
+    fn process_stack(stack: &str) -> &str {
         match stack {
             "<3" => "❤️",
             ">:)" => "😈",

--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -377,9 +377,14 @@ pub fn format_text(text: &str, should_markdown: bool, emojis: bool) -> String {
     if should_markdown {
         markdown(text, emojis)
     } else if emojis {
-        replace_emojis(text)
+        let s = replace_emojis(text);
+        if is_only_emojis(&s) {
+            format!("<span class=\"big-emoji\">{s}</span>")
+        } else {
+            format!("<p>{s}</p>")
+        }
     } else {
-        text.to_string()
+        format!("<p>{text}</p>")
     }
 }
 
@@ -595,6 +600,13 @@ mod tests {
     }
 
     #[test]
+    fn test_single_emoji4() {
+        let input = "🙂";
+        let expected = "<span class=\"single-emoji\">🙂</span>";
+        assert_eq!(&transform_only_emoji(input), expected);
+    }
+
+    #[test]
     fn test_triple_emoji() {
         let input = "😮😮👨‍👩‍👦‍👦";
         let expected = "<span class=\"single-emoji\">😮😮👨‍👩‍👦‍👦</span>";
@@ -603,8 +615,8 @@ mod tests {
 
     #[test]
     fn test_multiple_emoji() {
-        let input = "🤓😎🥸🤓";
-        let expected = "<span class=\"single-emoji\">🤓😎🥸🤓</span>";
+        let input = "🤓😎🥸🤓 🙂";
+        let expected = "<span class=\"single-emoji\">🤓😎🥸🤓 🙂</span>";
         assert_eq!(&transform_only_emoji(input), expected);
     }
 

--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -430,7 +430,12 @@ pub fn replace_emojis(input: &str) -> String {
 fn markdown(text: &str, emojis: bool) -> String {
     let txt = text.trim();
 
-    if is_only_emojis(txt) {
+    if emojis {
+        let r = replace_emojis(text);
+        if is_only_emojis(&r) {
+            return format!("<span class=\"big-emoji\">{r}</span>");
+        }
+    } else if is_only_emojis(txt) {
         return format!("<span class=\"big-emoji\">{txt}</span>");
     }
 
@@ -555,6 +560,19 @@ mod test {
         let input = ":)";
         let expected = "🙂";
         assert_eq!(&replace_emojis(input), expected);
+    }
+}
+
+#[cfg(test)]
+mod tests2 {
+    use super::*;
+
+    #[test]
+    fn test_format_text1() {
+        let input = ":) ";
+        let expected = "<span class=\"big-emoji\">🙂 </span>";
+        assert_eq!(&format_text(input, true, true), expected);
+        assert_eq!(&format_text(input, false, true), expected);
     }
 }
 

--- a/kit/src/layout/chatbar/mod.rs
+++ b/kit/src/layout/chatbar/mod.rs
@@ -3,7 +3,9 @@ use dioxus_elements::input_data::keyboard_types::Code;
 use warp::constellation::file::File;
 
 use crate::{
-    components::{embeds::file_embed::FileEmbed, message_typing::MessageTyping},
+    components::{
+        embeds::file_embed::FileEmbed, message::format_text, message_typing::MessageTyping,
+    },
     elements::{button::Button, label::Label, textarea, Appearance},
 };
 
@@ -53,11 +55,18 @@ pub struct ReplyProps<'a> {
     attachments: Option<Vec<File>>,
     onclose: EventHandler<'a>,
     children: Element<'a>,
+    markdown: Option<bool>,
+    transform_ascii_emojis: Option<bool>,
 }
 
 #[allow(non_snake_case)]
 pub fn Reply<'a>(cx: Scope<'a, ReplyProps<'a>>) -> Element<'a> {
     let remote = cx.props.remote.unwrap_or_default();
+    let message = format_text(
+        &cx.props.message,
+        cx.props.markdown.unwrap_or_default(),
+        cx.props.transform_ascii_emojis.unwrap_or_default(),
+    );
 
     let has_attachments = cx
         .props
@@ -107,7 +116,7 @@ pub fn Reply<'a>(cx: Scope<'a, ReplyProps<'a>>) -> Element<'a> {
                     aria_label: {
                         format_args!("reply-text-message{}", if remote { "-remote" } else { "" })
                     },
-                    "{cx.props.message}"
+                    dangerous_inner_html: "{message}",
                     has_attachments.then(|| {
                         rsx!(
                             attachment_list.map(|list| {

--- a/ui/src/components/settings/sidebar.rs
+++ b/ui/src/components/settings/sidebar.rs
@@ -18,6 +18,7 @@ pub enum Page {
     Developer,
     Extensions,
     General,
+    Messages,
     //Files,
     //Privacy,
     Profile,
@@ -35,6 +36,7 @@ impl FromStr for Page {
             "extensions" => Ok(Page::Extensions),
             //"files" => Ok(Page::Files),
             "general" => Ok(Page::General),
+            "messages" => Ok(Page::Messages),
             //"privacy" => Ok(Page::Privacy),
             "profile" => Ok(Page::Profile),
             "notifications" => Ok(Page::Notifications),
@@ -76,6 +78,13 @@ pub fn Sidebar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
         to: "general",
         name: get_local_text("settings.general"),
         icon: Icon::Cog6Tooth,
+        ..UIRoute::default()
+    };
+
+    let messages = UIRoute {
+        to: "messages",
+        name: get_local_text("settings.messages"),
+        icon: Icon::ChatBubbleBottomCenterText,
         ..UIRoute::default()
     };
 
@@ -137,6 +146,7 @@ pub fn Sidebar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let mut routes = vec![
         profile,
         general,
+        messages,
         //privacy,
         audio,
         // files,

--- a/ui/src/components/settings/sub_pages/messages.rs
+++ b/ui/src/components/settings/sub_pages/messages.rs
@@ -1,0 +1,41 @@
+use common::{
+    language::get_local_text,
+    state::{Action, State},
+};
+use dioxus::prelude::*;
+use kit::elements::switch::Switch;
+use warp::logging::tracing::log;
+
+use crate::components::settings::SettingSection;
+
+#[allow(non_snake_case)]
+pub fn Messages(cx: Scope) -> Element {
+    log::trace!("Messages settings page rendered.");
+    let state = use_shared_state::<State>(cx)?;
+    cx.render(rsx!(
+        div {
+            id: "settings-messages",
+            aria_label: "settings-messages",
+             SettingSection {
+                 section_label: get_local_text("settings-messages.emoji-conversion"),
+                 section_description: get_local_text("settings-messages.emoji-conversion-description"),
+                 Switch {
+                    active: state.read().ui.should_transform_ascii_emojis(),
+                    onflipped: move|flag| {
+                        state.write().mutate(Action::SetTransformAsciiEmojis(flag));
+                    }
+                 }
+             },
+            SettingSection {
+                section_label: get_local_text("settings-messages.markdown-support"),
+                section_description: get_local_text("settings-messages.markdown-support-description"),
+                Switch {
+                    active: state.read().ui.should_transform_markdown_text(),
+                    onflipped: move|flag| {
+                        state.write().mutate(Action::SetTransformMarkdownText(flag));
+                    }
+                }
+            }
+        }
+    ))
+}

--- a/ui/src/components/settings/sub_pages/mod.rs
+++ b/ui/src/components/settings/sub_pages/mod.rs
@@ -6,6 +6,7 @@ pub mod extensions;
 pub mod files;
 pub mod general;
 pub mod licenses;
+pub mod messages;
 pub mod notifications;
 pub mod privacy;
 pub mod profile;

--- a/ui/src/layouts/chats/presentation/chat/pinned_messages/mod.rs
+++ b/ui/src/layouts/chats/presentation/chat/pinned_messages/mod.rs
@@ -172,6 +172,7 @@ pub struct PinnedMessageProp<'a> {
 
 #[allow(non_snake_case)]
 pub fn PinnedMessage<'a>(cx: Scope<'a, PinnedMessageProp<'a>>) -> Element<'a> {
+    let state = use_shared_state::<State>(cx)?;
     let message = &cx.props.message;
     let attachments = message.attachments();
 
@@ -249,7 +250,8 @@ pub fn PinnedMessage<'a>(cx: Scope<'a, PinnedMessageProp<'a>>) -> Element<'a> {
                         text: message.value().join("\n"),
                         remote: true,
                         pending: false,
-                        markdown: true,
+                        markdown: state.read().ui.should_transform_markdown_text(),
+                        ascii_emoji: state.read().ui.should_transform_ascii_emojis(),
                     }
                 },
                 has_attachments.then(|| {

--- a/ui/src/layouts/chats/presentation/chatbar.rs
+++ b/ui/src/layouts/chats/presentation/chatbar.rs
@@ -569,7 +569,8 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, ChatProps>) -> Element<'a> {
                                         state.write().mutate(Action::CancelReply(chat_data.read().active_chat.id()))
                                     },
                                     attachments: msg.attachments(),
-                                    message: msg.value().join("\n"),
+                                    message: msg.value().join("\n"), 
+                                    markdown: state.read().ui.should_transform_markdown_text(),
                                     UserImage {
                                         image: profile_picture,
                                         platform: platform,

--- a/ui/src/layouts/chats/presentation/chatbar.rs
+++ b/ui/src/layouts/chats/presentation/chatbar.rs
@@ -573,6 +573,7 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, ChatProps>) -> Element<'a> {
                                     attachments: msg.attachments(),
                                     message: msg.value().join("\n"), 
                                     markdown: state.read().ui.should_transform_markdown_text(),
+                                    transform_ascii_emojis: state.read().ui.should_transform_ascii_emojis(),
                                     UserImage {
                                         image: profile_picture,
                                         platform: platform,

--- a/ui/src/layouts/chats/presentation/messages/mod.rs
+++ b/ui/src/layouts/chats/presentation/messages/mod.rs
@@ -525,6 +525,8 @@ fn render_message<'a>(cx: Scope<'a, MessageProps<'a>>) -> Element<'a> {
     let user_did_2 = user_did.clone();
     // todo: get attachment progress from a hook like state.
     let pending_uploads = vec![];
+    let render_markdown = state.read().ui.should_transform_markdown_text();
+    let should_transform_ascii_emojis = state.read().ui.should_transform_ascii_emojis();
 
     cx.render(rsx!(
         div {
@@ -538,6 +540,8 @@ fn render_message<'a>(cx: Scope<'a, MessageProps<'a>>) -> Element<'a> {
                     remote_message: cx.props.is_remote,
                     sender_did: sender_did.clone(),
                     replier_did: user_did_2.clone(),
+                    markdown: render_markdown,
+                    transform_ascii_emojis: should_transform_ascii_emojis,
                 }
             )),
             Message {
@@ -558,7 +562,8 @@ fn render_message<'a>(cx: Scope<'a, MessageProps<'a>>) -> Element<'a> {
                 pending: cx.props.pending,
                 pinned: message.inner.pinned(),
                 attachments_pending_uploads: pending_uploads,
-                parse_markdown: true,
+                parse_markdown: render_markdown,
+                transform_ascii_emojis: should_transform_ascii_emojis,
                 on_download: move |file: warp::constellation::file::File| {
                     let file_name = file.name();
                     let file_extension = std::path::Path::new(&file_name)

--- a/ui/src/layouts/chats/presentation/sidebar/mod.rs
+++ b/ui/src/layouts/chats/presentation/sidebar/mod.rs
@@ -10,7 +10,7 @@ use dioxus::prelude::*;
 use dioxus_router::prelude::use_navigator;
 use futures::channel::oneshot;
 use futures::StreamExt;
-use kit::components::message::markdown;
+use kit::components::message::format_text;
 use kit::layout::modal::Modal;
 use kit::{
     components::{
@@ -276,6 +276,8 @@ pub fn Sidebar(cx: Scope<SidebarProps>) -> Element {
                     let is_active = state.read().get_active_chat().map(|c| c.id) == Some(chat.id);
                     let chat_with = chat.clone();
                     let clear_unreads = chat.clone();
+                    let markdown = state.read().ui.should_transform_markdown_text();
+                    let should_transform_ascii_emojis = state.read().ui.should_transform_ascii_emojis();
 
                     // todo: how to tell who is participating in a group chat if the chat has a conversation_name?
                     let participants_name = match chat.conversation_name {
@@ -284,7 +286,7 @@ pub fn Sidebar(cx: Scope<SidebarProps>) -> Element {
                     };
 
                     let subtext_val = match unwrapped_message.value().iter().map(|x| x.trim()).find(|x| !x.is_empty()) {
-                        Some(v) => markdown(v),
+                        Some(v) => format_text(v, markdown, should_transform_ascii_emojis),
                         _ => match &unwrapped_message.attachments()[..] {
                             [] => get_local_text("sidebar.chat-new"),
                             [ file ] => file.name(),

--- a/ui/src/layouts/settings.rs
+++ b/ui/src/layouts/settings.rs
@@ -11,6 +11,7 @@ use crate::{
             extensions::ExtensionSettings,
             general::GeneralSettings,
             licenses::Licenses,
+            messages::Messages,
             notifications::NotificationSettings,
             // files::FilesSettings,
             // privacy::PrivacySettings,
@@ -42,6 +43,7 @@ pub fn SettingsLayout(cx: Scope) -> Element {
     let settings_page = match to.get() {
         Page::About => rsx!(AboutPage {}),
         Page::General => rsx!(GeneralSettings {}),
+        Page::Messages => rsx!(Messages {}),
         Page::Accessibility => rsx!(AccessibilitySettings {}),
         Page::Profile => rsx!(ProfileSettings {}),
         Page::Audio => rsx!(AudioSettings {}),

--- a/ui/src/layouts/storage/send_files_layout/mod.rs
+++ b/ui/src/layouts/storage/send_files_layout/mod.rs
@@ -5,7 +5,7 @@ use common::{
 use dioxus::prelude::*;
 use kit::{
     components::{
-        message::markdown, user::User, user_image::UserImage, user_image_group::UserImageGroup,
+        message::format_text, user::User, user_image::UserImage, user_image_group::UserImageGroup,
     },
     elements::{checkbox::Checkbox, label::Label},
 };
@@ -143,7 +143,7 @@ fn ChatsToSelect<'a>(cx: Scope<'a, ChatsToSelectProps<'a>>) -> Element<'a> {
             let is_checked = storage_controller.read().chats_selected_to_send.iter().any(|uuid| {uuid.eq(&chat.id)});
             let unwrapped_message = match chat.messages.iter().last() {Some(m) => m.inner.clone(),None => raygun::Message::default()};
             let subtext_val = match unwrapped_message.value().iter().map(|x| x.trim()).find(|x| !x.is_empty()) {
-                Some(v) => markdown(v),
+                Some(v) => format_text(v, state.read().ui.should_transform_markdown_text(), state.read().ui.should_transform_ascii_emojis()),
                 _ => match &unwrapped_message.attachments()[..] {
                     [] => get_local_text("sidebar.chat-new"),
                     [ file ] => file.name(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- copies over the stuff from the previous PR. No need to keep that stuff out of dev. 
- Transforms ascii emojis to unicode ex: :O -> 😮
- detects messages that consist of only emojis and whitespace and enlarges them
- makes markdown support configurable in settings

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

