### PR TITLE
fix(vscode): Remove debug arg from vscode launch

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,9 +14,6 @@
                     // "--package=example"
                 ],
             },
-            "args": [
-                "debug"
-            ],
             "cwd": "${workspaceFolder}"
         },
         {
@@ -24,9 +21,6 @@
             "type": "lldb",
             "request": "launch",
             "program": "${workspaceRoot}/target/debug/uplink",
-            "args": [
-                "debug"
-            ],
             "cwd": "${workspaceRoot}"
         },
         {
@@ -36,7 +30,6 @@
             "program": "${workspaceRoot}/target/debug/uplink",
             "args": [
                 "--with-mock",
-                "debug"
             ],
             "cwd": "${workspaceRoot}"
         }


### PR DESCRIPTION
### What this PR does 📖

- Removes debug arg from vscode launch settings since the debug arg got removed
