### PR TITLE
chore(cargo): Update dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,7 +1006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "542f33a8835a0884b006a0c3df3dadd99c0c3f296ed26c2fdc8028e01ad6230c"
 dependencies = [
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.3",
  "serde",
 ]
 
@@ -3602,8 +3602,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -4392,7 +4392,7 @@ dependencies = [
  "globset",
  "log",
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.3",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -5878,6 +5878,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6356,6 +6365,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6647,6 +6666,12 @@ name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
@@ -7602,8 +7627,17 @@ checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -7614,8 +7648,14 @@ checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.2",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -8474,10 +8514,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+
+[[package]]
+name = "shuttle"
+version = "0.1.0"
+source = "git+https://github.com/Satellite-im/Warp?rev=13e13a2a0dffec858cf2dd882e539d68ab3d18d9#13e13a2a0dffec858cf2dd882e539d68ab3d18d9"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "base64 0.21.5",
+ "bs58 0.4.0",
+ "chrono",
+ "clap 4.4.11",
+ "dotenv",
+ "either",
+ "futures",
+ "futures-timer",
+ "libipld",
+ "rust-ipfs",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "uuid",
+ "void",
+ "warp",
+ "zeroize",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -9069,6 +9150,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tiff"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9318,6 +9409,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9335,6 +9438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
 ]
 
 [[package]]
