### PR TITLE
fix(chatbar): don't close emoji picker on scroll

### DIFF
--- a/ui/src/layouts/chats/data/chat_props.rs
+++ b/ui/src/layouts/chats/data/chat_props.rs
@@ -1,3 +1,4 @@
+use common::state::Identity;
 use dioxus::prelude::*;
 use uuid::Uuid;
 use warp::raygun;
@@ -12,7 +13,7 @@ pub struct ChatProps {
 }
 
 #[derive(PartialEq, Props)]
-pub struct ChatBarProps {
+pub struct ChatbarProps {
     pub show_edit_group: UseState<Option<Uuid>>,
     pub show_group_users: UseState<Option<Uuid>>,
     pub ignore_focus: bool,
@@ -20,5 +21,5 @@ pub struct ChatBarProps {
     pub replying_to: Option<raygun::Message>,
     pub chat_initialized: bool,
     pub chat_id: Option<Uuid>,
-    pub other_participants: Vec<Uuid>,
+    pub other_participants: Vec<Identity>,
 }

--- a/ui/src/layouts/chats/data/chat_props.rs
+++ b/ui/src/layouts/chats/data/chat_props.rs
@@ -1,5 +1,6 @@
 use dioxus::prelude::*;
 use uuid::Uuid;
+use warp::raygun;
 
 #[derive(PartialEq, Props)]
 pub struct ChatProps {
@@ -8,4 +9,16 @@ pub struct ChatProps {
     pub ignore_focus: bool,
     pub is_owner: bool,
     pub is_edit_group: bool,
+}
+
+#[derive(PartialEq, Props)]
+pub struct ChatBarProps {
+    pub show_edit_group: UseState<Option<Uuid>>,
+    pub show_group_users: UseState<Option<Uuid>>,
+    pub ignore_focus: bool,
+    pub is_owner: bool,
+    pub replying_to: Option<raygun::Message>,
+    pub chat_initialized: bool,
+    pub chat_id: Option<Uuid>,
+    pub other_participants: Vec<Uuid>,
 }

--- a/ui/src/layouts/chats/data/chat_props.rs
+++ b/ui/src/layouts/chats/data/chat_props.rs
@@ -1,7 +1,5 @@
-use common::state::Identity;
 use dioxus::prelude::*;
 use uuid::Uuid;
-use warp::raygun;
 
 #[derive(PartialEq, Props)]
 pub struct ChatProps {
@@ -10,17 +8,4 @@ pub struct ChatProps {
     pub ignore_focus: bool,
     pub is_owner: bool,
     pub is_edit_group: bool,
-}
-
-#[derive(PartialEq, Props)]
-pub struct ChatbarProps {
-    pub show_edit_group: UseState<Option<Uuid>>,
-    pub show_group_users: UseState<Option<Uuid>>,
-    pub ignore_focus: bool,
-    pub is_owner: bool,
-    #[props(!optional)]
-    pub replying_to: Option<raygun::Message>,
-    pub chat_initialized: bool,
-    pub chat_id: Uuid,
-    pub other_participants: Vec<Identity>,
 }

--- a/ui/src/layouts/chats/data/chat_props.rs
+++ b/ui/src/layouts/chats/data/chat_props.rs
@@ -18,8 +18,9 @@ pub struct ChatbarProps {
     pub show_group_users: UseState<Option<Uuid>>,
     pub ignore_focus: bool,
     pub is_owner: bool,
+    #[props(!optional)]
     pub replying_to: Option<raygun::Message>,
     pub chat_initialized: bool,
-    pub chat_id: Option<Uuid>,
+    pub chat_id: Uuid,
     pub other_participants: Vec<Identity>,
 }

--- a/ui/src/layouts/chats/data/chatbar/mod.rs
+++ b/ui/src/layouts/chats/data/chatbar/mod.rs
@@ -1,0 +1,8 @@
+pub type ChatInput = (Vec<String>, Uuid, Option<Uuid>, Option<Uuid>);
+
+mod typing_indicator;
+mod typing_info;
+
+pub use typing_indicator::*;
+pub use typing_info::*;
+use uuid::Uuid;

--- a/ui/src/layouts/chats/data/chatbar/typing_indicator.rs
+++ b/ui/src/layouts/chats/data/chatbar/typing_indicator.rs
@@ -1,0 +1,10 @@
+#[derive(Eq, PartialEq)]
+pub enum TypingIndicator {
+    // reset the typing indicator timer
+    Typing(uuid::Uuid),
+    // clears the typing indicator, ensuring the indicator
+    // will not be refreshed
+    NotTyping,
+    // resend the typing indicator
+    Refresh(uuid::Uuid),
+}

--- a/ui/src/layouts/chats/data/chatbar/typing_info.rs
+++ b/ui/src/layouts/chats/data/chatbar/typing_info.rs
@@ -1,0 +1,5 @@
+#[derive(Clone)]
+pub struct TypingInfo {
+    pub chat_id: uuid::Uuid,
+    pub last_update: std::time::Instant,
+}

--- a/ui/src/layouts/chats/data/mod.rs
+++ b/ui/src/layouts/chats/data/mod.rs
@@ -1,5 +1,6 @@
 mod chat_data;
 mod chat_props;
+mod chatbar;
 mod js_msg;
 mod misc;
 mod msg_group;
@@ -7,6 +8,7 @@ mod scroll_btn;
 
 pub use chat_data::*;
 pub use chat_props::*;
+pub use chatbar::*;
 pub use js_msg::*;
 pub use misc::*;
 pub use msg_group::*;

--- a/ui/src/layouts/chats/presentation/chat/mod.rs
+++ b/ui/src/layouts/chats/presentation/chat/mod.rs
@@ -47,7 +47,8 @@ pub fn Compose(cx: Scope) -> Element {
     let show_edit_group: &UseState<Option<Uuid>> = use_state(cx, || None);
     let show_group_users: &UseState<Option<Uuid>> = use_state(cx, || None);
 
-    let should_ignore_focus = state.read().ui.ignore_focus;
+    // if the emoji picker is visible, autofocusing on the chatbar will close the emoji picker.
+    let should_ignore_focus = state.read().ui.ignore_focus || state.read().ui.emoji_picker_visible;
     let creator = chat_data.read().active_chat.creator();
 
     let chat_id = chat_data.read().active_chat.id();

--- a/ui/src/layouts/chats/presentation/chatbar/coroutines.rs
+++ b/ui/src/layouts/chats/presentation/chatbar/coroutines.rs
@@ -1,18 +1,21 @@
-use std::path::PathBuf;
+use std::{
+    path::PathBuf,
+    time::{Duration, Instant},
+};
 
 use common::{
     state::{Action, State},
     warp_runner::{RayGunCmd, WarpCmd},
-    WARP_CMD_CH,
+    STATIC_ARGS, WARP_CMD_CH,
 };
 use dioxus::prelude::*;
 use futures::{channel::oneshot, StreamExt};
 use uuid::Uuid;
-use warp::raygun::Location;
+use warp::raygun::{self, Location};
 
 use crate::layouts::chats::data::{self, ChatProps, DEFAULT_MESSAGES_TO_TAKE};
 
-use super::ChatInput;
+use super::{ChatInput, TypingIndicator, TypingInfo};
 
 pub fn get_msg_ch<'a>(
     cx: &Scoped<'a, ChatProps>,
@@ -119,6 +122,84 @@ pub fn get_scroll_ch<'a>(
                         );
                     }
                     Err(e) => log::error!("{e}"),
+                }
+            }
+        }
+    })
+    .clone()
+}
+
+// typing indicator notes
+// consider side A, the local side, and side B, the remote side
+// side A -> (typing indicator) -> side B
+// side B removes the typing indicator after a timeout
+// side A doesn't want to send too many typing indicators, say once every 4-5 seconds
+// should we consider matching the timeout with the send frequency so we can closely match if a person is straight up typing for 5 mins straight.
+
+// tracks if the local participant is typing
+// re-sends typing indicator in response to the Refresh command
+pub fn get_typing_ch<'a>(cx: &Scoped<'a, ChatProps>) -> Coroutine<TypingIndicator> {
+    use_coroutine(cx, |mut rx: UnboundedReceiver<TypingIndicator>| {
+        // to_owned![];
+        async move {
+            let mut typing_info: Option<TypingInfo> = None;
+            let warp_cmd_tx = WARP_CMD_CH.tx.clone();
+
+            let send_typing_indicator = |conv_id| async move {
+                let (tx, rx) = oneshot::channel::<Result<(), warp::error::Error>>();
+                let event = raygun::MessageEvent::Typing;
+                if let Err(e) = warp_cmd_tx.send(WarpCmd::RayGun(RayGunCmd::SendEvent {
+                    conv_id,
+                    event,
+                    rsp: tx,
+                })) {
+                    log::error!("failed to send warp command: {}", e);
+                    // return from the closure
+                    return;
+                }
+                let rsp = rx.await.expect("command canceled");
+                if let Err(e) = rsp {
+                    log::error!("failed to send typing indicator: {}", e);
+                }
+            };
+
+            while let Some(indicator) = rx.next().await {
+                match indicator {
+                    TypingIndicator::Typing(chat_id) => {
+                        // if typing_info was none or the chat id changed, send the indicator immediately
+                        let should_send_indicator = match typing_info {
+                            None => true,
+                            Some(info) => info.chat_id != chat_id,
+                        };
+                        if should_send_indicator {
+                            send_typing_indicator.clone()(chat_id).await;
+                        }
+                        typing_info = Some(TypingInfo {
+                            chat_id,
+                            last_update: Instant::now(),
+                        });
+                    }
+                    TypingIndicator::NotTyping => {
+                        typing_info = None;
+                    }
+                    TypingIndicator::Refresh(conv_id) => {
+                        let info = match &typing_info {
+                            Some(i) => i.clone(),
+                            None => continue,
+                        };
+                        if info.chat_id != conv_id {
+                            typing_info = None;
+                            continue;
+                        }
+                        // todo: verify duration for timeout
+                        let now = Instant::now();
+                        if now - info.last_update
+                            <= (Duration::from_secs(STATIC_ARGS.typing_indicator_timeout)
+                                - Duration::from_millis(500))
+                        {
+                            send_typing_indicator.clone()(conv_id).await;
+                        }
+                    }
                 }
             }
         }

--- a/ui/src/layouts/chats/presentation/chatbar/coroutines.rs
+++ b/ui/src/layouts/chats/presentation/chatbar/coroutines.rs
@@ -13,9 +13,11 @@ use futures::{channel::oneshot, StreamExt};
 use uuid::Uuid;
 use warp::raygun::{self, Location};
 
-use crate::layouts::chats::data::{self, ChatProps, DEFAULT_MESSAGES_TO_TAKE};
+use crate::layouts::chats::data::{
+    self, ChatInput, ChatProps, TypingInfo, DEFAULT_MESSAGES_TO_TAKE,
+};
 
-use super::{ChatInput, TypingIndicator, TypingInfo};
+use super::TypingIndicator;
 
 pub type MsgChInput = (Vec<String>, Uuid, Option<Uuid>, Option<Uuid>);
 pub fn get_msg_ch(

--- a/ui/src/layouts/chats/presentation/chatbar/coroutines.rs
+++ b/ui/src/layouts/chats/presentation/chatbar/coroutines.rs
@@ -18,8 +18,8 @@ use crate::layouts::chats::data::{self, ChatProps, DEFAULT_MESSAGES_TO_TAKE};
 use super::{ChatInput, TypingIndicator, TypingInfo};
 
 pub type msg_ch_input = (Vec<String>, Uuid, Option<Uuid>, Option<Uuid>);
-pub fn get_msg_ch<'a>(
-    cx: &Scoped<'a, ChatProps>,
+pub fn get_msg_ch(
+    cx: &Scoped<'_, ChatProps>,
     state: &UseSharedState<State>,
 ) -> Coroutine<msg_ch_input> {
     use_coroutine(cx, |mut rx: UnboundedReceiver<ChatInput>| {
@@ -97,8 +97,8 @@ pub fn get_msg_ch<'a>(
     .clone()
 }
 
-pub fn get_scroll_ch<'a>(
-    cx: &Scoped<'a, ChatProps>,
+pub fn get_scroll_ch(
+    cx: &Scoped<'_, ChatProps>,
     chat_data: &UseSharedState<data::ChatData>,
     state: &UseSharedState<State>,
 ) -> Coroutine<Uuid> {
@@ -138,7 +138,7 @@ pub fn get_scroll_ch<'a>(
 
 // tracks if the local participant is typing
 // re-sends typing indicator in response to the Refresh command
-pub fn get_typing_ch<'a>(cx: &Scoped<'a, ChatProps>) -> Coroutine<TypingIndicator> {
+pub fn get_typing_ch(cx: &Scoped<'_, ChatProps>) -> Coroutine<TypingIndicator> {
     use_coroutine(cx, |mut rx: UnboundedReceiver<TypingIndicator>| {
         // to_owned![];
         async move {

--- a/ui/src/layouts/chats/presentation/chatbar/coroutines.rs
+++ b/ui/src/layouts/chats/presentation/chatbar/coroutines.rs
@@ -1,0 +1,127 @@
+use std::path::PathBuf;
+
+use common::{
+    state::{Action, State},
+    warp_runner::{RayGunCmd, WarpCmd},
+    WARP_CMD_CH,
+};
+use dioxus::prelude::*;
+use futures::{channel::oneshot, StreamExt};
+use uuid::Uuid;
+use warp::raygun::Location;
+
+use crate::layouts::chats::data::{self, ChatProps, DEFAULT_MESSAGES_TO_TAKE};
+
+use super::ChatInput;
+
+pub fn get_msg_ch<'a>(
+    cx: &Scoped<'a, ChatProps>,
+    chat_data: &UseSharedState<data::ChatData>,
+    state: &UseSharedState<State>,
+) -> Coroutine<(Vec<String>, Uuid, Option<Uuid>, Option<Uuid>)> {
+    use_coroutine(cx, |mut rx: UnboundedReceiver<ChatInput>| {
+        to_owned![state];
+        async move {
+            let warp_cmd_tx = WARP_CMD_CH.tx.clone();
+            while let Some((msg, conv_id, ui_msg_id, reply)) = rx.next().await {
+                let (tx, rx) = oneshot::channel::<Result<(), warp::error::Error>>();
+                let attachments = state
+                    .read()
+                    .get_active_chat()
+                    .map(|f| f.files_attached_to_send)
+                    .unwrap_or_default();
+                let msg_clone = msg.clone();
+                let cmd = match reply {
+                    Some(reply_to) => RayGunCmd::Reply {
+                        conv_id,
+                        reply_to,
+                        msg,
+                        attachments,
+                        rsp: tx,
+                    },
+                    None => RayGunCmd::SendMessage {
+                        conv_id,
+                        msg,
+                        attachments,
+                        ui_msg_id,
+                        rsp: tx,
+                    },
+                };
+                let attachments = state
+                    .read()
+                    .get_active_chat()
+                    .map(|f| f.files_attached_to_send)
+                    .unwrap_or_default();
+                state
+                    .write_silent()
+                    .mutate(Action::ClearChatAttachments(conv_id));
+                let attachment_files: Vec<String> = attachments
+                    .iter()
+                    .map(|p| {
+                        let pathbuf = match p {
+                            Location::Disk { path } => path.clone(),
+                            Location::Constellation { path } => PathBuf::from(path),
+                        };
+                        pathbuf
+                            .file_name()
+                            .map_or_else(String::new, |ostr| ostr.to_string_lossy().to_string())
+                    })
+                    .collect();
+                if let Err(e) = warp_cmd_tx.send(WarpCmd::RayGun(cmd)) {
+                    log::error!("failed to send warp command: {}", e);
+                    state.write().decrement_outgoing_messages(
+                        conv_id,
+                        msg_clone,
+                        attachment_files,
+                        ui_msg_id,
+                    );
+                    continue;
+                }
+
+                let rsp = rx.await.expect("command canceled");
+                if let Err(e) = rsp {
+                    log::error!("failed to send message: {}", e);
+                    state.write().decrement_outgoing_messages(
+                        conv_id,
+                        msg_clone,
+                        attachment_files,
+                        ui_msg_id,
+                    );
+                }
+            }
+        }
+    })
+    .clone()
+}
+
+pub fn get_scroll_ch<'a>(
+    cx: &Scoped<'a, ChatProps>,
+    chat_data: &UseSharedState<data::ChatData>,
+    state: &UseSharedState<State>,
+) -> Coroutine<Uuid> {
+    use_coroutine(cx, |mut rx: UnboundedReceiver<Uuid>| {
+        to_owned![chat_data, state];
+        async move {
+            while let Some(conv_id) = rx.next().await {
+                match crate::layouts::chats::presentation::chat::coroutines::fetch_most_recent(
+                    conv_id,
+                    DEFAULT_MESSAGES_TO_TAKE,
+                )
+                .await
+                {
+                    Ok((messages, behavior)) => {
+                        log::debug!("re-init messages with most recent");
+                        chat_data.write().set_active_chat(
+                            &state.read(),
+                            &conv_id,
+                            behavior,
+                            messages,
+                        );
+                    }
+                    Err(e) => log::error!("{e}"),
+                }
+            }
+        }
+    })
+    .clone()
+}

--- a/ui/src/layouts/chats/presentation/chatbar/coroutines.rs
+++ b/ui/src/layouts/chats/presentation/chatbar/coroutines.rs
@@ -17,11 +17,12 @@ use crate::layouts::chats::data::{self, ChatProps, DEFAULT_MESSAGES_TO_TAKE};
 
 use super::{ChatInput, TypingIndicator, TypingInfo};
 
+pub type msg_ch_input = (Vec<String>, Uuid, Option<Uuid>, Option<Uuid>);
 pub fn get_msg_ch<'a>(
     cx: &Scoped<'a, ChatProps>,
     chat_data: &UseSharedState<data::ChatData>,
     state: &UseSharedState<State>,
-) -> Coroutine<(Vec<String>, Uuid, Option<Uuid>, Option<Uuid>)> {
+) -> Coroutine<msg_ch_input> {
     use_coroutine(cx, |mut rx: UnboundedReceiver<ChatInput>| {
         to_owned![state];
         async move {

--- a/ui/src/layouts/chats/presentation/chatbar/coroutines.rs
+++ b/ui/src/layouts/chats/presentation/chatbar/coroutines.rs
@@ -20,7 +20,6 @@ use super::{ChatInput, TypingIndicator, TypingInfo};
 pub type msg_ch_input = (Vec<String>, Uuid, Option<Uuid>, Option<Uuid>);
 pub fn get_msg_ch<'a>(
     cx: &Scoped<'a, ChatProps>,
-    chat_data: &UseSharedState<data::ChatData>,
     state: &UseSharedState<State>,
 ) -> Coroutine<msg_ch_input> {
     use_coroutine(cx, |mut rx: UnboundedReceiver<ChatInput>| {

--- a/ui/src/layouts/chats/presentation/chatbar/coroutines.rs
+++ b/ui/src/layouts/chats/presentation/chatbar/coroutines.rs
@@ -17,11 +17,11 @@ use crate::layouts::chats::data::{self, ChatProps, DEFAULT_MESSAGES_TO_TAKE};
 
 use super::{ChatInput, TypingIndicator, TypingInfo};
 
-pub type msg_ch_input = (Vec<String>, Uuid, Option<Uuid>, Option<Uuid>);
+pub type MsgChInput = (Vec<String>, Uuid, Option<Uuid>, Option<Uuid>);
 pub fn get_msg_ch(
     cx: &Scoped<'_, ChatProps>,
     state: &UseSharedState<State>,
-) -> Coroutine<msg_ch_input> {
+) -> Coroutine<MsgChInput> {
     use_coroutine(cx, |mut rx: UnboundedReceiver<ChatInput>| {
         to_owned![state];
         async move {

--- a/ui/src/layouts/chats/presentation/chatbar/mod.rs
+++ b/ui/src/layouts/chats/presentation/chatbar/mod.rs
@@ -9,11 +9,10 @@ use common::{
     icons::{self},
     language::{get_local_text, get_local_text_with_args},
     state::{Action, Identity, State},
-    warp_runner::{RayGunCmd, WarpCmd},
-    MAX_FILES_PER_MESSAGE, STATIC_ARGS, WARP_CMD_CH,
+    MAX_FILES_PER_MESSAGE, STATIC_ARGS,
 };
 use dioxus::prelude::*;
-use futures::{channel::oneshot, StreamExt};
+use futures::{StreamExt};
 use kit::{
     components::{
         indicator::{Platform, Status},
@@ -33,7 +32,7 @@ use uuid::Uuid;
 use warp::{
     crypto::DID,
     logging::tracing::log,
-    raygun::{self, Location},
+    raygun::{Location},
 };
 
 const MAX_CHARS_LIMIT: usize = 1024;
@@ -44,7 +43,7 @@ use crate::{
     layouts::chats::{data::ChatProps, scripts::SHOW_CONTEXT},
     layouts::{
         chats::{
-            data::{self, ChatData, ScrollBtn, DEFAULT_MESSAGES_TO_TAKE},
+            data::{self, ChatData, ScrollBtn},
             presentation::chatbar::coroutines::msg_ch_input,
         },
         storage::send_files_layout::{modal::SendFilesLayoutModal, SendFilesStartLocation},
@@ -93,8 +92,8 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, ChatProps>) -> Element<'a> {
     render!(get_chatbar_internal {
         show_edit_group: cx.props.show_edit_group.clone(),
         show_group_users: cx.props.show_group_users.clone(),
-        ignore_focus: cx.props.ignore_focus.clone(),
-        is_owner: cx.props.is_owner.clone(),
+        ignore_focus: cx.props.ignore_focus,
+        is_owner: cx.props.is_owner,
         replying_to: chat_data.read().active_chat.replying_to(),
         chat_initialized: chat_data.read().active_chat.is_initialized,
         chat_id: chat_data.read().active_chat.id(),
@@ -277,7 +276,7 @@ fn get_chatbar_internal<'a>(cx: &'a Scoped<'a, data::ChatbarProps>) -> Element<'
         }
     };
 
-    let submit_fn2 = submit_fn.clone();
+    let submit_fn2 = submit_fn;
 
     let extensions = &state.read().ui.extensions;
     let ext_renders = extensions

--- a/ui/src/layouts/chats/presentation/chatbar/mod.rs
+++ b/ui/src/layouts/chats/presentation/chatbar/mod.rs
@@ -109,8 +109,8 @@ fn get_chatbar_internal<'a>(cx: &'a Scoped<'a, data::ChatbarProps>) -> Element<'
     state.write_silent().scope_ids.chatbar = Some(cx.scope_id().0);
 
     let is_loading = cx.props.chat_initialized;
-    let active_chat_id = cx.props.chat_id.unwrap_or_default();
-    let chat_id = cx.props.chat_id.unwrap_or_default();
+    let active_chat_id = cx.props.chat_id;
+    let chat_id = cx.props.chat_id;
     let can_send = use_state(cx, || state.read().active_chat_has_draft());
     let update_script = use_state(cx, String::new);
     let upload_button_menu_uuid = &*cx.use_hook(|| Uuid::new_v4().to_string());
@@ -415,7 +415,7 @@ fn get_chatbar_internal<'a>(cx: &'a Scoped<'a, data::ChatbarProps>) -> Element<'
             with_replying_to: (!disabled).then(|| {
                 cx.render(
                     rsx!(
-                        cx.props.replying_to.map(|msg| {
+                        cx.props.replying_to.as_ref().map(|msg| {
                             let our_did = state.read().did_key();
                             let msg_owner = if state.read().did_key() == msg.sender() {
                                 state.read().get_identity(&state.read().did_key())
@@ -430,7 +430,7 @@ fn get_chatbar_internal<'a>(cx: &'a Scoped<'a, data::ChatbarProps>) -> Element<'
                                     label: get_local_text("messages.replying"),
                                     remote: our_did != msg.sender(),
                                     onclose: move |_| {
-                                        state.write().mutate(Action::CancelReply(cx.props.chat_id.unwrap_or_default()))
+                                        state.write().mutate(Action::CancelReply(cx.props.chat_id))
                                     },
                                     attachments: msg.attachments(),
                                     message: msg.lines().join("\n"), 

--- a/ui/src/layouts/chats/presentation/chatbar/mod.rs
+++ b/ui/src/layouts/chats/presentation/chatbar/mod.rs
@@ -81,7 +81,7 @@ fn get_chatbar_internal<'a>(cx: &'a Scoped<'a, data::ChatbarProps>) -> Element<'
     let scroll_btn = use_shared_state::<ScrollBtn>(cx)?;
     state.write_silent().scope_ids.chatbar = Some(cx.scope_id().0);
 
-    let is_loading = cx.props.chat_initialized;
+    let is_loading = !cx.props.chat_initialized;
     let active_chat_id = cx.props.chat_id;
     let chat_id = cx.props.chat_id;
     let can_send = use_state(cx, || state.read().active_chat_has_draft());

--- a/ui/src/layouts/chats/presentation/chatbar/mod.rs
+++ b/ui/src/layouts/chats/presentation/chatbar/mod.rs
@@ -1,9 +1,6 @@
 mod coroutines;
 
-use std::{
-    path::PathBuf,
-    time::{Duration, Instant},
-};
+use std::{path::PathBuf, time::Duration};
 
 use common::{
     icons::{self},
@@ -38,7 +35,7 @@ use crate::{
     layouts::chats::{data::ChatProps, scripts::SHOW_CONTEXT},
     layouts::{
         chats::{
-            data::{self, ChatData, ScrollBtn},
+            data::{self, ChatData, ScrollBtn, TypingIndicator},
             presentation::chatbar::coroutines::MsgChInput,
         },
         storage::send_files_layout::{modal::SendFilesLayoutModal, SendFilesStartLocation},
@@ -50,25 +47,6 @@ use crate::{
         },
     },
 };
-
-type ChatInput = (Vec<String>, Uuid, Option<Uuid>, Option<Uuid>);
-
-#[derive(Eq, PartialEq)]
-pub enum TypingIndicator {
-    // reset the typing indicator timer
-    Typing(Uuid),
-    // clears the typing indicator, ensuring the indicator
-    // will not be refreshed
-    NotTyping,
-    // resend the typing indicator
-    Refresh(Uuid),
-}
-
-#[derive(Clone)]
-struct TypingInfo {
-    pub chat_id: Uuid,
-    pub last_update: Instant,
-}
 
 pub fn get_chatbar<'a>(cx: &'a Scoped<'a, ChatProps>) -> Element<'a> {
     log::trace!("get_chatbar");

--- a/ui/src/layouts/chats/presentation/chatbar/mod.rs
+++ b/ui/src/layouts/chats/presentation/chatbar/mod.rs
@@ -86,7 +86,7 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, ChatProps>) -> Element<'a> {
     let _scroll_ch = coroutines::get_scroll_ch(cx, chat_data, state);
 
     let _msg_ch: Coroutine<(Vec<String>, Uuid, Option<Uuid>, Option<Uuid>)> =
-        coroutines::get_msg_ch(cx, chat_data, state);
+        coroutines::get_msg_ch(cx, state);
 
     let _local_typing_ch = coroutines::get_typing_ch(cx);
 

--- a/ui/src/layouts/chats/presentation/messages/coroutines.rs
+++ b/ui/src/layouts/chats/presentation/messages/coroutines.rs
@@ -108,7 +108,7 @@ pub fn hangle_msg_scroll(
                                 Ok(s) => match serde_json::from_str::<JsMsg>(s.as_str().unwrap_or_default()) {
                                     Ok(msg) => {
                                         // note: if something is wrong with messages, the first thing you should do is to uncomment this log
-                                        // log::debug!("{:?}", msg);
+                                        log::trace!("{:?}", msg);
                                         // perhaps this is redundant now that the IntersectionObserver self terminates.
                                         let is_evt_valid = matches!(msg, JsMsg::Top { key }
                                             | JsMsg::Bottom { key }
@@ -156,10 +156,9 @@ pub fn hangle_msg_scroll(
                                     JsMsg::Add { msg_id, .. } => {
                                         chat_data.write_silent().add_message_to_view(conv_id, msg_id);
                                         let chat_behavior = chat_data.read().get_chat_behavior(conv_id);
-                                        let msg_end = chat_data.read().active_chat.messages.bottom();
                                         // a message can be added to the top of the view without removing a message from the bottom of the view.
                                         // need to explicitly compare the bottom of messages.all and messages.displayed
-                                        if chat_data.read().get_bottom_of_view(conv_id).map(|pm| matches!(msg_end, Some(x) if x == pm.message_id)).unwrap_or_default() {
+                                        if chat_data.read().get_bottom_of_view(conv_id).map(|pm|  pm.message_id) == chat_data.read().active_chat.messages.bottom(){
                                             // have to check on_scroll_end in case the user scrolled up and switched chats.
                                             if chat_behavior.on_scroll_end == data::ScrollBehavior::DoNothing && scroll_btn.read().get(conv_id) {
                                                 scroll_btn.write().clear(conv_id);

--- a/ui/src/layouts/chats/presentation/messages/coroutines.rs
+++ b/ui/src/layouts/chats/presentation/messages/coroutines.rs
@@ -108,7 +108,7 @@ pub fn hangle_msg_scroll(
                                 Ok(s) => match serde_json::from_str::<JsMsg>(s.as_str().unwrap_or_default()) {
                                     Ok(msg) => {
                                         // note: if something is wrong with messages, the first thing you should do is to uncomment this log
-                                        log::trace!("{:?}", msg);
+                                        //log::trace!("{:?}", msg);
                                         // perhaps this is redundant now that the IntersectionObserver self terminates.
                                         let is_evt_valid = matches!(msg, JsMsg::Top { key }
                                             | JsMsg::Bottom { key }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- prevents the chatbar from auto-focusing while the emoji picker is open. 
- moved some `use_coroutines` into their own files, to make `get_chatbar` smaller. 

### Which issue(s) this PR fixes 🔨

- Resolve #1416 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
I bet the typing indicator causes the emoji picker to close. but that's a separate issue. one could probably fix that by removing the dependency on State. 
