### PR TITLE
chore(cargo): Update warp dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,6 +534,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8489,7 +8500,7 @@ checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
 [[package]]
 name = "shuttle"
 version = "0.1.0"
-source = "git+https://github.com/Satellite-im/Warp?rev=ac92f8f7a683b8f4a6954349c983a4fe5e32dc1e#ac92f8f7a683b8f4a6954349c983a4fe5e32dc1e"
+source = "git+https://github.com/Satellite-im/Warp?rev=a92a3674cd1d2e700e5275beb606984160cb9532#a92a3674cd1d2e700e5275beb606984160cb9532"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -9888,7 +9899,7 @@ dependencies = [
 [[package]]
 name = "warp"
 version = "0.1.0"
-source = "git+https://github.com/Satellite-im/Warp?rev=ac92f8f7a683b8f4a6954349c983a4fe5e32dc1e#ac92f8f7a683b8f4a6954349c983a4fe5e32dc1e"
+source = "git+https://github.com/Satellite-im/Warp?rev=a92a3674cd1d2e700e5275beb606984160cb9532#a92a3674cd1d2e700e5275beb606984160cb9532"
 dependencies = [
  "aes-gcm 0.10.3",
  "anyhow",
@@ -9934,7 +9945,6 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "uuid",
- "warp-derive",
  "wasm-bindgen",
  "web-sys",
  "x25519-dalek 1.1.1",
@@ -9944,7 +9954,7 @@ dependencies = [
 [[package]]
 name = "warp-blink-wrtc"
 version = "0.1.0"
-source = "git+https://github.com/Satellite-im/Warp?rev=ac92f8f7a683b8f4a6954349c983a4fe5e32dc1e#ac92f8f7a683b8f4a6954349c983a4fe5e32dc1e"
+source = "git+https://github.com/Satellite-im/Warp?rev=a92a3674cd1d2e700e5275beb606984160cb9532#a92a3674cd1d2e700e5275beb606984160cb9532"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -9974,21 +9984,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "warp-derive"
-version = "0.1.0"
-source = "git+https://github.com/Satellite-im/Warp?rev=ac92f8f7a683b8f4a6954349c983a4fe5e32dc1e#ac92f8f7a683b8f4a6954349c983a4fe5e32dc1e"
-dependencies = [
- "paste",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "warp-ipfs"
 version = "0.1.0"
-source = "git+https://github.com/Satellite-im/Warp?rev=ac92f8f7a683b8f4a6954349c983a4fe5e32dc1e#ac92f8f7a683b8f4a6954349c983a4fe5e32dc1e"
+source = "git+https://github.com/Satellite-im/Warp?rev=a92a3674cd1d2e700e5275beb606984160cb9532#a92a3674cd1d2e700e5275beb606984160cb9532"
 dependencies = [
  "anyhow",
+ "async-recursion 1.0.5",
  "async-stream",
  "async-trait",
  "bayespam",
@@ -11145,7 +11146,7 @@ dependencies = [
  "async-executor",
  "async-io 1.13.0",
  "async-lock 2.8.0",
- "async-recursion",
+ "async-recursion 0.3.2",
  "async-task",
  "async-trait",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,9 +45,9 @@ arboard = "3.2"
 humansize = "2.1.3"
 uuid = { version = "1", features = ["serde", "v4"] }
 libloading = "0.7.4"
-warp = { git = "https://github.com/Satellite-im/Warp", rev = "ac92f8f7a683b8f4a6954349c983a4fe5e32dc1e" }
-warp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "ac92f8f7a683b8f4a6954349c983a4fe5e32dc1e" }
-warp-blink-wrtc = { git = "https://github.com/Satellite-im/Warp", rev = "ac92f8f7a683b8f4a6954349c983a4fe5e32dc1e" }
+warp = { git = "https://github.com/Satellite-im/Warp", rev = "a92a3674cd1d2e700e5275beb606984160cb9532" }
+warp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "a92a3674cd1d2e700e5275beb606984160cb9532" }
+warp-blink-wrtc = { git = "https://github.com/Satellite-im/Warp", rev = "a92a3674cd1d2e700e5275beb606984160cb9532" }
 rfd = "0.11.3"
 mime = "0.3.16"
 serde = "1.0"

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -31,7 +31,7 @@ pub use ui::{Theme, ToastNotification, UI};
 use warp::blink::BlinkEventKind;
 use warp::constellation::Progression;
 use warp::multipass::identity::Platform;
-use warp::raygun::{ConversationType, Location, Reaction};
+use warp::raygun::{ConversationType, Location};
 
 use crate::STATIC_ARGS;
 
@@ -1146,7 +1146,7 @@ impl State {
 
     // this is used for adding/removing reactions.
     // if pinned messages ever need to display a reaction, additional code may be needed here.
-    pub fn update_reactions(&mut self, mut message: warp::raygun::Message) {
+    pub fn update_reactions(&mut self, message: warp::raygun::Message) {
         let conv = match self.chats.all.get_mut(&message.conversation_id()) {
             Some(c) => c,
             None => {
@@ -1160,15 +1160,7 @@ impl State {
             .iter_mut()
             .find(|m| m.inner.id() == message_id)
         {
-            let mut reactions: Vec<Reaction> = Vec::new();
-            for mut reaction in message.reactions() {
-                let users_not_duplicated: HashSet<DID> =
-                    HashSet::from_iter(reaction.users().iter().cloned());
-                reaction.set_users(users_not_duplicated.into_iter().collect());
-                reactions.insert(0, reaction);
-            }
-            message.set_reactions(reactions);
-            msg.inner = message.clone();
+            *msg.inner.reactions_mut() = message.reactions();
         } else {
             log::warn!("attempted to update a message which wasn't found");
         }

--- a/common/src/testing/mock.rs
+++ b/common/src/testing/mock.rs
@@ -103,7 +103,6 @@ fn generate_fake_chat(participants: Vec<Identity>, conversation: Uuid) -> Chat {
         let mut default_message = Message::default();
         default_message.set_conversation_id(conversation);
         default_message.set_sender(sender.did_key());
-        default_message.set_reactions(vec![]);
         default_message.set_lines(vec![lipsum(word_count)]);
 
         messages.push_back(ui_adapter::Message {
@@ -256,7 +255,6 @@ fn generate_fake_message(conversation_id: Uuid, identities: &[Identity]) -> ui_a
     default_message.set_conversation_id(conversation_id);
     default_message.set_date(timestamp);
     default_message.set_sender(sender.did_key());
-    default_message.set_reactions(vec![]);
     default_message.set_replied(None);
     default_message.set_lines(vec![text.into()]);
 

--- a/common/src/warp_runner/manager/commands/raygun_commands.rs
+++ b/common/src/warp_runner/manager/commands/raygun_commands.rs
@@ -12,7 +12,9 @@ use warp::{
     crypto::DID,
     error::Error,
     logging::tracing::log,
-    raygun::{self, AttachmentKind, ConversationType, Location, PinState, ReactionState},
+    raygun::{
+        self, AttachmentKind, ConversationType, GroupSettings, Location, PinState, ReactionState,
+    },
 };
 
 use crate::{
@@ -611,7 +613,7 @@ async fn raygun_create_group_conversation(
     group_name: Option<String>,
 ) -> Result<Uuid, Error> {
     match messaging
-        .create_group_conversation(group_name, recipients)
+        .create_group_conversation(group_name, recipients, GroupSettings::default())
         .await
     {
         Ok(conv) | Err(Error::ConversationExist { conversation: conv }) => Ok(conv.id()),

--- a/common/src/warp_runner/mod.rs
+++ b/common/src/warp_runner/mod.rs
@@ -23,7 +23,7 @@ use warp::{
     tesseract::Tesseract,
 };
 use warp_ipfs::{
-    config::{Config, Discovery, UpdateEvents, Bootstrap},
+    config::{Bootstrap, Config, Discovery, UpdateEvents},
     WarpIpfsBuilder,
 };
 
@@ -384,7 +384,7 @@ async fn warp_initialization(tesseract: Tesseract) -> Result<manager::Warp, warp
     // Discovery is disabled by default for now but may offload manual discovery through a separate service
     // in the near future
     config.store_setting.discovery = Discovery::from(&STATIC_ARGS.discovery);
-    
+
     config.save_phrase = true; // TODO: This should be bound to a setting within Uplink so that the user can choose not to reveal the phrase for increased security.``
     config.bootstrap = Bootstrap::None;
     config.ipfs_setting.disable_quic = !STATIC_ARGS.enable_quic;

--- a/common/src/warp_runner/mod.rs
+++ b/common/src/warp_runner/mod.rs
@@ -23,7 +23,7 @@ use warp::{
     tesseract::Tesseract,
 };
 use warp_ipfs::{
-    config::{Config, Discovery, UpdateEvents},
+    config::{Config, Discovery, UpdateEvents, Bootstrap},
     WarpIpfsBuilder,
 };
 
@@ -384,8 +384,9 @@ async fn warp_initialization(tesseract: Tesseract) -> Result<manager::Warp, warp
     // Discovery is disabled by default for now but may offload manual discovery through a separate service
     // in the near future
     config.store_setting.discovery = Discovery::from(&STATIC_ARGS.discovery);
-
+    
     config.save_phrase = true; // TODO: This should be bound to a setting within Uplink so that the user can choose not to reveal the phrase for increased security.``
+    config.bootstrap = Bootstrap::None;
     config.ipfs_setting.disable_quic = !STATIC_ARGS.enable_quic;
     config.ipfs_setting.portmapping = true;
     config.ipfs_setting.agent_version = Some(format!("uplink/{}", env!("CARGO_PKG_VERSION")));

--- a/ui/src/layouts/chats/presentation/messages/coroutines.rs
+++ b/ui/src/layouts/chats/presentation/messages/coroutines.rs
@@ -450,13 +450,14 @@ pub fn handle_warp_commands(
                 match cmd {
                     MessagesCommand::React((user, message, emoji)) => {
                         let (tx, rx) = futures::channel::oneshot::channel();
-                        let reaction_state =
-                            match message.reactions().iter().find(|x| x.emoji() == emoji) {
-                                Some(reaction) if reaction.users().contains(&user) => {
-                                    ReactionState::Remove
-                                }
-                                _ => ReactionState::Add,
-                            };
+                        let reaction_state = match message
+                            .reactions()
+                            .iter()
+                            .find(|(message_emoji, _)| emoji == message_emoji.to_string())
+                        {
+                            Some((_, users)) if users.contains(&user) => ReactionState::Remove,
+                            _ => ReactionState::Add,
+                        };
                         if let Err(e) = warp_cmd_tx.send(WarpCmd::RayGun(RayGunCmd::React {
                             conversation_id: message.conversation_id(),
                             message_id: message.id(),

--- a/ui/src/layouts/chats/presentation/messages/mod.rs
+++ b/ui/src/layouts/chats/presentation/messages/mod.rs
@@ -547,14 +547,13 @@ fn render_message<'a>(cx: Scope<'a, MessageProps<'a>>) -> Element<'a> {
         .inner
         .reactions()
         .iter()
-        .map(|x| {
-            let users = x.users();
+        .map(|(emoji, users)| {
             let user_names: Vec<String> = users
                 .iter()
                 .filter_map(|id| state.read().get_identity(id).map(|x| x.username()))
                 .collect();
             ReactionAdapter {
-                emoji: x.emoji(),
+                emoji: emoji.into(),
                 reaction_count: users.len(),
                 self_reacted: users.iter().any(|x| x == &user_did),
                 alt: user_names.join(", "),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Change how the index signals the task to export
- Prevent request from being excluded when receiving document over mesh
- Change internal events to send conversation document directly, and how update events are handled internally
- Added `GroupSettings` to `RayGun::create_group_conversation`, with a single setting to allow for open or closed groups
- Update group conversation with a block list when group creator blocks/unblocks a user.
- Change internal conversation signature.
- Optimize internal task to prevent a possible race during cleanup
- Use `BTreeMap` for storing reactions instead of a vector
- Store thumbnail internally, adding a reference to `File`.

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️
- This PR breaks compatibility with the previous commit. Although you should not need a new identity (since there is no breaking change there), conversations may not load or may not be compatible. Furthermore, group conversations in this PR will not be compatible with the any previous commit.
- Should possibly resolve https://github.com/Satellite-im/Uplink/issues/1680 when updating identity using the shuttle discovery.

### Additional comments 🎤

