### PR TITLE
chore(ci): fix warning on workflow

### DIFF
--- a/.github/workflows/ui-test-automation.yml
+++ b/.github/workflows/ui-test-automation.yml
@@ -531,14 +531,13 @@ jobs:
 
   remove-label:
     needs:
-      [
-        build-mac,
-        build-windows,
-        test-mac,
-        test-mac-chats,
-        test-windows,
-        publish-results,
-      ]
+    - build-mac
+    - build-windows
+    - test-mac
+    - test-mac-chats
+    - test-windows
+    - publish-results
+
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- I noticed this warning `unexpected end of the stream within a flow collection` on the workflow when the file is on edit mode

<img width="341" alt="Captura de ecrã 2024-01-19, às 20 33 37" src="https://github.com/Satellite-im/Uplink/assets/29093946/5e63976e-9abe-4aa1-9107-8cb5d2ae5772">
<img width="451" alt="Captura de ecrã 2024-01-19, às 20 33 40" src="https://github.com/Satellite-im/Uplink/assets/29093946/ce6f7fae-d82b-4501-87b3-974e599ccd06">


so i tried this

<img width="369" alt="Captura de ecrã 2024-01-19, às 20 31 53" src="https://github.com/Satellite-im/Uplink/assets/29093946/71006ff2-f29f-4f58-9915-5ddf9c76a18f">

checking if is all green with CI 