### PR TITLE
fix(chat): Markdown strikethrough fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4572,6 +4572,7 @@ dependencies = [
  "humansize",
  "linkify",
  "mime",
+ "once_cell",
  "pulldown-cmark",
  "regex",
  "reqwest",

--- a/kit/Cargo.toml
+++ b/kit/Cargo.toml
@@ -25,6 +25,7 @@ linkify = { workspace = true }
 reqwest = { workspace = true }
 base64 = { workspace = true }
 mime = { workspace = true }
+once_cell = { workspace = true }
 
 [dependencies.uuid]
 workspace = true

--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -407,7 +407,7 @@ pub fn markdown(text: &str) -> String {
     let mut add_text_language = true;
 
     for line in &mut modified_lines_refs {
-        let parser = pulldown_cmark::Parser::new_ext(&line, options);
+        let parser = pulldown_cmark::Parser::new_ext(line, options);
         let line_trim = line.trim();
         if line_trim == "```" && add_text_language {
             *line = "```text";
@@ -430,11 +430,11 @@ pub fn markdown(text: &str) -> String {
                     let text = if let Some(pulldown_cmark::Event::End(Tag::Strikethrough)) =
                         previous_event
                     {
-                        t.strip_prefix(" ").unwrap_or(&t).into()
+                        t.strip_prefix(' ').unwrap_or(&t).into()
                     } else if let Some(&pulldown_cmark::Event::Start(Tag::Strikethrough)) =
                         it.peek()
                     {
-                        t.strip_suffix(" ").unwrap_or(&t).into()
+                        t.strip_suffix(' ').unwrap_or(&t).into()
                     } else {
                         t.to_string()
                     };

--- a/ui/src/style.scss
+++ b/ui/src/style.scss
@@ -231,6 +231,10 @@ s {
   text-decoration: line-through;
 }
 
+del {
+  text-decoration: line-through;
+}
+
 strong {
   font-weight: bold;
 }


### PR DESCRIPTION
### What this PR does 📖

- Fixes strikethrough not working
- Also fixes an issue where strikethrough are only detected if they stand alone:
  - `test ~~test~~` this works
  - `test~~test~~` this didn't works (it treated it as a whole word)
- Adds the dependency `once_cell` to kit because of regex usage. and fixes an instance where the regex was constructed always instead of cached

### Which issue(s) this PR fixes 🔨

- Resolve #1359
