### PR TITLE
chore(appium): remove not required artifacts on failed test executions

### DIFF
--- a/.github/workflows/ui-test-automation.yml
+++ b/.github/workflows/ui-test-automation.yml
@@ -529,7 +529,21 @@ jobs:
           message: |
             UI Automated Tests execution is complete! You can find the test results report [here](https://satellite-im.github.io/Uplink/${{ github.run_number }})
 
-  remove-artifacts:
+      - name: Delete artifacts not required after publishing results
+        uses: geekyeggo/delete-artifact@v2
+        with:
+          name: |
+            Uplink-Windows
+            uplink-windows-assets
+            app-macos
+            test-report-macos-ci
+            test-report-windows-ci
+            test-report-macos-chats
+            test-allure-macos-ci
+            test-allure-windows-ci
+            test-allure-macos-chats
+
+  remove-label:
     needs:
       [
         build-mac,
@@ -552,17 +566,3 @@ jobs:
           labels: |
             Failed Automated Test
           type: remove
-
-      - name: Delete artifacts
-        uses: geekyeggo/delete-artifact@v2
-        with:
-          name: |
-            Uplink-Windows
-            uplink-windows-assets
-            app-macos
-            test-report-macos-ci
-            test-report-windows-ci
-            test-report-macos-chats
-            test-allure-macos-ci
-            test-allure-windows-ci
-            test-allure-macos-chats

--- a/.github/workflows/ui-test-automation.yml
+++ b/.github/workflows/ui-test-automation.yml
@@ -533,9 +533,6 @@ jobs:
         uses: geekyeggo/delete-artifact@v2
         with:
           name: |
-            Uplink-Windows
-            uplink-windows-assets
-            app-macos
             test-report-macos-ci
             test-report-windows-ci
             test-report-macos-chats
@@ -558,6 +555,14 @@ jobs:
     steps:
       - name: Checkout testing directory 🔖
         uses: actions/checkout@v3
+
+      - name: Delete artifacts not required after publishing results
+        uses: geekyeggo/delete-artifact@v2
+        with:
+          name: |
+            Uplink-Windows
+            uplink-windows-assets
+            app-macos
 
       - name: Remove label if all test jobs succeeded
         uses: buildsville/add-remove-label@v2.0.0


### PR DESCRIPTION
### What this PR does 📖

- Remove not required artifacts after publishing test results
- Applying this change since there is no need to keep builds, test reports and allure assets after results have been published
- After this change, we are just keeping appium logs and appium screenshots/videos when execution is failed

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

