### PR TITLE
fix(chat): Fix long msg in codeblocks not breaking

### DIFF
--- a/kit/src/elements/textarea/style.scss
+++ b/kit/src/elements/textarea/style.scss
@@ -6,6 +6,7 @@ textarea {
 	max-height: 250px; //Maybe make max variable?
 	min-height: 22px;
 	margin: 9px 0;
+	word-wrap: anywhere;
 	&.disabled {
 		cursor: not-allowed;
 		filter: brightness(85%);

--- a/ui/extra/assets/styles/prism-one-dark.css
+++ b/ui/extra/assets/styles/prism-one-dark.css
@@ -36,9 +36,9 @@ pre[class*="language-"] {
 	font-family: "Fira Code", "Fira Mono", Menlo, Consolas, "DejaVu Sans Mono", monospace;
 	direction: ltr;
 	text-align: left;
-	white-space: pre;
+	white-space: pre-wrap;
 	word-spacing: normal;
-	word-break: normal;
+	word-break: break-word;
 	line-height: 1.5;
 	-moz-tab-size: 2;
 	-o-tab-size: 2;


### PR DESCRIPTION
### What this PR does 📖

- Fixes long messages in codeblocks not breaking properly
- Also fixes long input for textarea not breaking and instead causing horizontal scroll

### Which issue(s) this PR fixes 🔨

- Resolve #1461
