### PR TITLE
chore(icon): update icon when sharing DID

### DIFF
--- a/ui/src/components/friends/friends_list/mod.rs
+++ b/ui/src/components/friends/friends_list/mod.rs
@@ -450,7 +450,7 @@ pub fn ShareFriendsModal(cx: Scope<FriendProps>) -> Element {
                     class: "send-chat-button",
                     Button {
                         text: get_local_text("friends.share-to-chat"),
-                        icon: Icon::ArrowTopRightOnSquare,
+                        icon: Icon::Share,
                         aria_label: "share_to_chat".into(),
                         appearance: Appearance::Secondary,
                         disabled: chats_selected.read().is_empty(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖


atm when you go to chat > share did > this is the icon that would appear


![image](https://github.com/Satellite-im/Uplink/assets/29093946/c7f21e94-3ed2-4c54-ad16-843b7242a705)


that icon is related to external links so it wasn't the correct icon

i've updated to this

<img width="518" alt="Captura de ecrã 2024-01-30, às 17 32 10" src="https://github.com/Satellite-im/Uplink/assets/29093946/429e0068-4987-428e-b402-aec394fdfe50">


flow
- go to chat
- share did
- icon appears fine