### PR TITLE
fix(NoFriends): Fixes mascot becoming very wide

### DIFF
--- a/ui/src/components/friends/style.scss
+++ b/ui/src/components/friends/style.scss
@@ -47,6 +47,11 @@
     justify-content: center;
     padding: var(--padding);
     pointer-events: none;
+
+    img {
+        max-height: 100%;
+        max-width: unset;
+    }
 }
 
 .no-friends-text {

--- a/ui/src/components/friends/style.scss
+++ b/ui/src/components/friends/style.scss
@@ -49,8 +49,13 @@
     pointer-events: none;
 
     img {
-        max-height: 100%;
-        max-width: unset;
+        max-height: 500px;
+        object-fit: cover;
+        display: block;
+        min-height: 0;
+        min-width: 0;
+        height: 100%;
+        max-width: 100%;
     }
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
Fixes wide mascot

Before:
![image](https://github.com/Satellite-im/Uplink/assets/1770198/4b5ba0c5-e4c1-4cad-b3f5-4cfc0accf0aa)
After:
<img width="1519" alt="image" src="https://github.com/Satellite-im/Uplink/assets/1770198/30d7e6b8-624f-4dde-a805-5ffb13af8c82">

