### PR TITLE
fix(TouchPad): Fix context menu with touch pad when there is dialog

### DIFF
--- a/kit/src/components/embeds/file_embed/mod.rs
+++ b/kit/src/components/embeds/file_embed/mod.rs
@@ -201,7 +201,7 @@ pub fn FileEmbed<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                                     img {
                                         aria_label: "message-image",
                                         onclick: move |mouse_event_data: Event<MouseData>| 
-                                        if !(mouse_event_data.modifiers() == Modifiers::CONTROL) {
+                                        if mouse_event_data.modifiers() != Modifiers::CONTROL {
                                             fullscreen_preview.set(true)
                                         },
                                         class: format_args!(

--- a/kit/src/components/embeds/file_embed/mod.rs
+++ b/kit/src/components/embeds/file_embed/mod.rs
@@ -201,7 +201,7 @@ pub fn FileEmbed<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                                     img {
                                         aria_label: "message-image",
                                         onclick: move |mouse_event_data: Event<MouseData>| 
-                                        if !(mouse_event_data.modifiers() == Modifiers::CONTROL || mouse_event_data.modifiers() == Modifiers::META) {
+                                        if !(mouse_event_data.modifiers() == Modifiers::CONTROL) {
                                             fullscreen_preview.set(true)
                                         },
                                         class: format_args!(

--- a/kit/src/components/embeds/file_embed/mod.rs
+++ b/kit/src/components/embeds/file_embed/mod.rs
@@ -5,8 +5,8 @@ use crate::elements::button::Button;
 use crate::elements::Appearance;
 use crate::layout::modal::Modal;
 use common::icons::outline::Shape as Icon;
-use dioxus_html::input_data::keyboard_types::Modifiers;
 use common::icons::Icon as IconElement;
+use dioxus_html::input_data::keyboard_types::Modifiers;
 
 use dioxus::prelude::*;
 
@@ -200,7 +200,7 @@ pub fn FileEmbed<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                                     aria_label: "message-image-container",
                                     img {
                                         aria_label: "message-image",
-                                        onclick: move |mouse_event_data: Event<MouseData>| 
+                                        onclick: move |mouse_event_data: Event<MouseData>|
                                         if mouse_event_data.modifiers() != Modifiers::CONTROL {
                                             fullscreen_preview.set(true)
                                         },

--- a/kit/src/components/embeds/file_embed/mod.rs
+++ b/kit/src/components/embeds/file_embed/mod.rs
@@ -5,6 +5,7 @@ use crate::elements::button::Button;
 use crate::elements::Appearance;
 use crate::layout::modal::Modal;
 use common::icons::outline::Shape as Icon;
+use dioxus_html::input_data::keyboard_types::Modifiers;
 use common::icons::Icon as IconElement;
 
 use dioxus::prelude::*;
@@ -199,7 +200,10 @@ pub fn FileEmbed<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                                     aria_label: "message-image-container",
                                     img {
                                         aria_label: "message-image",
-                                        onclick: move |_| fullscreen_preview.set(true),
+                                        onclick: move |mouse_event_data: Event<MouseData>| 
+                                        if !(mouse_event_data.modifiers() == Modifiers::CONTROL || mouse_event_data.modifiers() == Modifiers::META) {
+                                            fullscreen_preview.set(true)
+                                        },
                                         class: format_args!(
                                             "image {} expandable-image",
                                             if cx.props.big.unwrap_or_default() {

--- a/kit/src/elements/file/mod.rs
+++ b/kit/src/elements/file/mod.rs
@@ -8,6 +8,8 @@ use crate::elements::{
     input::{Input, Options, Size, SpecialCharsAction, Validation},
     Appearance,
 };
+use dioxus_html::input_data::keyboard_types::Modifiers;
+
 use common::icons::outline::Shape as Icon;
 use common::icons::Icon as IconElement;
 
@@ -88,7 +90,11 @@ pub fn File<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     format_args!("file {}", if disabled { "disabled" } else { "" })
                 },
                 aria_label: "{aria_label}",
-                onclick: move |_| emit_press(&cx),
+                onclick: move |mouse_event_data| {
+                    if !(mouse_event_data.modifiers() == Modifiers::CONTROL || mouse_event_data.modifiers() == Modifiers::META) {
+                        emit_press(&cx);
+                    } 
+                },
                 div {
                     class: "icon alignment",
                     if thumbnail.is_empty() {

--- a/kit/src/elements/file/mod.rs
+++ b/kit/src/elements/file/mod.rs
@@ -93,7 +93,7 @@ pub fn File<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 onclick: move |mouse_event_data| {
                     if mouse_event_data.modifiers() != Modifiers::CONTROL {
                         emit_press(&cx);
-                    } 
+                    }
                 },
                 div {
                     class: "icon alignment",

--- a/kit/src/elements/file/mod.rs
+++ b/kit/src/elements/file/mod.rs
@@ -91,7 +91,7 @@ pub fn File<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 },
                 aria_label: "{aria_label}",
                 onclick: move |mouse_event_data| {
-                    if !(mouse_event_data.modifiers() == Modifiers::CONTROL || mouse_event_data.modifiers() == Modifiers::META) {
+                    if !(mouse_event_data.modifiers() == Modifiers::CONTROL) {
                         emit_press(&cx);
                     } 
                 },

--- a/kit/src/elements/file/mod.rs
+++ b/kit/src/elements/file/mod.rs
@@ -91,7 +91,7 @@ pub fn File<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 },
                 aria_label: "{aria_label}",
                 onclick: move |mouse_event_data| {
-                    if !(mouse_event_data.modifiers() == Modifiers::CONTROL) {
+                    if mouse_event_data.modifiers() != Modifiers::CONTROL {
                         emit_press(&cx);
                     } 
                 },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
### 1. Fix to open context menu if user uses touch pad, without open dialog, generally a modal with image


### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

