### PR TITLE
fix(chats): show the scroll button early while still tracking the scroll position using intersectionobserver

### DIFF
--- a/ui/src/layouts/chats/data/chat_props.rs
+++ b/ui/src/layouts/chats/data/chat_props.rs
@@ -5,6 +5,7 @@ use uuid::Uuid;
 pub struct ChatProps {
     pub show_edit_group: UseState<Option<Uuid>>,
     pub show_group_users: UseState<Option<Uuid>>,
+    pub js_scroll_btn: Option<UseState<bool>>,
     pub ignore_focus: bool,
     pub is_owner: bool,
     pub is_edit_group: bool,

--- a/ui/src/layouts/chats/presentation/chat/mod.rs
+++ b/ui/src/layouts/chats/presentation/chat/mod.rs
@@ -39,6 +39,7 @@ pub fn Compose(cx: Scope) -> Element {
     use_shared_state_provider(cx, ScrollBtn::new);
     let state = use_shared_state::<State>(cx)?;
     let chat_data = use_shared_state::<ChatData>(cx)?;
+    let js_scroll_btn = use_state(cx, || false);
 
     let init = coroutines::init_chat_data(cx, state, chat_data);
     coroutines::handle_warp_events(cx, state, chat_data);
@@ -187,11 +188,12 @@ pub fn Compose(cx: Scope) -> Element {
                 }
             )
         } else {
-            rsx!(get_messages{quickprofile_data: quickprofile_data.clone()})
+            rsx!(get_messages{quickprofile_data: quickprofile_data.clone(), js_scroll_btn: js_scroll_btn.clone()})
         },
         get_chatbar {
             show_edit_group: show_edit_group.clone(),
             show_group_users: show_group_users.clone(),
+            js_scroll_btn: js_scroll_btn.clone(),
             ignore_focus: should_ignore_focus,
             is_owner: is_owner,
             is_edit_group: is_edit_group,

--- a/ui/src/layouts/chats/presentation/chatbar/mod.rs
+++ b/ui/src/layouts/chats/presentation/chatbar/mod.rs
@@ -53,6 +53,13 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, ChatProps>) -> Element<'a> {
     let scroll_btn = use_shared_state::<ScrollBtn>(cx)?;
     state.write_silent().scope_ids.chatbar = Some(cx.scope_id().0);
 
+    let js_scroll_btn = cx
+        .props
+        .js_scroll_btn
+        .as_ref()
+        .map(|x| *x.current())
+        .unwrap_or_default();
+
     let is_loading = !chat_data.read().active_chat.is_initialized;
     let active_chat_id = chat_data.read().active_chat.id();
     let can_send = use_state(cx, || state.read().active_chat_has_draft());
@@ -63,7 +70,7 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, ChatProps>) -> Element<'a> {
     let suggestions = use_state(cx, || SuggestionType::None);
     let mentions = use_ref(cx, Vec::new);
 
-    let with_scroll_btn = scroll_btn.read().get(active_chat_id);
+    let with_scroll_btn = scroll_btn.read().get(active_chat_id) || js_scroll_btn;
 
     // if the active chat is scrolled up and a message is received, want to increment unreads
     // but the needed information isn't accessible in main.rs. so a flag was added to State

--- a/ui/src/layouts/chats/presentation/messages/coroutines.rs
+++ b/ui/src/layouts/chats/presentation/messages/coroutines.rs
@@ -16,7 +16,7 @@ use warp::raygun::{PinState, ReactionState};
 
 use crate::{
     layouts::chats::{
-        data::{self, ChatBehavior, ChatData, JsMsg, DEFAULT_MESSAGES_TO_TAKE},
+        data::{self, ChatBehavior, ChatData, JsMsg, ScrollBtn, DEFAULT_MESSAGES_TO_TAKE},
         scripts::OBSERVER_SCRIPT,
     },
     utils::download::get_download_path,
@@ -28,9 +28,10 @@ pub fn hangle_msg_scroll(
     cx: &ScopeState,
     eval_provider: &crate::utils::EvalProvider,
     chat_data: &UseSharedState<ChatData>,
+    scroll_btn: &UseSharedState<ScrollBtn>,
 ) -> Coroutine<()> {
     let ch = use_coroutine(cx, |mut rx: UnboundedReceiver<()>| {
-        to_owned![eval_provider, chat_data];
+        to_owned![eval_provider, chat_data, scroll_btn];
         async move {
             let warp_cmd_tx = WARP_CMD_CH.tx.clone();
 
@@ -158,6 +159,19 @@ pub fn hangle_msg_scroll(
                                 Some(msg) => match msg {
                                     JsMsg::Add { msg_id, .. } => {
                                         chat_data.write_silent().add_message_to_view(conv_id, msg_id);
+                                        let chat_behavior = chat_data.read().get_chat_behavior(conv_id);
+                                        // a message can be added to the top of the view without removing a message from the bottom of the view.
+                                        // need to explicitly compare the bottom of messages.all and messages.displayed
+                                        if chat_data.read().get_bottom_of_view(conv_id).map(|pm|  pm.message_id) == chat_data.read().active_chat.messages.bottom(){
+                                            // have to check on_scroll_end in case the user scrolled up and switched chats.
+                                            if chat_behavior.on_scroll_end == data::ScrollBehavior::DoNothing && scroll_btn.read().get(conv_id) {
+                                                scroll_btn.write().clear(conv_id);
+                                                log::trace!("clearing scroll_btn");
+                                            }
+                                        } else if !scroll_btn.read().get(conv_id) {
+                                            scroll_btn.write().set(conv_id);
+                                            log::trace!("setting scroll_btn");
+                                        }
                                     },
                                     JsMsg::Remove { msg_id, .. } => {
                                         chat_data.write_silent().remove_message_from_view(conv_id, msg_id);

--- a/ui/src/layouts/chats/scripts/read_scroll.js
+++ b/ui/src/layouts/chats/scripts/read_scroll.js
@@ -1,1 +1,0 @@
-return document.getElementById("messages").scrollTop

--- a/ui/src/layouts/chats/scripts/read_scroll.js
+++ b/ui/src/layouts/chats/scripts/read_scroll.js
@@ -1,0 +1,1 @@
+return document.getElementById("messages").scrollTop


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- reverts #1530 but then adds back the `onscroll` handler. This time the `onscroll` handler sets a flag which is used in conjunction with the `UseSharedState<ScrollBtn>`. This way the scroll button can appear early for very large pictures while preserving the ChatBehavior functionality. 

### Which issue(s) this PR fixes 🔨

- Resolve #1566 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

