### PR TITLE
chore(appium): remove all artifacts only if job execution is passed

### DIFF
--- a/.github/workflows/ui-test-automation.yml
+++ b/.github/workflows/ui-test-automation.yml
@@ -527,17 +527,6 @@ jobs:
           message: |
             UI Automated Tests execution is complete! You can find the test results report [here](https://satellite-im.github.io/Uplink/${{ github.run_number }})
 
-      - name: Delete artifacts not required after publishing results
-        uses: geekyeggo/delete-artifact@v2
-        with:
-          name: |
-            test-report-macos-ci
-            test-report-windows-ci
-            test-report-macos-chats
-            test-allure-macos-ci
-            test-allure-windows-ci
-            test-allure-macos-chats
-
   remove-label:
     needs:
       [
@@ -554,13 +543,19 @@ jobs:
       - name: Checkout testing directory 🔖
         uses: actions/checkout@v3
 
-      - name: Delete artifacts not required after publishing results
+      - name: Delete all artifacts
         uses: geekyeggo/delete-artifact@v2
         with:
           name: |
             Uplink-Windows
             uplink-windows-assets
             app-macos
+            test-report-macos-ci
+            test-report-windows-ci
+            test-report-macos-chats
+            test-allure-macos-ci
+            test-allure-windows-ci
+            test-allure-macos-chats
 
       - name: Remove label if all test jobs succeeded
         uses: buildsville/add-remove-label@v2.0.0


### PR DESCRIPTION
### What this PR does 📖

- @phillsatellite  noticed that there was an issue happening on publish results step when doing a manual retry of the tests. This was caused because test reports artifacts were deleted before even if test was failed. The fix for this is to go back to the prior state before my last PR, where all artifacts are deleted only on passed execution. 
- Also, now that artifacts are kept for only 7 days, the impact on storage of removing these test reports artifacts before or after test is passed is almost zero

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

