### PR TITLE
chore(appium): update ui automated tests to run on macos 14

### DIFF
--- a/.github/workflows/ui-test-automation.yml
+++ b/.github/workflows/ui-test-automation.yml
@@ -51,7 +51,7 @@ jobs:
 
   build-mac:
     needs: create-node
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Checkout Uplink Repo 🔖
         uses: actions/checkout@v4
@@ -183,7 +183,7 @@ jobs:
 
   test-mac:
     needs: build-mac
-    runs-on: macos-13
+    runs-on: macos-14
 
     steps:
       - name: Checkout testing directory 🔖
@@ -315,7 +315,7 @@ jobs:
 
   test-mac-chats:
     needs: build-mac
-    runs-on: macos-13
+    runs-on: macos-14
 
     steps:
       - name: Checkout testing directory 🔖


### PR DESCRIPTION
### What this PR does 📖

- Upgrading GH macos runner used for CI automated tests to macos-14

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

