### PR TITLE
chore(emoji): Fix issue where numbers and some symbols got big_emoji class applied

### DIFF
--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -447,11 +447,11 @@ fn markdown(text: &str, emojis: bool) -> String {
     let txt = text.trim();
 
     if emojis {
-        let r = replace_emojis(txt);
+        let r = replace_emojis(txt).to_string();
         // TODO: Watch this issue for a fix: https://github.com/open-i18n/rust-unic/issues/280
         // This is a temporary workaround for some characters unic-emoji-char thinks are emojis
-        if !r.to_string().contains("#") // for multiple #
-           && !r.to_string().contains("*") // for multiple #
+        if !r.contains('#') // for multiple #
+           && !r.contains('*') // for multiple #
            && !r.chars().all(char::is_alphanumeric) // for any numbers, eg 1, 11, 111
            && is_only_emojis(&r)
         {

--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -445,14 +445,23 @@ pub fn replace_emojis(input: &str) -> String {
 
 fn markdown(text: &str, emojis: bool) -> String {
     let txt = text.trim();
+    let string_to_exclude = "0123456789#*".to_string();
 
     if emojis {
         let r = replace_emojis(text);
-        if is_only_emojis(&r) {
+        // TODO: Watch this issue for a fix: https://github.com/open-i18n/rust-unic/issues/280
+        // This is a temporary workaround for some characters rust-unic thinks are emojis
+        if !string_to_exclude.contains(&r)
+            && !r.to_string().contains("#") // for multiple #
+            && !r.to_string().contains("*") // for multiple #
+            && is_only_emojis(&r)
+        {
             return format!("<span class=\"big-emoji\">{r}</span>");
+        } else {
+            return format!("<span>{r}</span>");
         }
-    } else if is_only_emojis(txt) {
-        return format!("<span class=\"big-emoji\">{txt}</span>");
+        // } else if is_only_emojis(txt) {
+        //     return format!("<span class=\"big-emoji\">{txt}</span>");
     }
 
     let mut options = Options::empty();

--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -447,7 +447,7 @@ fn markdown(text: &str, emojis: bool) -> String {
     let txt = text.trim();
 
     if emojis {
-        let r = replace_emojis(txt).to_string();
+        let r = replace_emojis(txt);
         // TODO: Watch this issue for a fix: https://github.com/open-i18n/rust-unic/issues/280
         // This is a temporary workaround for some characters unic-emoji-char thinks are emojis
         if !r.contains('#') // for multiple #

--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -447,7 +447,7 @@ fn markdown(text: &str, emojis: bool) -> String {
     let txt = text.trim();
 
     if emojis {
-        let r = replace_emojis(text);
+        let r = replace_emojis(txt);
         // TODO: Watch this issue for a fix: https://github.com/open-i18n/rust-unic/issues/280
         // This is a temporary workaround for some characters unic-emoji-char thinks are emojis
         if !r.to_string().contains("#") // for multiple #
@@ -459,8 +459,6 @@ fn markdown(text: &str, emojis: bool) -> String {
         } else {
             return format!("<span>{r}</span>");
         }
-        // } else if is_only_emojis(txt) {
-        //     return format!("<span class=\"big-emoji\">{txt}</span>");
     }
 
     let mut options = Options::empty();

--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -445,16 +445,15 @@ pub fn replace_emojis(input: &str) -> String {
 
 fn markdown(text: &str, emojis: bool) -> String {
     let txt = text.trim();
-    let string_to_exclude = "0123456789#*".to_string();
 
     if emojis {
         let r = replace_emojis(text);
         // TODO: Watch this issue for a fix: https://github.com/open-i18n/rust-unic/issues/280
-        // This is a temporary workaround for some characters rust-unic thinks are emojis
-        if !string_to_exclude.contains(&r)
-            && !r.to_string().contains("#") // for multiple #
-            && !r.to_string().contains("*") // for multiple #
-            && is_only_emojis(&r)
+        // This is a temporary workaround for some characters unic-emoji-char thinks are emojis
+        if !r.to_string().contains("#") // for multiple #
+           && !r.to_string().contains("*") // for multiple #
+           && !r.chars().all(char::is_alphanumeric) // for any numbers, eg 1, 11, 111
+           && is_only_emojis(&r)
         {
             return format!("<span class=\"big-emoji\">{r}</span>");
         } else {

--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -450,14 +450,17 @@ fn markdown(text: &str, emojis: bool) -> String {
         let r = replace_emojis(txt);
         // TODO: Watch this issue for a fix: https://github.com/open-i18n/rust-unic/issues/280
         // This is a temporary workaround for some characters unic-emoji-char thinks are emojis
-        if !r.contains('#') // for multiple #
-           && !r.contains('*') // for multiple *
-           && !r.chars().all(char::is_alphanumeric) // for any numbers, eg 1, 11, 111
+        if !r.chars().all(char::is_alphanumeric) // for any numbers, eg 1, 11, 111
+           && r != "#"
+           && r != "*"
+           && r != "##"
+           && r != "**"
+           && r != "-"
            && is_only_emojis(&r)
         {
             return format!("<span class=\"big-emoji\">{r}</span>");
-        } else {
-            return format!("<p>{r}</p>");
+        } else if is_only_emojis(txt) || r == "-" {
+            return format!("<p>{txt}</p>");
         }
     }
 

--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -451,13 +451,13 @@ fn markdown(text: &str, emojis: bool) -> String {
         // TODO: Watch this issue for a fix: https://github.com/open-i18n/rust-unic/issues/280
         // This is a temporary workaround for some characters unic-emoji-char thinks are emojis
         if !r.contains('#') // for multiple #
-           && !r.contains('*') // for multiple #
+           && !r.contains('*') // for multiple *
            && !r.chars().all(char::is_alphanumeric) // for any numbers, eg 1, 11, 111
            && is_only_emojis(&r)
         {
             return format!("<span class=\"big-emoji\">{r}</span>");
         } else {
-            return format!("<span>{r}</span>");
+            return format!("<p>{r}</p>");
         }
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
This is a workaround for the big numbers in chat, if you send them by themselves.

We rely on this crate: https://crates.io/crates/unic-emoji-char/0.8.0

That crate has this bug: https://github.com/open-i18n/rust-unic/issues/280

numbers and some symbols (like # and *) trigger the emoji checks from that crate.
- 

### Which issue(s) this PR fixes 🔨

- Resolve #1468

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

