### PR TITLE
update(main): add prod mode attr to remove terminal from windows build

### DIFF
--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "production_mode", windows_subsystem = "windows")]
+
 fn main() {
     uplink::main_lib();
 }


### PR DESCRIPTION
### What this PR does 📖

- To remove terminal window opened on Windows Build created with "cargo build --release -F production_mode"
- Just added this config line at thetop of the file as suggested by Darius

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

