### PR TITLE
fix(ChatText): don't try to parse DID if string is too short

### DIFF
--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -353,9 +353,13 @@ pub struct ChatMessageProps {
 
 #[allow(non_snake_case)]
 pub fn ChatText(cx: Scope<ChatMessageProps>) -> Element {
-    if let Ok(id) = DID::from_str(&cx.props.text) {
-        return cx.render(rsx!(IdentityMessage { id: id }));
+    // DID::from_str panics if text is 'z'. simple fix is to ensure string is long enough.
+    if cx.props.text.len() > 2 {
+        if let Ok(id) = DID::from_str(&cx.props.text) {
+            return cx.render(rsx!(IdentityMessage { id: id }));
+        }
     }
+
     let mut formatted_text = format_text(&cx.props.text, cx.props.markdown, cx.props.ascii_emoji);
     formatted_text = wrap_links_with_a_tags(&formatted_text);
 


### PR DESCRIPTION
this eliminates a panic in DID::from_str

<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- don't try to parse DID if string is too short due to panic in` DID::from_str` for input 'z'

### Which issue(s) this PR fixes 🔨

- Resolve #1588 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

