### PR TITLE
fix(attachment): show thumbnail for images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4602,6 +4602,7 @@ dependencies = [
  "glob",
  "humansize",
  "linkify",
+ "log",
  "mime",
  "once_cell",
  "pulldown-cmark",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ notify = "5.1.0"
 rand = "0.8"
 notify-rust = { version = "4.6.0", default-features = false, features = ["d"] }
 titlecase = "2.2.1"
+log = { version = "0.4.17", features = ["std"] }
 
 tempfile = "3.0.7"
 fdlimit = "0.2"

--- a/common/locales/en-US/main.ftl
+++ b/common/locales/en-US/main.ftl
@@ -148,7 +148,6 @@ files = Files
     .no-thumbnail = No Thumbnail
     .one-file-to-upload = File to Upload 1!
     .files-to-upload = Files to Upload { $num }!
-    .no-thumbnail-preview = No thumbnail to see
     .file-already-opened = File already opened
     .directory-already-with-name = There is already a directory with this name
     .no-size-available = No size available for file: { $file }

--- a/common/locales/en-US/main.ftl
+++ b/common/locales/en-US/main.ftl
@@ -148,6 +148,8 @@ files = Files
     .no-thumbnail = No Thumbnail
     .one-file-to-upload = File to Upload 1!
     .files-to-upload = Files to Upload { $num }!
+        .placeholder = Files to Upload!
+
     .file-already-opened = File already opened
     .directory-already-with-name = There is already a directory with this name
     .no-size-available = No size available for file: { $file }

--- a/common/locales/pt-PT/main.ftl
+++ b/common/locales/pt-PT/main.ftl
@@ -133,7 +133,6 @@ files = Ficheiros
     .no-thumbnail = Sem miniatura
     .one-file-to-upload = Ficheiro para carregar: 1!
     .files-to-upload = Ficheiros a carregar { $num }!
-    .files-to-upload = Ficheiros a carregar
     .no-thumbnail-preview = Não existe uma miniatura de pré-visualização para este ficheiro
     .directory-already-with-name = Já existe um directório com este nome
     .no-size-available = Sem tamanho disponível para o ficheiro: { $file }

--- a/common/src/language/mod.rs
+++ b/common/src/language/mod.rs
@@ -62,10 +62,13 @@ pub fn get_local_text(text: &str) -> String {
 }
 
 // Looks and formats a local text using the given args
-pub fn get_local_text_with_args(text: &str, args: Vec<(&str, FluentValue<'_>)>) -> String {
+pub fn get_local_text_with_args<T>(text: &str, args: Vec<(&str, T)>) -> String
+where
+    T: ToString,
+{
     get_local_text_args_builder(text, |m| {
         for (key, val) in args {
-            m.insert(key, val);
+            m.insert(key, val.to_string().into());
         }
     })
 }

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -1303,7 +1303,7 @@ impl State {
 
             friends_by_first_letter
                 .entry(first_letter)
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(friend.clone());
         }
 

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -366,7 +366,7 @@ impl State {
                         get_local_text("friends.new-request"),
                         get_local_text_with_args(
                             "friends.new-request-name",
-                            vec![("name", identity.username().into())],
+                            vec![("name", identity.username())],
                         ),
                         Some(crate::sounds::Sounds::Notification),
                         notify_rust::Timeout::Milliseconds(4),
@@ -470,7 +470,7 @@ impl State {
                     let text = match id {
                         Some(id) => get_local_text_with_args(
                             "messages.user-sent-message",
-                            vec![("user", id.username().into())],
+                            vec![("user", id.username())],
                         ),
                         None => get_local_text("messages.unknown-sent-message"),
                     };

--- a/kit/Cargo.toml
+++ b/kit/Cargo.toml
@@ -29,6 +29,7 @@ once_cell = { workspace = true }
 emojis = "0.5"
 unic-segment = "0.9"
 unic-emoji-char = "0.9"
+log = { workspace = true }
 
 [dependencies.uuid]
 workspace = true

--- a/kit/src/components/embeds/file_embed/mod.rs
+++ b/kit/src/components/embeds/file_embed/mod.rs
@@ -57,6 +57,7 @@ pub struct Props<'a> {
 
 #[allow(non_snake_case)]
 pub fn FileEmbed<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
+    //log::trace!("rendering file embed: {}", cx.props.filename);
     let fullscreen_preview = use_state(cx, || false);
     let file_extension = std::path::Path::new(&cx.props.filename)
         .extension()
@@ -198,6 +199,23 @@ pub fn FileEmbed<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                             ),
                             src: "{thumbnail}",
                         }
+                        // if anyone asks for the file name from constellation, uncomment this. 
+                        // div {
+                        //     class: "file-info",
+                        //     width: "100%",
+                        //     aria_label: "file-info",
+                        //     p {
+                        //         class: "name",
+                        //         aria_label: "file-name",
+                        //         color: "var(--text-color)",
+                        //         "{filename}"
+                        //     },
+                        //     p {
+                        //         class: "meta",
+                        //         aria_label: "file-meta",
+                        //         "{file_description}"
+                        //     }
+                        // },
                         if with_download_button {
                             rsx!(Button {
                                         icon: btn_icon,

--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -693,7 +693,7 @@ pub fn IdentityMessage(cx: Scope<IdentityMessageProps>) -> Element {
                     onpress: move |_| {
                         ch.send(IdentityCmd::SentFriendRequest(identity.did_key().to_string(), state.read().outgoing_fr_identities()));
                     },
-                    text: get_local_text_with_args("friends.add-name", vec![("name", identity.username().into())]),
+                    text: get_local_text_with_args("friends.add-name", vec![("name", identity.username())]),
                     appearance: crate::elements::Appearance::Primary
                 }
             }));

--- a/kit/src/components/message_typing/mod.rs
+++ b/kit/src/components/message_typing/mod.rs
@@ -27,7 +27,7 @@ pub fn MessageTyping(cx: Scope<Props>) -> Element {
         } else {
             users
         };
-        get_local_text_with_args(translation, vec![(key, users.into())])
+        get_local_text_with_args(translation, vec![(key, users)])
     };
 
     cx.render(rsx! (

--- a/kit/src/elements/input/mod.rs
+++ b/kit/src/elements/input/mod.rs
@@ -220,7 +220,7 @@ fn validate_alphanumeric(
         }
         return Some(get_local_text_with_args(
             "warning-messages.disallowed-characters",
-            vec![("chars", t.into())],
+            vec![("chars", t)],
         ));
     }
 
@@ -236,7 +236,7 @@ pub fn validate_min_max(val: &str, min: Option<i32>, max: Option<i32>) -> Option
     if max > 0 && val.len() > max {
         return Some(get_local_text_with_args(
             "warning-messages.maximum-of",
-            vec![("num", max.into())],
+            vec![("num", max)],
         ));
     }
 
@@ -244,10 +244,7 @@ pub fn validate_min_max(val: &str, min: Option<i32>, max: Option<i32>) -> Option
     // then make sure the value's length is greater than or equal to the minimum
     if min > 0 && val.len() < min {
         return Some(if min > 1 {
-            get_local_text_with_args(
-                "warning-messages.please-enter-at-least",
-                vec![("num", min.into())],
-            )
+            get_local_text_with_args("warning-messages.please-enter-at-least", vec![("num", min)])
         } else {
             get_local_text("warning-messages.please-enter-at-least-one")
         });

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -63,7 +63,7 @@ reqwest = { workspace = true, default-features = false, features = [
     "rustls-tls",
     "stream",
 ] }
-log = { version = "0.4.17", features = ["std"] }
+log = { workspace = true }
 
 [features]
 default = ["dioxus-desktop/devtools"]

--- a/ui/src/components/files/attachments.rs
+++ b/ui/src/components/files/attachments.rs
@@ -20,73 +20,56 @@ pub struct AttachmentProps<'a> {
 pub fn Attachments<'a>(cx: Scope<'a, AttachmentProps>) -> Element<'a> {
     let state = use_shared_state::<State>(cx)?;
     let files_attached_to_send = cx.props.files_to_attach.clone();
-    let files_attached_to_send2 = files_attached_to_send.clone();
     let files_attached_to_send3 = files_attached_to_send;
 
     // todo: pick an icon based on the file extension
-    let attachments = cx.render(rsx!(files_attached_to_send2.iter().cloned().map(
-        |location| {
-            match location {
-                Location::Constellation { path } => {
-                    let path = path.clone();
-                    let filename = PathBuf::from(&path)
-                        .file_name()
-                        .map(|x| x.to_string_lossy().to_string())
-                        .unwrap_or_default();
-                    let warp_file = state
-                        .read()
-                        .storage
-                        .files
-                        .iter()
-                        .find(|x| x.name() == filename)
-                        .cloned();
+    let attachments = cx.render(rsx!(cx.props.files_to_attach.iter().map(|location| {
+        let (filename, filepath, thumbnail) = match &location {
+            Location::Constellation { path } => {
+                let filename = PathBuf::from(&path)
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string();
 
-                    let thumbnail = match warp_file {
-                        Some(f) => thumbnail_to_base64(&f),
-                        None => String::new(),
-                    };
+                let warp_file = state
+                    .read()
+                    .storage
+                    .files
+                    .iter()
+                    .find(|x| x.name() == filename)
+                    .cloned();
 
-                    rsx!(FileEmbed {
-                        filename: filename.clone(),
-                        filepath: PathBuf::from(&path),
-                        remote: false,
-                        button_icon: icons::outline::Shape::Minus,
-                        thumbnail: thumbnail,
-                        on_press: move |_| {
-                            let mut attachments = cx.props.files_to_attach.clone();
-                            attachments.retain(|location| match location {
-                                Location::Constellation { path: path2 } => *path2 != path,
-                                Location::Disk { .. } => true,
-                            });
-                            cx.props.on_remove.call(attachments);
-                        },
-                    })
-                }
-                Location::Disk { path } => {
-                    let filename = path
-                        .file_name()
-                        .unwrap_or_default()
-                        .to_string_lossy()
-                        .to_string();
+                let thumbnail = match warp_file {
+                    Some(f) => thumbnail_to_base64(&f),
+                    None => String::new(),
+                };
 
-                    rsx!(FileEmbed {
-                        filename: filename.clone(),
-                        filepath: path.clone(),
-                        remote: false,
-                        button_icon: icons::outline::Shape::Minus,
-                        on_press: move |_| {
-                            let mut attachments = cx.props.files_to_attach.clone();
-                            attachments.retain(|location| match location {
-                                Location::Constellation { .. } => true,
-                                Location::Disk { path: path2 } => *path2 != path,
-                            });
-                            cx.props.on_remove.call(attachments);
-                        },
-                    })
-                }
+                (filename, PathBuf::from(&path), thumbnail)
             }
-        }
-    )));
+            Location::Disk { path } => (
+                path.file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string(),
+                path.clone(),
+                String::new(),
+            ),
+        };
+
+        rsx!(FileEmbed {
+            filename: filename,
+            filepath: filepath,
+            remote: false,
+            thumbnail: thumbnail,
+            button_icon: icons::outline::Shape::Minus,
+            on_press: move |_| {
+                let mut attachments = cx.props.files_to_attach.clone();
+                attachments.retain(|location2| location2 != location);
+                cx.props.on_remove.call(attachments);
+            },
+        })
+    })));
 
     let attachments_vec = files_attached_to_send3;
 

--- a/ui/src/components/files/upload_progress_bar/mod.rs
+++ b/ui/src/components/files/upload_progress_bar/mod.rs
@@ -227,12 +227,9 @@ pub fn UploadProgressBar<'a>(cx: Scope<'a, Props>) -> Element<'a> {
 
 fn count_files_to_show(files_to_upload_len: usize) -> String {
     if files_to_upload_len > 1 {
-        get_local_text_with_args(
-            "files.files-to-upload",
-            vec![("num", files_to_upload_len.into())],
-        )
+        get_local_text_with_args("files.files-to-upload", vec![("num", files_to_upload_len)])
     } else {
-        get_local_text_with_args("files.one-file-to-upload", vec![("num", 1.into())])
+        get_local_text_with_args("files.one-file-to-upload", vec![("num", 1)])
     }
 }
 

--- a/ui/src/layouts/chats/mod.rs
+++ b/ui/src/layouts/chats/mod.rs
@@ -170,17 +170,15 @@ async fn drag_and_drop_function(
                     let mut script = OVERLAY_SCRIPT.replace("$IS_DRAGGING", "true");
                     let feedback_script = &FEEDBACK_TEXT_SCRIPT.replace(
                         "$TEXT",
-                        &format!(
-                            "{}"
-                            if paths.len() > 1 {
-                                get_local_text_with_args(
-                                    "files.files-to-upload",
-                                    vec![("num", paths.len())],
-                                )
-                            } else {
-                                get_local_text("files.one-file-to-upload")
-                            }
-                        ),
+                        &(if paths.len() > 1 {
+                            get_local_text_with_args(
+                                "files.files-to-upload",
+                                vec![("num", paths.len())],
+                            )
+                        } else {
+                            get_local_text("files.one-file-to-upload")
+                        })
+                        .to_string(),
                     );
                     script.push_str(feedback_script);
                     let _ = eval(&script);

--- a/ui/src/layouts/chats/mod.rs
+++ b/ui/src/layouts/chats/mod.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 use common::{
-    language::get_local_text,
+    language::{get_local_text, get_local_text_with_args},
     state::{ui, Action, State},
 };
 use dioxus::prelude::*;
@@ -171,10 +171,12 @@ async fn drag_and_drop_function(
                     let feedback_script = &FEEDBACK_TEXT_SCRIPT.replace(
                         "$TEXT",
                         &format!(
-                            "{} {}!",
-                            paths.len(),
+                            "{}"
                             if paths.len() > 1 {
-                                get_local_text("files.files-to-upload")
+                                get_local_text_with_args(
+                                    "files.files-to-upload",
+                                    vec![("num", paths.len())],
+                                )
                             } else {
                                 get_local_text("files.one-file-to-upload")
                             }

--- a/ui/src/layouts/chats/presentation/chat/topbar.rs
+++ b/ui/src/layouts/chats/presentation/chat/topbar.rs
@@ -90,7 +90,7 @@ pub fn get_topbar_children(cx: Scope<ChatProps>) -> Element {
     all_participants.push(active_participant);
     let members_count = get_local_text_with_args(
         "uplink.members-count",
-        vec![("num", all_participants.len().into())],
+        vec![("num", all_participants.len())],
     );
 
     let conv_id = data.active_chat.id();

--- a/ui/src/layouts/chats/presentation/chatbar.rs
+++ b/ui/src/layouts/chats/presentation/chatbar.rs
@@ -639,7 +639,7 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, ChatProps>) -> Element<'a> {
             p {
                 class: "chatbar-error-input-message",
                 aria_label: "chatbar-input-error",
-                get_local_text_with_args("warning-messages.maximum-of", vec![("num", MAX_CHARS_LIMIT.into())])
+                get_local_text_with_args("warning-messages.maximum-of", vec![("num", MAX_CHARS_LIMIT)])
             }
         ))
     ));

--- a/ui/src/layouts/chats/presentation/messages/mod.rs
+++ b/ui/src/layouts/chats/presentation/messages/mod.rs
@@ -244,7 +244,7 @@ fn render_message_group<'a>(cx: Scope<'a, MessageGroupProps<'a>>) -> Element<'a>
                 div {
                     class: "blocked-container",
                     p {
-                        get_local_text_with_args("messages.blocked", vec![("amount", messages.len().into())])
+                        get_local_text_with_args("messages.blocked", vec![("amount", messages.len())])
                     },
                     p {
                         style: "white-space: pre",
@@ -264,7 +264,7 @@ fn render_message_group<'a>(cx: Scope<'a, MessageGroupProps<'a>>) -> Element<'a>
             div {
                 class: "blocked-container",
                 p {
-                    get_local_text_with_args("messages.blocked", vec![("amount", messages.len().into())])
+                    get_local_text_with_args("messages.blocked", vec![("amount", messages.len())])
                 },
                 p {
                     style: "white-space: pre",

--- a/ui/src/layouts/chats/presentation/sidebar/mod.rs
+++ b/ui/src/layouts/chats/presentation/sidebar/mod.rs
@@ -291,7 +291,7 @@ pub fn Sidebar(cx: Scope<SidebarProps>) -> Element {
                             [] => get_local_text("sidebar.chat-new"),
                             [ file ] => file.name(),
                             _ => match participants.iter().find(|p| p.did_key()  == unwrapped_message.sender()).map(|x| x.username()) {
-                                Some(name) => get_local_text_with_args("sidebar.subtext", vec![("user", name.into())]),
+                                Some(name) => get_local_text_with_args("sidebar.subtext", vec![("user", name)]),
                                 None => {
                                     log::error!("error calculating subtext for sidebar chat");
                                     // Still return default message

--- a/ui/src/layouts/storage/functions.rs
+++ b/ui/src/layouts/storage/functions.rs
@@ -469,7 +469,7 @@ pub fn start_upload_file_listener(
                                     "".into(),
                                     get_local_text_with_args(
                                         "files.no-size-available",
-                                        vec![("file", file_name.into())],
+                                        vec![("file", file_name)],
                                     ),
                                     None,
                                     3,

--- a/ui/src/layouts/storage/send_files_layout/mod.rs
+++ b/ui/src/layouts/storage/send_files_layout/mod.rs
@@ -148,7 +148,7 @@ fn ChatsToSelect<'a>(cx: Scope<'a, ChatsToSelectProps<'a>>) -> Element<'a> {
                     [] => get_local_text("sidebar.chat-new"),
                     [ file ] => file.name(),
                     _ => match participants.iter().find(|p| p.did_key()  == unwrapped_message.sender()).map(|x| x.username()) {
-                        Some(name) => get_local_text_with_args("sidebar.subtext", vec![("user", name.into())]),
+                        Some(name) => get_local_text_with_args("sidebar.subtext", vec![("user", name)]),
                         None => {
                             log::error!("error calculating subtext for sidebar chat");
                             // Still return default message

--- a/ui/src/layouts/storage/send_files_layout/modal.rs
+++ b/ui/src/layouts/storage/send_files_layout/modal.rs
@@ -41,7 +41,6 @@ pub fn SendFilesLayoutModal<'a>(cx: Scope<'a, SendFilesLayoutModalProps<'a>>) ->
                             send_files_from_storage_state: send_files_from_storage.clone(),
                             files_pre_selected_to_send: files_pre_selected_to_send,
                             on_files_attached: move |(files_location, convs_id): (Vec<Location>, Vec<Uuid>)| {
-                                log::info!("files attached: {:?}", files_location);
                                 cx.props.on_send.call((files_location, convs_id));
                                 send_files_from_storage.set(false);
                             },

--- a/ui/src/layouts/storage/send_files_layout/modal.rs
+++ b/ui/src/layouts/storage/send_files_layout/modal.rs
@@ -41,6 +41,7 @@ pub fn SendFilesLayoutModal<'a>(cx: Scope<'a, SendFilesLayoutModalProps<'a>>) ->
                             send_files_from_storage_state: send_files_from_storage.clone(),
                             files_pre_selected_to_send: files_pre_selected_to_send,
                             on_files_attached: move |(files_location, convs_id): (Vec<Location>, Vec<Uuid>)| {
+                                log::info!("files attached: {:?}", files_location);
                                 cx.props.on_send.call((files_location, convs_id));
                                 send_files_from_storage.set(false);
                             },

--- a/ui/src/layouts/storage/send_files_layout/send_files_components.rs
+++ b/ui/src/layouts/storage/send_files_layout/send_files_components.rs
@@ -65,7 +65,7 @@ pub fn SendFilesTopbar<'a>(
                     },
                 },
                 Button {
-                    text: get_local_text_with_args("files.send-files-text-amount", vec![("amount", format!("{}/{}", storage_controller.with(|f| f.files_selected_to_send.clone()).len(), MAX_FILES_PER_MESSAGE).into())]),
+                    text: get_local_text_with_args("files.send-files-text-amount", vec![("amount", format!("{}/{}", storage_controller.with(|f| f.files_selected_to_send.clone()).len(), MAX_FILES_PER_MESSAGE))]),
                     aria_label: "send_files_modal_send_button".into(),
                     disabled: storage_controller.with(|f| f.files_selected_to_send.is_empty() || (*in_files && f.chats_selected_to_send.is_empty())),
                     appearance: Appearance::Primary,

--- a/ui/src/layouts/unlock.rs
+++ b/ui/src/layouts/unlock.rs
@@ -329,5 +329,5 @@ fn get_welcome_message(state: &State) -> String {
         None => String::from("UNKNOWN"),
     };
 
-    get_local_text_with_args("unlock.welcome", vec![("name", name.into())])
+    get_local_text_with_args("unlock.welcome", vec![("name", name)])
 }

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -754,13 +754,11 @@ fn get_update_icon(cx: Scope) -> Element {
         None => return cx.render(rsx!("")),
     };
 
-    let update_msg = get_local_text_with_args(
-        "uplink.update-available",
-        vec![("version", new_version.into())],
-    );
+    let update_msg =
+        get_local_text_with_args("uplink.update-available", vec![("version", new_version)]);
     let downloading_msg = get_local_text_with_args(
         "uplink.update-downloading",
-        vec![("progress", (download_state.read().progress as u32).into())],
+        vec![("progress", download_state.read().progress as u32)],
     );
     let downloaded_msg = get_local_text("uplink.update-downloaded");
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- shows thumbnails for images attached from constellation. 
- and fix a misuse of get_local_text - if it has an arg, this will crash. 
- improves `get_local_text_with_args` - made the function  generic so that you don't have to type `.into()` every time. See here: `common/src/language/mod.rs`

### Which issue(s) this PR fixes 🔨

- Resolve #1400 
- Resolve #1419 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

