### PR TITLE
chore(readme): Fix the binary name

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ To get running fast, ensure you have [Rust](https://www.rust-lang.org/tools/inst
 
 **Standard Run:**
 ```
-cargo run --bin ui
+cargo run --bin uplink
 ```
 
 **Rapid Release Testing:**
 This version will run close to release but without recompiling crates every time.
 ```
-cargo run --bin ui --profile=rapid
+cargo run --bin uplink --profile=rapid
 ```
 
 ---


### PR DESCRIPTION
The current instructions are wrong and fails to build and run the binary.