### PR TITLE
fix(groups): Fix search crashes

### DIFF
--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -1625,7 +1625,7 @@ impl State {
             if v.len() < name_prefix.len() {
                 false
             } else {
-                v[..(name_prefix.len())].eq_ignore_ascii_case(name_prefix)
+                v.to_lowercase().starts_with(name_prefix)
             }
         };
 

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -1625,7 +1625,6 @@ impl State {
             if v.len() < name_prefix.len() {
                 false
             } else {
-                log::debug!("v {v} prefix : {name_prefix}");
                 v.to_lowercase().starts_with(&name_prefix.to_lowercase())
             }
         };

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -1625,7 +1625,8 @@ impl State {
             if v.len() < name_prefix.len() {
                 false
             } else {
-                v.to_lowercase().starts_with(name_prefix)
+                log::debug!("v {v} prefix : {name_prefix}");
+                v.to_lowercase().starts_with(&name_prefix.to_lowercase())
             }
         };
 


### PR DESCRIPTION
### What this PR does 📖

- Fixes crash when searching for groups if a group has chars that are bigger than a byte (usually non latin chars)

### Which issue(s) this PR fixes 🔨

- Resolve #1700
