### PR TITLE
fix(images): Fix img thumbnails converted to jpeg always

### DIFF
--- a/common/src/warp_runner/mod.rs
+++ b/common/src/warp_runner/mod.rs
@@ -369,7 +369,6 @@ async fn warp_initialization(tesseract: Tesseract) -> Result<manager::Warp, warp
         ))
     }));
     config.thumbnail_size = (500, 500);
-    config.thumbnail_exact_format = false;
 
     let (multipass, raygun, constellation) = WarpIpfsBuilder::default()
         .set_tesseract(tesseract.clone())


### PR DESCRIPTION
### What this PR does 📖

- Fixes image thumbnails always converted to jpeg and thus having no transparency

### Which issue(s) this PR fixes 🔨

- Resolve #1467
