### PR TITLE
chore(workflows): add or remove invalid PR title label automatically

### DIFF
--- a/.github/workflows/lint-PR-title.yml
+++ b/.github/workflows/lint-PR-title.yml
@@ -27,5 +27,24 @@ jobs:
             :warning: The title of this PR is invalid.
             Please make the title match the regex `(?:add|update|task|chore|feat|fix|refactor)\([a-z-A-Z]+\):\s.+`.
             e.g.) `add(cli): enable --verbose flag`, `fix(api): avoid unexpected error in handler`
+
+      - name: Add invalid PR title label if regex is not matching
+        if: ${{ steps.regex-match.outputs.match == '' }}
+        uses: buildsville/add-remove-label@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: |
+            invalid PR title
+          type: add
+
+      - name: Remove label if regex is matching
+        if: ${{ steps.regex-match.outputs.match != '' }}
+        uses: buildsville/add-remove-label@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: |
+            invalid PR title
+          type: remove
+
       - run: exit 1
         if: ${{ steps.regex-match.outputs.match == '' }}


### PR DESCRIPTION
### What this PR does 📖

- Add or remove "invalid PR title" label on PR's depending on results from Lint PR title workflow

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