@@ -9347,6 +9451,35 @@ dependencies = [
  "futures-task",
  "pin-project",
  "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -9739,6 +9872,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
 name = "version-compare"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9793,7 +9932,7 @@ dependencies = [
 [[package]]
 name = "warp"
 version = "0.1.0"
-source = "git+https://github.com/Satellite-im/Warp?rev=fbdc9451c5129fad7895287db22e522443e83a61#fbdc9451c5129fad7895287db22e522443e83a61"
+source = "git+https://github.com/Satellite-im/Warp?rev=13e13a2a0dffec858cf2dd882e539d68ab3d18d9#13e13a2a0dffec858cf2dd882e539d68ab3d18d9"
 dependencies = [
  "aes-gcm 0.10.3",
  "anyhow",
@@ -9849,7 +9988,7 @@ dependencies = [
 [[package]]
 name = "warp-blink-wrtc"
 version = "0.1.0"
-source = "git+https://github.com/Satellite-im/Warp?rev=fbdc9451c5129fad7895287db22e522443e83a61#fbdc9451c5129fad7895287db22e522443e83a61"
+source = "git+https://github.com/Satellite-im/Warp?rev=13e13a2a0dffec858cf2dd882e539d68ab3d18d9#13e13a2a0dffec858cf2dd882e539d68ab3d18d9"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -9881,7 +10020,7 @@ dependencies = [
 [[package]]
 name = "warp-derive"
 version = "0.1.0"
-source = "git+https://github.com/Satellite-im/Warp?rev=fbdc9451c5129fad7895287db22e522443e83a61#fbdc9451c5129fad7895287db22e522443e83a61"
+source = "git+https://github.com/Satellite-im/Warp?rev=13e13a2a0dffec858cf2dd882e539d68ab3d18d9#13e13a2a0dffec858cf2dd882e539d68ab3d18d9"
 dependencies = [
  "paste",
  "quote",
@@ -9891,7 +10030,7 @@ dependencies = [
 [[package]]
 name = "warp-ipfs"
 version = "0.1.0"
-source = "git+https://github.com/Satellite-im/Warp?rev=fbdc9451c5129fad7895287db22e522443e83a61#fbdc9451c5129fad7895287db22e522443e83a61"
+source = "git+https://github.com/Satellite-im/Warp?rev=13e13a2a0dffec858cf2dd882e539d68ab3d18d9#13e13a2a0dffec858cf2dd882e539d68ab3d18d9"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -9911,6 +10050,7 @@ dependencies = [
  "rust-ipfs",
  "serde",
  "serde_json",
+ "shuttle",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8531,7 +8531,7 @@ checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
 [[package]]
 name = "shuttle"
 version = "0.1.0"
-source = "git+https://github.com/Satellite-im/Warp?rev=13e13a2a0dffec858cf2dd882e539d68ab3d18d9#13e13a2a0dffec858cf2dd882e539d68ab3d18d9"
+source = "git+https://github.com/Satellite-im/Warp?rev=786328d0c7ef6e2c5d142c5539fb5e0166837013#786328d0c7ef6e2c5d142c5539fb5e0166837013"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -9932,7 +9932,7 @@ dependencies = [
 [[package]]
 name = "warp"
 version = "0.1.0"
-source = "git+https://github.com/Satellite-im/Warp?rev=13e13a2a0dffec858cf2dd882e539d68ab3d18d9#13e13a2a0dffec858cf2dd882e539d68ab3d18d9"
+source = "git+https://github.com/Satellite-im/Warp?rev=786328d0c7ef6e2c5d142c5539fb5e0166837013#786328d0c7ef6e2c5d142c5539fb5e0166837013"
 dependencies = [
  "aes-gcm 0.10.3",
  "anyhow",
@@ -9988,7 +9988,7 @@ dependencies = [
 [[package]]
 name = "warp-blink-wrtc"
 version = "0.1.0"
-source = "git+https://github.com/Satellite-im/Warp?rev=13e13a2a0dffec858cf2dd882e539d68ab3d18d9#13e13a2a0dffec858cf2dd882e539d68ab3d18d9"
+source = "git+https://github.com/Satellite-im/Warp?rev=786328d0c7ef6e2c5d142c5539fb5e0166837013#786328d0c7ef6e2c5d142c5539fb5e0166837013"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -10020,7 +10020,7 @@ dependencies = [
 [[package]]
 name = "warp-derive"
 version = "0.1.0"
-source = "git+https://github.com/Satellite-im/Warp?rev=13e13a2a0dffec858cf2dd882e539d68ab3d18d9#13e13a2a0dffec858cf2dd882e539d68ab3d18d9"
+source = "git+https://github.com/Satellite-im/Warp?rev=786328d0c7ef6e2c5d142c5539fb5e0166837013#786328d0c7ef6e2c5d142c5539fb5e0166837013"
 dependencies = [
  "paste",
  "quote",
@@ -10030,7 +10030,7 @@ dependencies = [
 [[package]]
 name = "warp-ipfs"
 version = "0.1.0"
-source = "git+https://github.com/Satellite-im/Warp?rev=13e13a2a0dffec858cf2dd882e539d68ab3d18d9#13e13a2a0dffec858cf2dd882e539d68ab3d18d9"
+source = "git+https://github.com/Satellite-im/Warp?rev=786328d0c7ef6e2c5d142c5539fb5e0166837013#786328d0c7ef6e2c5d142c5539fb5e0166837013"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,9 +45,9 @@ arboard = "3.2"
 humansize = "2.1.3"
 uuid = { version = "1", features = ["serde", "v4"] }
 libloading = "0.7.4"
-warp = { git = "https://github.com/Satellite-im/Warp", rev = "fbdc9451c5129fad7895287db22e522443e83a61" }
-warp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "fbdc9451c5129fad7895287db22e522443e83a61" }
-warp-blink-wrtc = { git = "https://github.com/Satellite-im/Warp", rev = "fbdc9451c5129fad7895287db22e522443e83a61" }
+warp = { git = "https://github.com/Satellite-im/Warp", rev = "13e13a2a0dffec858cf2dd882e539d68ab3d18d9" }
+warp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "13e13a2a0dffec858cf2dd882e539d68ab3d18d9" }
+warp-blink-wrtc = { git = "https://github.com/Satellite-im/Warp", rev = "13e13a2a0dffec858cf2dd882e539d68ab3d18d9" }
 rfd = "0.11.3"
 mime = "0.3.16"
 serde = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,9 +45,9 @@ arboard = "3.2"
 humansize = "2.1.3"
 uuid = { version = "1", features = ["serde", "v4"] }
 libloading = "0.7.4"
-warp = { git = "https://github.com/Satellite-im/Warp", rev = "13e13a2a0dffec858cf2dd882e539d68ab3d18d9" }
-warp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "13e13a2a0dffec858cf2dd882e539d68ab3d18d9" }
-warp-blink-wrtc = { git = "https://github.com/Satellite-im/Warp", rev = "13e13a2a0dffec858cf2dd882e539d68ab3d18d9" }
+warp = { git = "https://github.com/Satellite-im/Warp", rev = "786328d0c7ef6e2c5d142c5539fb5e0166837013" }
+warp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "786328d0c7ef6e2c5d142c5539fb5e0166837013" }
+warp-blink-wrtc = { git = "https://github.com/Satellite-im/Warp", rev = "786328d0c7ef6e2c5d142c5539fb5e0166837013" }
 rfd = "0.11.3"
 mime = "0.3.16"
 serde = "1.0"

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -59,6 +59,9 @@ pub enum DiscoveryMode {
     /// Enable full discovery
     Full,
 
+    /// Use warp specific discovery
+    Shuttle,
+
     /// Address to a specific discovery point
     RzPoint { address: String },
 
@@ -70,8 +73,9 @@ pub enum DiscoveryMode {
 impl std::str::FromStr for DiscoveryMode {
     type Err = warp::error::Error;
     fn from_str(mode: &str) -> Result<Self, Self::Err> {
-        match mode {
+        match mode.to_lowercase().as_str() {
             "full" => Ok(DiscoveryMode::Full),
+            "shuttle" => Ok(DiscoveryMode::Shuttle),
             "disable" => Ok(DiscoveryMode::Disable),
             _ => Err(warp::error::Error::Other),
         }

--- a/common/src/warp_runner/mod.rs
+++ b/common/src/warp_runner/mod.rs
@@ -1,6 +1,9 @@
 //! Defines important types and structs, and spawns the main task for warp_runner - manager::run.
 use derive_more::Display;
-use std::sync::Arc;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use tokio::sync::{
     broadcast,
@@ -355,6 +358,26 @@ impl From<&DiscoveryMode> for Discovery {
                     addresses: vec![address.parse().expect("Valid multiaddr address")],
                 },
             },
+            DiscoveryMode::Shuttle => {
+                #[cfg(not(feature = "production_mode"))]
+                {
+                    Discovery::Shuttle {
+                        addresses: HashMap::from_iter([(
+                            "12D3KooWJSes8386p2T1sMeZ2DzsNJThKkZWbj4US6uPMpEgBTHu"
+                                .parse()
+                                .expect("Valid id"),
+                            HashSet::from_iter(["/ip4/104.236.194.35/tcp/34053"
+                                .parse()
+                                .expect("valid addr")]),
+                        )]),
+                    }
+                }
+                #[cfg(feature = "production_mode")]
+                {
+                    //TODO: Add a production map
+                    Discovery::None
+                }
+            }
             DiscoveryMode::Disable => Discovery::None,
         }
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Updates dependency
- Added new discovery option

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️
- Receiving friend request may not resolve the identity right away if the identity never been resolved before, but once the request is accepted, it would be resolved.

### Additional comments 🎤
- This PR adds a separate to store accounts and send/receive accounts to those who are offline, however this option is disabled in uplink by default. To enable it, one must pass `--discovery shuttle` in argument of the application. This may be flip to be default in the near future, but for now its a disabled by default while its a WIP, as well as to prevent the external node from being hammered it with requests from the CI.
- This PR also allows account recovery, however the above flag must be passed and the profile must be registered, however this would still require #1181
- If one sends a request to another who is not registered and/or not using the above flag, they will not receive anything until both are online. 
- At this time, profile images and banners will not be stored but instead would be transmitted to other users upon connectivity. This might change in the future but for the moment, this is to prevent any possible abuse. In addition, sending messages to one that is offline as well as file storage is not supported in this PR but will be in a near future PR. 
