### PR TITLE
fix(windows): update dioxus to fix panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,7 +2177,7 @@ dependencies = [
 [[package]]
 name = "dioxus"
 version = "0.4.2"
-source = "git+https://github.com/satellite-im/dioxus?rev=1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2#1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2"
+source = "git+https://github.com/satellite-im/dioxus?rev=99cf5c79ff76241eb4b5763539931261d71e114f#99cf5c79ff76241eb4b5763539931261d71e114f"
 dependencies = [
  "dioxus-core",
  "dioxus-core-macro",
@@ -2190,7 +2190,7 @@ dependencies = [
 [[package]]
 name = "dioxus-core"
 version = "0.4.2"
-source = "git+https://github.com/satellite-im/dioxus?rev=1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2#1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2"
+source = "git+https://github.com/satellite-im/dioxus?rev=99cf5c79ff76241eb4b5763539931261d71e114f#99cf5c79ff76241eb4b5763539931261d71e114f"
 dependencies = [
  "bumpalo",
  "futures-channel",
@@ -2206,7 +2206,7 @@ dependencies = [
 [[package]]
 name = "dioxus-core-macro"
 version = "0.4.2"
-source = "git+https://github.com/satellite-im/dioxus?rev=1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2#1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2"
+source = "git+https://github.com/satellite-im/dioxus?rev=99cf5c79ff76241eb4b5763539931261d71e114f#99cf5c79ff76241eb4b5763539931261d71e114f"
 dependencies = [
  "constcat",
  "dioxus-core",
@@ -2225,7 +2225,7 @@ checksum = "2ea539174bb236e0e7dc9c12b19b88eae3cb574dedbd0252a2d43ea7e6de13e2"
 [[package]]
 name = "dioxus-desktop"
 version = "0.4.2"
-source = "git+https://github.com/satellite-im/dioxus?rev=1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2#1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2"
+source = "git+https://github.com/satellite-im/dioxus?rev=99cf5c79ff76241eb4b5763539931261d71e114f#99cf5c79ff76241eb4b5763539931261d71e114f"
 dependencies = [
  "async-trait",
  "core-foundation",
@@ -2256,7 +2256,7 @@ dependencies = [
 [[package]]
 name = "dioxus-hooks"
 version = "0.4.2"
-source = "git+https://github.com/satellite-im/dioxus?rev=1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2#1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2"
+source = "git+https://github.com/satellite-im/dioxus?rev=99cf5c79ff76241eb4b5763539931261d71e114f#99cf5c79ff76241eb4b5763539931261d71e114f"
 dependencies = [
  "dioxus-core",
  "dioxus-debug-cell",
@@ -2269,7 +2269,7 @@ dependencies = [
 [[package]]
 name = "dioxus-hot-reload"
 version = "0.4.2"
-source = "git+https://github.com/satellite-im/dioxus?rev=1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2#1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2"
+source = "git+https://github.com/satellite-im/dioxus?rev=99cf5c79ff76241eb4b5763539931261d71e114f#99cf5c79ff76241eb4b5763539931261d71e114f"
 dependencies = [
  "dioxus-core",
  "dioxus-html",
@@ -2282,7 +2282,7 @@ dependencies = [
 [[package]]
 name = "dioxus-html"
 version = "0.4.2"
-source = "git+https://github.com/satellite-im/dioxus?rev=1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2#1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2"
+source = "git+https://github.com/satellite-im/dioxus?rev=99cf5c79ff76241eb4b5763539931261d71e114f#99cf5c79ff76241eb4b5763539931261d71e114f"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -2301,12 +2301,12 @@ dependencies = [
 [[package]]
 name = "dioxus-interpreter-js"
 version = "0.4.2"
-source = "git+https://github.com/satellite-im/dioxus?rev=1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2#1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2"
+source = "git+https://github.com/satellite-im/dioxus?rev=99cf5c79ff76241eb4b5763539931261d71e114f#99cf5c79ff76241eb4b5763539931261d71e114f"
 
 [[package]]
 name = "dioxus-router"
 version = "0.4.2"
-source = "git+https://github.com/satellite-im/dioxus?rev=1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2#1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2"
+source = "git+https://github.com/satellite-im/dioxus?rev=99cf5c79ff76241eb4b5763539931261d71e114f#99cf5c79ff76241eb4b5763539931261d71e114f"
 dependencies = [
  "anyhow",
  "dioxus",
@@ -2326,7 +2326,7 @@ dependencies = [
 [[package]]
 name = "dioxus-router-macro"
 version = "0.4.2"
-source = "git+https://github.com/satellite-im/dioxus?rev=1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2#1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2"
+source = "git+https://github.com/satellite-im/dioxus?rev=99cf5c79ff76241eb4b5763539931261d71e114f#99cf5c79ff76241eb4b5763539931261d71e114f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2337,7 +2337,7 @@ dependencies = [
 [[package]]
 name = "dioxus-rsx"
 version = "0.4.2"
-source = "git+https://github.com/satellite-im/dioxus?rev=1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2#1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2"
+source = "git+https://github.com/satellite-im/dioxus?rev=99cf5c79ff76241eb4b5763539931261d71e114f#99cf5c79ff76241eb4b5763539931261d71e114f"
 dependencies = [
  "dioxus-core",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,15 +31,15 @@ version = "0.1.6"
 rust-version = "1.70"
 
 [workspace.dependencies]
-dioxus = { git = "https://github.com/satellite-im/dioxus", rev = "1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2" }
-dioxus-hooks = { git = "https://github.com/satellite-im/dioxus", rev = "1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2" }
-dioxus-html = { git = "https://github.com/satellite-im/dioxus", rev = "1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2" }
-dioxus-router = { git = "https://github.com/satellite-im/dioxus", rev = "1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2" }
-dioxus-desktop = { git = "https://github.com/satellite-im/dioxus", rev = "1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2", features = ["transparent"] }
+dioxus = { git = "https://github.com/satellite-im/dioxus", rev = "99cf5c79ff76241eb4b5763539931261d71e114f" }
+dioxus-hooks = { git = "https://github.com/satellite-im/dioxus", rev = "99cf5c79ff76241eb4b5763539931261d71e114f" }
+dioxus-html = { git = "https://github.com/satellite-im/dioxus", rev = "99cf5c79ff76241eb4b5763539931261d71e114f" }
+dioxus-router = { git = "https://github.com/satellite-im/dioxus", rev = "99cf5c79ff76241eb4b5763539931261d71e114f" }
+dioxus-desktop = { git = "https://github.com/satellite-im/dioxus", rev = "99cf5c79ff76241eb4b5763539931261d71e114f", features = ["transparent"] }
 muda = "0.9.4"
 raw-window-handle = "0.5"
-dioxus-core = { git = "https://github.com/satellite-im/dioxus", rev = "1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2" }
-fermi = { git = "https://github.com/satellite-im/dioxus", rev = "1dba57f39db8485ccdc03f3a6c11a6fcbb2f87f2" }
+dioxus-core = { git = "https://github.com/satellite-im/dioxus", rev = "99cf5c79ff76241eb4b5763539931261d71e114f" }
+fermi = { git = "https://github.com/satellite-im/dioxus", rev = "99cf5c79ff76241eb4b5763539931261d71e114f" }
 tokio-util = { version = "0.7", features = ["full"] }
 arboard = "3.2"
 humansize = "2.1.3"

--- a/kit/src/components/topbar_controls/mod.rs
+++ b/kit/src/components/topbar_controls/mod.rs
@@ -4,7 +4,7 @@ use dioxus::prelude::*;
 use dioxus_desktop::{use_window, LogicalSize};
 
 #[allow(non_snake_case)]
-pub fn Topbar_Controls(cx: Scope) -> Element {
+pub fn TopbarControls(cx: Scope) -> Element {
     let state = use_ref(cx, State::load);
     let desktop = use_window(cx);
     let first_resize = use_ref(cx, || true);

--- a/ui/src/auth_guard.rs
+++ b/ui/src/auth_guard.rs
@@ -1,6 +1,6 @@
 use dioxus::prelude::*;
 use dioxus_desktop::{use_window, LogicalSize};
-use kit::components::topbar_controls::Topbar_Controls;
+use kit::components::topbar_controls::TopbarControls;
 use kit::STYLE as UIKIT_STYLES;
 use warp::multipass;
 pub const APP_STYLE: &str = include_str!("./compiled_styles.css");
@@ -43,7 +43,7 @@ pub fn AuthGuard(cx: Scope, page: UseState<AuthPages>) -> Element {
                 class: "titlebar disable-select",
                 id: if cfg!(target_os = "macos") {""}  else {"lockscreen-controls"},
                 onmousedown: move |_| { desktop.drag(); },
-                Topbar_Controls {},
+                TopbarControls {},
             },
 
             match *page.current() {

--- a/ui/src/auth_guard.rs
+++ b/ui/src/auth_guard.rs
@@ -41,8 +41,11 @@ pub fn AuthGuard(cx: Scope, page: UseState<AuthPages>) -> Element {
             id: "app-wrap",
             div {
                 class: "titlebar disable-select",
-                id: if cfg!(target_os = "macos") {""}  else {"lockscreen-controls"},
-                onmousedown: move |_| { desktop.drag(); },
+                id: "lockscreen-controls",
+                div {
+                    class: "draggable-topbar",
+                    onmousedown: move |_| { desktop.drag(); },
+                },
                 TopbarControls {},
             },
 

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -27,7 +27,7 @@ use extensions::UplinkExtension;
 use futures::channel::oneshot;
 use futures::StreamExt;
 use kit::components::context_menu::{ContextItem, ContextMenu};
-use kit::components::topbar_controls::Topbar_Controls;
+use kit::components::topbar_controls::TopbarControls;
 use kit::elements::button::Button;
 use kit::elements::tooltip::ArrowPosition;
 use kit::elements::Appearance;
@@ -965,7 +965,7 @@ fn Titlebar(cx: Scope) -> Element {
             cx.render(rsx!(span {
                 class: "inline-controls",
                 get_update_icon{},
-                Topbar_Controls {}
+                TopbarControls {}
             })),
         },
     ))

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -960,13 +960,16 @@ fn Titlebar(cx: Scope) -> Element {
     cx.render(rsx!(
         div {
             class: "titlebar disable-select",
-            onmousedown: move |_| { desktop.drag(); },
             Release_Info{},
-            cx.render(rsx!(span {
+            div {
+                class: "draggable-topbar",
+                onmousedown: move |_| { desktop.drag(); },
+            },
+            span {
                 class: "inline-controls",
                 get_update_icon{},
                 TopbarControls {}
-            })),
+            },
         },
     ))
 }

--- a/ui/src/style.scss
+++ b/ui/src/style.scss
@@ -41,11 +41,21 @@ body {
       height: 100%;
     }
   }
+
+  .draggable-topbar {
+    flex-grow: 1;
+    height: 100%;
+  }
 }
 
 #lockscreen-controls {
   align-items: flex-end;
   justify-content: flex-end;
+
+  .draggable-topbar {
+    flex-grow: 1;
+    height: 100%;
+  }
 }
 
 #update-available-menu {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- merged in the event bubbling fix to Satellite's fork of Dioxus. 
- this required changing the titlebar because desktop.drag_window() now prevents onclick events from firing on child elements. 
- on windows you should now be able to turn on developer settings and not crash. 

### Which issue(s) this PR fixes 🔨

- Resolve #1243 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

