### PR TITLE
chore(vscode): Remove suggestion for unnecessary Rust Syntax extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
 	"recommendations": [
 		"tamasfe.even-better-toml",
-		"dustypomerleau.rust-syntax",
 		"ms-vscode.makefile-tools",
 		"vadimcn.vscode-lldb",
 		"rust-lang.rust-analyzer",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
         "editor.defaultFormatter": "rust-lang.rust-analyzer",
         "editor.formatOnSave": true
     },
-    "editor.codeActionsOnSave": {"source.fixAll": true, "source.organizeImports": true}
+    "editor.codeActionsOnSave": {
+        "source.fixAll": "explicit",
+        "source.organizeImports": "explicit"
+    }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

As per its own documentation:

> In most cases, you won't need to install the extension, as this
> repository is upstreamed by VS Code (issues and PRs should be submitted
> here).
>
> If you are doing a significant amount of Rust programming, the semantic
> highlighting provided by Rust Analyzer will be superior to a textmate
> grammar.

Since we already have the Rust Analyzer extension in the list, we shouldn't recommend the Rust Syntax extension.

### Additional comments 🎤

There is also a minor formatting fix that vscode automatically did (probably the YAML extension) when I opened the project in it.