### PR TITLE
fix(ui): Fix context item height

### DIFF
--- a/kit/src/components/context_menu/style.scss
+++ b/kit/src/components/context_menu/style.scss
@@ -16,7 +16,8 @@
 		gap: var(--gap);
 		align-items: center;
 		border-radius: var(--border-radius-more);
-		height: var(--height-input);
+		height: fit-content;
+		min-height: var(--height-input);
 		padding: var(--padding-less);
 		width: 100%;
 	


### PR DESCRIPTION
### What this PR does 📖

- Fixes context item height to be a bit more dynamic which in turns fixes cases where e.g. text went out of bounds a bit for a button

### Which issue(s) this PR fixes 🔨

- Resolve #1559
