### PR TITLE
fix(Files): Fix showing message on toast notification when file has no thumbnail

### DIFF
--- a/common/locales/en-US/main.ftl
+++ b/common/locales/en-US/main.ftl
@@ -163,7 +163,7 @@ files = Files
     .no-thumbnail = No Thumbnail
     .one-file-to-upload = File to Upload 1!
     .files-to-upload = Files to Upload { $num }!
-
+    .no-thumbnail-preview = No Thumbnail available for preview
     .file-already-opened = File already opened
     .directory-already-with-name = There is already a directory with this name
     .no-size-available = No size available for file: { $file }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
### 1.  Fix showing message on toast notification when file has no thumbnail

![image](https://github.com/Satellite-im/Uplink/assets/63157656/d727ed52-eb61-4e22-9191-ffa26985ba62)



- 

### Which issue(s) this PR fixes 🔨

- Resolve #1615 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

