### PR TITLE
feat(download): Use temp file for download

### DIFF
--- a/ui/src/layouts/chats/presentation/messages/coroutines.rs
+++ b/ui/src/layouts/chats/presentation/messages/coroutines.rs
@@ -436,7 +436,7 @@ pub fn handle_warp_commands(
                                         2,
                                     ),
                                 ));
-                                on_finish();
+                                on_finish.await
                             }
                             Err(e) => {
                                 state.write().mutate(Action::AddToastNotification(

--- a/ui/src/layouts/storage/functions.rs
+++ b/ui/src/layouts/storage/functions.rs
@@ -21,7 +21,7 @@ use std::{ffi::OsStr, path::PathBuf, rc::Rc, time::Duration};
 use tokio::time::sleep;
 use warp::constellation::{directory::Directory, item::Item};
 
-use crate::components::files::upload_progress_bar;
+use crate::{components::files::upload_progress_bar, utils::download::get_download_path};
 
 use super::files_layout::controller::{StorageController, UploadFileController};
 
@@ -336,6 +336,8 @@ pub fn init_coroutine<'a>(
                         file_name,
                         local_path_to_save_file,
                     } => {
+                        let (local_path_to_save_file, on_finish) =
+                            get_download_path(local_path_to_save_file);
                         let (tx, rx) = oneshot::channel::<Result<(), warp::error::Error>>();
 
                         if let Err(e) = warp_cmd_tx.send(WarpCmd::Constellation(
@@ -374,6 +376,7 @@ pub fn init_coroutine<'a>(
                                         2,
                                     ),
                                 ));
+                                on_finish();
                             }
                             Err(error) => {
                                 state.write().mutate(Action::AddToastNotification(

--- a/ui/src/layouts/storage/functions.rs
+++ b/ui/src/layouts/storage/functions.rs
@@ -376,7 +376,7 @@ pub fn init_coroutine<'a>(
                                         2,
                                     ),
                                 ));
-                                on_finish();
+                                on_finish.await
                             }
                             Err(error) => {
                                 state.write().mutate(Action::AddToastNotification(

--- a/ui/src/utils/download.rs
+++ b/ui/src/utils/download.rs
@@ -1,0 +1,13 @@
+use std::{fs::rename, path::PathBuf};
+
+/// Returns a temporary file for downloads and a handler for when the download finishes
+pub fn get_download_path(path: PathBuf) -> (PathBuf, impl Fn() -> ()) {
+    let mut temp = path.clone();
+    temp.as_mut_os_string().push(".updownload");
+    let temp2 = temp.clone();
+    (temp, move || finish_download(&temp2, &path))
+}
+
+fn finish_download(temp: &PathBuf, path: &PathBuf) {
+    let _ = rename(temp, path);
+}

--- a/ui/src/utils/download.rs
+++ b/ui/src/utils/download.rs
@@ -1,7 +1,7 @@
 use std::{fs::rename, path::PathBuf};
 
 /// Returns a temporary file for downloads and a handler for when the download finishes
-pub fn get_download_path(path: PathBuf) -> (PathBuf, impl Fn() -> ()) {
+pub fn get_download_path(path: PathBuf) -> (PathBuf, impl Fn()) {
     let mut temp = path.clone();
     temp.as_mut_os_string().push(".updownload");
     let temp2 = temp.clone();

--- a/ui/src/utils/download.rs
+++ b/ui/src/utils/download.rs
@@ -1,13 +1,19 @@
-use std::{fs::rename, path::PathBuf};
+use std::path::PathBuf;
+
+use futures::{future::BoxFuture, FutureExt};
 
 /// Returns a temporary file for downloads and a handler for when the download finishes
-pub fn get_download_path(path: PathBuf) -> (PathBuf, impl Fn()) {
+pub fn get_download_path(path: PathBuf) -> (PathBuf, BoxFuture<'static, ()>) {
     let mut temp = path.clone();
-    temp.as_mut_os_string().push(".updownload");
+    temp.set_extension(".updownload");
     let temp2 = temp.clone();
-    (temp, move || finish_download(&temp2, &path))
-}
-
-fn finish_download(temp: &PathBuf, path: &PathBuf) {
-    let _ = rename(temp, path);
+    (
+        temp,
+        async move {
+            if let Err(e) = tokio::fs::rename(&temp2, &path).await {
+                log::error!("Unable to rename downloaded file: {e}");
+            }
+        }
+        .boxed(),
+    )
 }

--- a/ui/src/utils/mod.rs
+++ b/ui/src/utils/mod.rs
@@ -11,6 +11,7 @@ use crate::{window_manager::WindowManagerCmd, WINDOW_CMD_CH};
 
 pub mod auto_updater;
 pub mod clipboard;
+pub mod download;
 pub mod format_timestamp;
 pub mod get_drag_event;
 pub mod lifecycle;


### PR DESCRIPTION
### What this PR does 📖

- Uses a temporary file for download that has the `.updownload` extension indicating the file is still downloading
