### PR TITLE
fix(menu): Handle outside click for mobile dropdown

### DIFF
--- a/ui/src/layouts/chats/presentation/chat/controls.rs
+++ b/ui/src/layouts/chats/presentation/chat/controls.rs
@@ -242,7 +242,7 @@ pub fn get_controls(cx: Scope<ChatProps>) -> Element {
     if minimal {
         return cx.render(rsx!(
             div {
-                z_index: 6,
+                z_index: 100,
                 Button {
                     icon: Icon::EllipsisVertical,
                     aria_label: "control-group".into(),
@@ -263,9 +263,15 @@ pub fn get_controls(cx: Scope<ChatProps>) -> Element {
             },
             show_more.then(|| {
                 rsx!(div {
-                    class: "minimal-chat-button-group",
-                    buttons
-                })
+                        class: "minimal-chat-button-group-out",
+                        onclick: move |_|{
+                            show_more.set(false);
+                        },
+                    }
+                    div {
+                        class: "minimal-chat-button-group",
+                        buttons
+                    })
             }),
             pinned
         ));

--- a/ui/src/layouts/chats/presentation/style.scss
+++ b/ui/src/layouts/chats/presentation/style.scss
@@ -69,6 +69,16 @@
         width: 60vw;
     }
 }
+
+.minimal-chat-button-group-out {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 98,
+}
+
 .minimal-chat-button-group {
     display: flex;
     flex-direction: column; 
@@ -76,7 +86,7 @@
     right: calc(var(--gap) * -1);
     top: calc(var(--gap) * -1); 
     gap: var(--gap);
-    z-index: 5;
+    z-index: 99;
     background: var(--secondary-dark);
     border-radius: var(--border-radius-more) 0 0 var(--border-radius-more);
     padding: var(--gap);


### PR DESCRIPTION
### What this PR does 📖

- Makes it so clicking outside the dropdown for controls in chat closes the dropdown
- Also fixes ui issue where scrollbar for chat was in front of dropdown

### Which issue(s) this PR fixes 🔨

- Resolve #1640
