### PR TITLE
fix(sidebar): Update some layouts for search bar results

### DIFF
--- a/ui/src/layouts/chats/presentation/sidebar/search.rs
+++ b/ui/src/layouts/chats/presentation/sidebar/search.rs
@@ -108,10 +108,11 @@ pub fn search_friends<'a>(cx: Scope<'a, SearchProps<'a>>) -> Element<'a> {
                                 div {
                                     padding_right: "32px",
                                     aria_label: "search-result-blocked-user",
+                                    display: "flex",
                                     IconElement {
                                         size: 40,
                                         fill: "var(--text-color-muted)",
-                                        icon: Icon::NoSymbol,
+                                        icon: Icon::UserBlocked,
                                     },
                                 }
                             )
@@ -273,11 +274,12 @@ pub fn search_friends<'a>(cx: Scope<'a, SearchProps<'a>>) -> Element<'a> {
                                     rsx!(
                                         div {
                                             padding_right: "32px",
+                                            display: "flex",
                                             aria_label: "search-result-blocked-user-in-group",
                                             IconElement {
                                                 size: 40,
                                                 fill: "var(--text-color-muted)",
-                                                icon: Icon::NoSymbol,
+                                                icon: Icon::UserBlocked,
                                             },
                                         }
                                     )

--- a/ui/src/layouts/chats/style.scss
+++ b/ui/src/layouts/chats/style.scss
@@ -243,6 +243,10 @@
     padding-left: 16px;
     padding-bottom: 4px;
     margin-bottom: 4px;
+    div {
+      margin-top: auto;
+      margin-bottom: auto;
+    }
     #profile-image {
       margin: var(--gap-less);
       //TODO(Lucas): Look to it, should be width: var(--height-input);


### PR DESCRIPTION
### What this PR does 📖

- Changes the blocked icon that appears in the sidebar search. Should be more clear now what it represents
- Centers various ui components in the search result

First is the old layout. Second is the new one
<img width="354" alt="Screenshot 2023-11-03 at 18 58 44" src="https://github.com/Satellite-im/Uplink/assets/34157027/d15e08a2-6da9-40de-8f7e-b68fa18dea51">
<img width="356" alt="Screenshot 2023-11-03 at 18 58 33" src="https://github.com/Satellite-im/Uplink/assets/34157027/5c38d7a7-387a-42fe-a87c-224473063228">

### Which issue(s) this PR fixes 🔨

- Resolve #1373
