### PR TITLE
fix(QuickProfile): Only show quick profile if a profile is selected

### DIFF
--- a/ui/src/layouts/chats/presentation/chat/mod.rs
+++ b/ui/src/layouts/chats/presentation/chat/mod.rs
@@ -169,11 +169,13 @@ pub fn Compose(cx: Scope) -> Element {
             is_owner: is_owner,
             is_edit_group: is_edit_group,
         },
-        super::quick_profile::QuickProfileContext{
-            id: quick_profile_uuid,
-            update_script: update_script,
-            did_key: identity_profile,
-        }
+        quickprofile_data.read().is_some().then(|| rsx!(
+            super::quick_profile::QuickProfileContext{
+                id: quick_profile_uuid,
+                update_script: update_script,
+                did_key: identity_profile,
+            }
+        )),
     }
     ))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
The quick profile was being rendered even when there was no profile selected, which was causing a space below the chatbar. This only renders the quick profile if the data is some. This previously caused an empty space below the chatbar.

Before, you can see the space below the chatbar.:
<img width="1356" alt="image" src="https://github.com/Satellite-im/Uplink/assets/1770198/50de45a0-2af5-436d-b525-7fc848b97879">

