### PR TITLE
chore(misc): Add env variable for list of addresses for shuttle discovery

### DIFF
--- a/common/src/warp_runner/mod.rs
+++ b/common/src/warp_runner/mod.rs
@@ -369,6 +369,8 @@ impl From<&DiscoveryMode> for Discovery {
                     true => env_addrs
                 };
 
+                log::info!("shuttle addresses: {:?}", addresses);
+
                 Discovery::Shuttle { addresses }
             }
             DiscoveryMode::Disable => Discovery::None,

--- a/common/src/warp_runner/mod.rs
+++ b/common/src/warp_runner/mod.rs
@@ -351,9 +351,23 @@ impl From<&DiscoveryMode> for Discovery {
                 },
             },
             DiscoveryMode::Shuttle => {
-                let addresses = Vec::from_iter(["/ip4/104.236.194.35/tcp/34053/p2p/12D3KooWJSes8386p2T1sMeZ2DzsNJThKkZWbj4US6uPMpEgBTHu"
-                .parse()
-                .expect("valid addr")]);
+                let env_addrs = match cfg!(feature = "production_mode") {
+                    true => std::env::var("SHUTTLE_ADDR_POINT")
+                        .map(|val| {
+                            val.split(',')
+                                .filter_map(|addr_str| addr_str.parse::<_>().ok())
+                                .collect::<Vec<_>>()
+                        })
+                        .unwrap_or_default(),
+                    false => vec![],
+                };
+
+                let  addresses = match env_addrs.is_empty() {
+                    false => Vec::from_iter(["/ip4/104.236.194.35/tcp/34053/p2p/12D3KooWJSes8386p2T1sMeZ2DzsNJThKkZWbj4US6uPMpEgBTHu"
+                                .parse()
+                                .expect("valid addr")]),
+                    true => env_addrs
+                };
 
                 Discovery::Shuttle { addresses }
             }

--- a/common/src/warp_runner/mod.rs
+++ b/common/src/warp_runner/mod.rs
@@ -352,14 +352,14 @@ impl From<&DiscoveryMode> for Discovery {
             },
             DiscoveryMode::Shuttle => {
                 let env_addrs = match cfg!(feature = "production_mode") {
-                    true => std::env::var("SHUTTLE_ADDR_POINT")
+                    false => std::env::var("SHUTTLE_ADDR_POINT")
                         .map(|val| {
                             val.split(',')
                                 .filter_map(|addr_str| addr_str.parse::<_>().ok())
                                 .collect::<Vec<_>>()
                         })
                         .unwrap_or_default(),
-                    false => vec![],
+                    true => vec![],
                 };
 
                 let  addresses = match env_addrs.is_empty() {

--- a/common/src/warp_runner/mod.rs
+++ b/common/src/warp_runner/mod.rs
@@ -369,7 +369,7 @@ impl From<&DiscoveryMode> for Discovery {
                     false => env_addrs
                 };
 
-                log::info!("shuttle addresses: {:?}", addresses);
+                log::debug!("shuttle addresses: {:?}", addresses);
 
                 Discovery::Shuttle { addresses }
             }

--- a/common/src/warp_runner/mod.rs
+++ b/common/src/warp_runner/mod.rs
@@ -351,18 +351,15 @@ impl From<&DiscoveryMode> for Discovery {
                 },
             },
             DiscoveryMode::Shuttle => {
-                let env_addrs = match cfg!(feature = "production_mode") {
-                    false => std::env::var("SHUTTLE_ADDR_POINT")
-                        .map(|val| {
-                            val.split(',')
-                                .filter_map(|addr_str| addr_str.parse::<_>().ok())
-                                .collect::<Vec<_>>()
-                        })
-                        .unwrap_or_default(),
-                    true => vec![],
-                };
+                let env_addrs = std::env::var("SHUTTLE_ADDR_POINT")
+                    .map(|val| {
+                        val.split(',')
+                            .filter_map(|addr_str| addr_str.parse::<_>().ok())
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
 
-                let  addresses = match env_addrs.is_empty() {
+                let addresses = match env_addrs.is_empty() {
                     true => Vec::from_iter(["/ip4/104.236.194.35/tcp/34053/p2p/12D3KooWJSes8386p2T1sMeZ2DzsNJThKkZWbj4US6uPMpEgBTHu"
                                 .parse()
                                 .expect("valid addr")]),

--- a/common/src/warp_runner/mod.rs
+++ b/common/src/warp_runner/mod.rs
@@ -363,10 +363,10 @@ impl From<&DiscoveryMode> for Discovery {
                 };
 
                 let  addresses = match env_addrs.is_empty() {
-                    false => Vec::from_iter(["/ip4/104.236.194.35/tcp/34053/p2p/12D3KooWJSes8386p2T1sMeZ2DzsNJThKkZWbj4US6uPMpEgBTHu"
+                    true => Vec::from_iter(["/ip4/104.236.194.35/tcp/34053/p2p/12D3KooWJSes8386p2T1sMeZ2DzsNJThKkZWbj4US6uPMpEgBTHu"
                                 .parse()
                                 .expect("valid addr")]),
-                    true => env_addrs
+                    false => env_addrs
                 };
 
                 log::info!("shuttle addresses: {:?}", addresses);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Add environment variable to provide a list addresses to use for shuttle discovery

### Which issue(s) this PR fixes 🔨

- Resolve #1756 
- Relates to #1771 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
- ~~This variable is used mostly for testing (including CI). In production (with the `production_mode` feature used), this variable is ignored while changes in the future may allow a list of addresses to be provided via command line arguments or from the state.~~
- If a address is not supplied, or all addresses are invalid (eg incorrect formatting), this will fallback to the current node that is set. 
