### PR TITLE
update(aria): simplify aria labels for chat messages

### DIFF
--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -224,13 +224,10 @@ pub fn Message<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             },
             aria_label: {
                 format_args!(
-                    "message-{}-{}",
+                    "message-{}",
                     if is_remote {
                         "remote"
                     } else { "local" },
-                    if cx.props.order.is_some() {
-                        order.to_string()
-                    } else { "".into() }
                 )
             },
             white_space: "pre-wrap",


### PR DESCRIPTION
### What this PR does 📖

- Simplifying aria labels for chat messages to only use "message-remote" or "message-local", since adding the position (first, middle, last) was not adding any value to the UI locators and are making the process of finding elements more complex during test execution

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

