### PR TITLE
update(FileEmbed): Improve file extension name if it is too large

### DIFF
--- a/kit/src/components/embeds/file_embed/mod.rs
+++ b/kit/src/components/embeds/file_embed/mod.rs
@@ -66,7 +66,13 @@ pub fn FileEmbed<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let file_extension = std::path::Path::new(&cx.props.filename)
         .extension()
         .and_then(OsStr::to_str)
-        .map(|s| format!(".{s}"))
+        .map(|s| {
+            if s.len() > 6 {
+                format!(".{}...", &s[0..4])
+            } else {
+                format!(".{}", s)
+            }
+        })
         .unwrap_or_default();
     let file_extension_is_empty = file_extension.is_empty();
     let filename = &cx.props.filename;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
### 1. Format file extension name if it is too large

####  Issue 1622
![image](https://github.com/Satellite-im/Uplink/assets/63157656/3b86ece1-4564-4614-9a4a-0a65c7d22f3f)

#### Issue: 1621 
![image](https://github.com/Satellite-im/Uplink/assets/63157656/a02ce067-bfc0-4510-93b5-78f72e630aeb)

- 

### Which issue(s) this PR fixes 🔨

- Resolve #1622
- Resolve #1621 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

