### PR TITLE
fix(themes): change link color

### DIFF
--- a/kit/src/style.scss
+++ b/kit/src/style.scss
@@ -262,7 +262,7 @@ pre code {
   --text-color-muted: #aaafb2;
   --text-color-dark: #343a40;
   --text-color-bright: #ffffff;
-  --text-color-link: #ff860d;
+  --text-color-link: #4761fc;
   --text-color-user-tag: #576ae5b1;
   --text-selection: #e0e0e0;
   --placeholder: #bcbcbc;


### PR DESCRIPTION
### What this PR does 📖

- Changes link color to a blue color. Since most sites and app do this. Also fixes color not super visible in light theme

### Which issue(s) this PR fixes 🔨

- Resolve #1746

