### PR TITLE
fix(chat): Fix scroll btn for large msg

### DIFF
--- a/ui/src/layouts/chats/scripts/observer_script.js
+++ b/ui/src/layouts/chats/scripts/observer_script.js
@@ -1,13 +1,14 @@
 function observe_list() {
     var send_top_event = $SEND_TOP_EVENT;
     var send_bottom_event = $SEND_BOTTOM_EVENT;
+    var msg_view = document.getElementById("messages");
+    var view_height = msg_view.getBoundingClientRect().height * 0.8;
     var conversation_key = "$CONVERSATION_KEY";
     var top_msg_id = "$TOP_MSG_ID";
     var bottom_msg_id = "$BOTTOM_MSG_ID";
     console.log("send_top_event is " + send_top_event);
     console.log("send_bottom_event is " + send_bottom_event);
-    
-    var observer3 = new IntersectionObserver( (entries, observer) => {
+    const callback = (entries, observer) => {
         const el = document.getElementById(conversation_key);
         if  (!el) {
             observer.disconnect();
@@ -32,15 +33,26 @@ function observe_list() {
                 dioxus.send("{\"Remove\":{\"msg_id\":\"" + entry.target.id + "\",\"key\":\"" + conversation_key + "\"}}");
             }
         });
-    }, {
-        root: null,
-        rootMargin: "0px",
+    };
+    var observer = new IntersectionObserver(callback, {
+        root: msg_view,
+        rootMargin: "4px",
         threshold: 0.95,
     });
     const elements = document.querySelectorAll("#messages div.message-group > div.context-wrap > div.context-inner");
     elements.forEach( (element) => {
         let id = "#" + element.id;
-        observer3.observe(element);
+        var element_height = element.getBoundingClientRect().height;
+        if (element_height > view_height) {
+            var threshold = Math.max(0, view_height / element_height - 0.05 )
+            new IntersectionObserver(callback, {
+                root: msg_view,
+                rootMargin: "40px",
+                threshold: threshold,
+            }).observe(element)
+        } else {
+            observer.observe(element);
+        }
     });
 }
 


### PR DESCRIPTION
### What this PR does 📖

- Currently if you have a large message (bigger than the screen) then our scrolling system will not detect when that message goes out of the viewport.
  This causes the scroll button to not appear (and if present not disappear). Can test this with a large message that was sent last in a chat.
  This PR fixes that problem


