### PR TITLE
chore(slimbar): hide slimbar when it doesnt have anything in it

### DIFF
--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -865,12 +865,12 @@ impl State {
 
     // hide IF favorites.len() = 0 AND not is_minimal_view OR is_sidebar_hidden
     pub fn show_slimbar(&self) -> bool {
-        let has_favs = self.chats_favorites().len() > 0;
+        let has_favs = !self.chats_favorites().is_empty();
         let is_minimal_view = self.ui.is_minimal_view();
         let sidebar_hidden = self.ui.sidebar_hidden;
         let experimental_features = self.configuration.developer.experimental_features;
 
-        return has_favs || is_minimal_view || sidebar_hidden || experimental_features;
+        has_favs || is_minimal_view || sidebar_hidden || experimental_features
     }
     fn add_msg_to_chat(&mut self, conversation_id: Uuid, message: ui_adapter::Message) {
         let msg_id = message.inner.id();

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -862,6 +862,16 @@ impl State {
             .cloned()
             .collect()
     }
+
+    // hide IF favorites.len() = 0 AND not is_minimal_view OR is_sidebar_hidden
+    pub fn show_slimbar(&self) -> bool {
+        let has_favs = self.chats_favorites().len() > 0;
+        let is_minimal_view = self.ui.is_minimal_view();
+        let sidebar_hidden = self.ui.sidebar_hidden;
+        let experimental_features = self.configuration.developer.experimental_features;
+
+        return has_favs || is_minimal_view || sidebar_hidden || experimental_features;
+    }
     fn add_msg_to_chat(&mut self, conversation_id: Uuid, message: ui_adapter::Message) {
         let msg_id = message.inner.id();
         let is_active_scrolled = self.chats.active_chat_is_scrolled();

--- a/ui/src/layouts/chats/mod.rs
+++ b/ui/src/layouts/chats/mod.rs
@@ -76,6 +76,8 @@ pub fn ChatLayout(cx: Scope) -> Element {
     let window = use_window(cx);
     let eval: &UseEvalFn = use_eval(cx);
 
+    let show_slimbar = state.read().show_slimbar();
+
     // #[cfg(target_os = "windows")]
     use_future(cx, (), |_| {
         to_owned![state, window, drag_event, eval];
@@ -104,7 +106,11 @@ pub fn ChatLayout(cx: Scope) -> Element {
                 p {id: "overlay-text0", class: "overlay-text"},
                 p {id: "overlay-text", class: "overlay-text"}
             },
-            SlimbarLayout { active: crate::UplinkRoute::ChatLayout{} },
+            if show_slimbar {
+                cx.render(rsx!(
+                    SlimbarLayout { active: crate::UplinkRoute::ChatLayout{} },
+                ))
+            },
             // todo: consider showing a welcome screen if the sidebar is to be shown but there are no conversations in the sidebar. this case arises when
             // creating a new account on a mobile device.
             ChatSidebar {

--- a/ui/src/layouts/friends.rs
+++ b/ui/src/layouts/friends.rs
@@ -34,7 +34,7 @@ pub enum FriendRoute {
 pub fn FriendsLayout(cx: Scope) -> Element {
     let state = use_shared_state::<State>(cx)?;
     let route = use_state(cx, || FriendRoute::All);
-
+    let show_slimbar = state.read().show_slimbar();
     state.write_silent().ui.current_layout = ui::Layout::Friends;
 
     if state.read().ui.is_minimal_view() {
@@ -78,7 +78,11 @@ pub fn FriendsLayout(cx: Scope) -> Element {
             id: "friends-layout",
             aria_label: "friends-layout",
             class: "disable-select",
-            SlimbarLayout { active: crate::UplinkRoute::FriendsLayout {} },
+            if show_slimbar {
+                cx.render(rsx!(
+                    SlimbarLayout { active: crate::UplinkRoute::FriendsLayout {} },
+                ))
+            },
             ChatSidebar {
                 active_route: crate::UplinkRoute::FriendsLayout {},
             },

--- a/ui/src/layouts/settings.rs
+++ b/ui/src/layouts/settings.rs
@@ -28,7 +28,7 @@ use kit::layout::topbar::Topbar;
 pub fn SettingsLayout(cx: Scope) -> Element {
     let state = use_shared_state::<State>(cx)?;
     let to = use_state(cx, || Page::Profile);
-
+    let show_slimbar = state.read().show_slimbar();
     state.write_silent().ui.current_layout = ui::Layout::Settings;
 
     let first_render = use_state(cx, || true);
@@ -57,7 +57,11 @@ pub fn SettingsLayout(cx: Scope) -> Element {
         div {
             id: "settings-layout",
             aria_label: "settings-layout",
-            SlimbarLayout { active: crate::UplinkRoute::SettingsLayout{} },
+            if show_slimbar {
+                cx.render(rsx!(
+                    SlimbarLayout { active: crate::UplinkRoute::SettingsLayout{} },
+                ))
+            },
             Sidebar {
                 onpress: move |p| {
                     // If on mobile, we should hide the sidebar here.

--- a/ui/src/layouts/storage/files_layout/mod.rs
+++ b/ui/src/layouts/storage/files_layout/mod.rs
@@ -55,6 +55,7 @@ pub fn FilesLayout(cx: Scope<'_>) -> Element<'_> {
     let files_pre_selected_to_send: &UseRef<Vec<Location>> = use_ref(cx, Vec::new);
     let _router = use_navigator(cx);
     let eval: &UseEvalFn = use_eval(cx);
+    let show_slimbar = state.read().show_slimbar();
 
     functions::use_allow_block_folder_nav(cx, &files_in_queue_to_upload);
 
@@ -133,9 +134,13 @@ pub fn FilesLayout(cx: Scope<'_>) -> Element<'_> {
             onclick: |_| {
                 storage_controller.write().finish_renaming_item(false);
             },
-            SlimbarLayout {
-                active: crate::UplinkRoute::FilesLayout {}
-            },
+            if show_slimbar {
+                cx.render(rsx!(
+                    SlimbarLayout {
+                        active: crate::UplinkRoute::FilesLayout {}
+                    },
+                ))
+            }
             ChatSidebar {
                 active_route: crate::UplinkRoute::FilesLayout {},
             },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

Hides the sidebar when there is nothing to show there.

It will now display the sidebar with the following conditions:
has_favs OR is_minimal_view OR sidebar_hidden OR experimental_features

![Screenshot 2023-10-20 at 3 13 30 PM](https://github.com/Satellite-im/Uplink/assets/2993032/296bc1f5-8491-4836-94ac-29c43fc5a1c5)
![Screenshot 2023-10-20 at 3 16 15 PM](https://github.com/Satellite-im/Uplink/assets/2993032/6f012592-e532-4e99-9796-a01bc23394e3)
![Screenshot 2023-10-20 at 3 16 22 PM](https://github.com/Satellite-im/Uplink/assets/2993032/83d6936e-9b0d-46cd-9e77-b2bc2b7d299d)
![Screenshot 2023-10-20 at 3 16 30 PM](https://github.com/Satellite-im/Uplink/assets/2993032/e33ecf08-dec9-4a35-876f-d7455e889007)

- 

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

