### PR TITLE
chore(appium): workaround for automated tests issue with webdriverio

### DIFF
--- a/.github/workflows/ui-test-automation.yml
+++ b/.github/workflows/ui-test-automation.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Setup Node.js 🔨
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 18.17.1
 
       - name: Install NPM dependencies 📦
         working-directory: ./appium-tests
@@ -243,7 +243,7 @@ jobs:
       - name: Setup Node.js 🔨
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 18.17.1
 
       - name: Install NPM dependencies 📦
         working-directory: ./appium-tests
@@ -349,7 +349,7 @@ jobs:
       - name: Setup Node.js 🔨
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 18.17.1
 
       - name: Install NPM dependencies 📦
         working-directory: ./appium-tests


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- We noticed that since yesterday webdriverio automated tests started to fail randomly with this error message: "ERROR @wdio/config:ConfigParser: Failed loading configuration file: Cannot use import statement outside a module"
- After researching on this issue, I found that it started to happen with webdriverio with NodeJS update to 18.19 version
- I have tested and issue is not presented with NodeJS 18.17.1 (my local version of nodejs), so I am adding this version on setup nodejs actions for ui automated tests workflow as a workaround until Webdriverio team fixes the issue

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

