### PR TITLE
fix(sidebar): favorite buttons get moved on sidebar close

### DIFF
--- a/kit/src/layout/slimbar/style.scss
+++ b/kit/src/layout/slimbar/style.scss
@@ -17,6 +17,9 @@
     &::-webkit-scrollbar {
         display: none; 
     }
+    .slimbar-scroll {
+        height: 100%;
+    }
 
     // TODO: This is really tricky to get to work cleanly.
     // .slimbar-scroll {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- add height to sidebar-scroll div to allow children to place correctly

### Which issue(s) this PR fixes 🔨

- Resolve #1663 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️
I tested using 3 favorites, I have a sneaking suspicion we may have other problems if we have 100 favorites but we can hope

### Additional comments 🎤

