### PR TITLE
chore(script): fix assistant.sh script

### DIFF
--- a/assistant.sh
+++ b/assistant.sh
@@ -1,20 +1,78 @@
 #!/bin/sh
 
-MODE=$(gum choose "Build Extensions" "Build UI")
-FLAGS=$(gum choose " --profile=rapid" " --profile=dev" " --profile=release")
+# Check if 'gum' is available in the system
+if ! command -v gum &> /dev/null; then
+    echo "'gum' is not found. Attempting to install it using Homebrew..."
+    
+    # Check if Homebrew is installed
+    if ! command -v brew &> /dev/null; then
+        echo "Homebrew is not installed. Please install Homebrew (https://brew.sh/) and try again."
+        exit 1
+    fi
 
-case $MODE in
-  "Build Extensions")
-        echo "cargo build --all ${FLAGS}"
-        if [ $FLAGS != " --profile=release" ]
-        then
-            echo "cp -r target/debug/*.dylib ~/.uplink/extensions"
-        else
-            echo "cp -r target/release/*.dylib ~/.uplink/extensions"
-        fi
+    # Install 'gum' using Homebrew
+    brew install gum
+
+    # Check if the installation was successful
+    if ! command -v gum &> /dev/null; then
+        echo "Failed to install 'gum'. Please install it manually and try again."
+        exit 1
+    fi
+fi
+
+echo "Select an action:"
+echo "1. Build Extensions"
+echo "2. Build UI"
+echo "3. Help"
+echo "4. Run Clippy"
+echo "5. Run Fmt"
+echo "6. Auto-fix Clippy"
+echo "7. Auto-fix Fmt"
+
+read -p "Enter your choice (1/2/3/4/5/6/7): " choice
+
+case $choice in
+  1)
+    FLAGS=$(echo " --profile=rapid" " --profile=dev" " --profile=release" | xargs -n1 | gum choose)
+    echo "cargo build --all ${FLAGS}"
+    if [ "$FLAGS" != " --profile=release" ]; then
+      echo "cp -r target/debug/*.dylib ~/.uplink/extensions"
+    else
+      echo "cp -r target/release/*.dylib ~/.uplink/extensions"
+    fi
+    ;;
+  2)
+    echo "Building UI..."
+    cargo run
+    ;;
+  3)
+    echo "Usage: $0"
+    echo "Options:"
+    echo "  1. Build Extensions: Build extensions for the specified profile"
+    echo "  2. Build UI: Build the user interface"
+    echo "  3. Help: Show this help message"
+    echo "  4. Run Clippy: Run the Clippy linter"
+    echo "  5. Run Fmt: Run the Rust formatter in check mode"
+    echo "  6. Auto-fix Clippy: Automatically fix Clippy warnings"
+    echo "  7. Auto-fix Fmt: Automatically format the code using Rust fmt"
+    ;;
+  4)
+    echo "Running Clippy..."
+    cargo clippy
+    ;;
+  5)
+    echo "Running Fmt..."
+    cargo fmt --check
+    ;;
+  6)
+    echo "Auto-fixing Clippy warnings..."
+    cargo clippy --fix
+    ;;
+  7)
+    echo "Auto-fixing Fmt..."
+    cargo fmt
     ;;
   *)
-    # TODO: help here
-    echo "sorry, this isn't built yet."
+    echo "Invalid choice. Please select a valid option."
     ;;
 esac


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

in dev, would only have option 1, 2 and 3 and would not install `gum` if wasn't already installed

<img width="429" alt="Captura de ecrã 2024-01-30, às 01 02 36" src="https://github.com/Satellite-im/Uplink/assets/29093946/1d17d8a7-0af0-4250-b345-f4b708056648">

 and the 2) would say the following


![image](https://github.com/Satellite-im/Uplink/assets/29093946/02f39d7c-4f35-41aa-a1b1-49fee45b0101)


in this branch, if you don't have `gum` installed, will install automatically using brew

https://github.com/Satellite-im/Uplink/assets/29093946/a4236c15-c17b-49b4-976a-0041c052f36d

then you have the following options

1) it shows 3 options and then selecting each one it tells you the extensions command
in this case it doesnt really execute just writes the command for the user to use 😂 
2) executes `cargo run`
3) list of each option in more detail
4) to run `clippy`
5) to run `fmt`
6) to auto fix `clippy` 
7) to auto fix `fmt`


https://github.com/Satellite-im/Uplink/assets/29093946/cbe05fe4-8921-4750-9033-3c9c4f51eb51






if you have changes locally will warn you about those when running the auto fix linter commands

<img width="963" alt="Captura de ecrã 2024-01-30, às 00 49 51" src="https://github.com/Satellite-im/Uplink/assets/29093946/395693bc-935d-4a72-ae6b-11caddf2dc98">




