### PR TITLE
chore(appium): remove build ubuntu step on ui automated tests

### DIFF
--- a/.github/workflows/ui-test-automation.yml
+++ b/.github/workflows/ui-test-automation.yml
@@ -13,31 +13,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build-ubuntu:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout App directory 🔖
-        uses: actions/checkout@v3
-
-      - name: Get latest package list
-        run: sudo apt-get update
-
-      - name: Install libwebkit2gtk
-        run: sudo apt-get install -y build-essential pkg-config libssl-dev libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev librust-alsa-sys-dev dpkg-dev gzip webkit2gtk-driver xvfb libxdo-dev
-
-      - name: Set up cargo cache 🛠️
-        uses: Swatinem/rust-cache@v2
-
-      - name: Install Rust 💿
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.70.0
-          override: true
-
-      - name: Build executable 🖥️
-        run: cargo build --release -F production_mode
-
   build-mac:
     runs-on: macos-13
     steps:
@@ -475,14 +450,7 @@ jobs:
   publish-results:
     if: always()
     needs:
-      [
-        build-ubuntu,
-        build-mac,
-        build-windows,
-        test-mac,
-        test-windows-chats,
-        test-windows,
-      ]
+      [build-mac, build-windows, test-mac, test-windows-chats, test-windows]
     runs-on: ubuntu-latest
     permissions:
       checks: write
@@ -574,7 +542,6 @@ jobs:
   remove-artifacts:
     needs:
       [
-        build-ubuntu,
         build-mac,
         build-windows,
         test-mac,


### PR DESCRIPTION
### What this PR does 📖

- Removing Build Ubuntu job from UI Automated Tests workflow, since the validation to ensure that the app builds correctly in Linux is already performed by the Cargo Workflow

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

