### PR TITLE
fix(chat): Ignore case for matching emoji

### DIFF
--- a/common/src/state/ui.rs
+++ b/common/src/state/ui.rs
@@ -66,6 +66,7 @@ impl EmojiCounter {
         if pattern.is_empty() {
             return vec![];
         }
+        let pattern = &pattern.to_lowercase();
         let mut matches: HashMap<String, String> = default_emoji_list()
             .iter()
             .filter_map(|(emoji, alias)| {


### PR DESCRIPTION
### What this PR does 📖

- Have emoji search be case insensitive

### Which issue(s) this PR fixes 🔨

- Resolve #1391