### PR TITLE
update(FilePreview): Add option to listen to audio files 

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -219,12 +219,6 @@ pub fn return_correct_icon(file_name: &str) -> Icon {
     if is_audio(file_name) {
         return Icon::DocumentAudio;
     }
-    if DOC_EXTENSIONS
-        .iter()
-        .any(|x| file_name.to_lowercase().ends_with(x))
-    {
-        return Icon::Document;
-    }
     Icon::Document
 }
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -217,7 +217,7 @@ pub fn return_correct_icon(file_name: &str) -> Icon {
         return Icon::DocumentMedia;
     }
     if is_audio(file_name) {
-        return Icon::DocumentMedia;
+        return Icon::DocumentAudio;
     }
     if DOC_EXTENSIONS
         .iter()

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -11,6 +11,7 @@ use anyhow::bail;
 use clap::Parser;
 // export icons crate
 pub use icons;
+use icons::outline::Shape as Icon;
 use once_cell::sync::Lazy;
 use std::{
     path::{Path, PathBuf},
@@ -195,12 +196,36 @@ pub const VIDEO_FILE_EXTENSIONS: &[&str] = &[
     ".mp4", ".mov", ".mkv", ".avi", ".flv", ".wmv", ".m4v", ".3gp",
 ];
 
+pub const AUDIO_FILE_EXTENSIONS: &[&str] = &[".mp3", ".wav", ".ogg", ".flac", ".aac", ".m4a"];
+
 pub const DOC_EXTENSIONS: &[&str] = &[".doc", ".docx", ".pdf", ".txt"];
 
 pub fn is_video(file_name: &str) -> bool {
     VIDEO_FILE_EXTENSIONS
         .iter()
         .any(|x| file_name.to_lowercase().ends_with(x))
+}
+
+pub fn is_audio(file_name: &str) -> bool {
+    AUDIO_FILE_EXTENSIONS
+        .iter()
+        .any(|x| file_name.to_lowercase().ends_with(x))
+}
+
+pub fn return_correct_icon(file_name: &str) -> Icon {
+    if is_video(file_name) {
+        return Icon::DocumentMedia;
+    }
+    if is_audio(file_name) {
+        return Icon::DocumentMedia;
+    }
+    if DOC_EXTENSIONS
+        .iter()
+        .any(|x| file_name.to_lowercase().ends_with(x))
+    {
+        return Icon::Document;
+    }
+    Icon::Document
 }
 
 pub fn get_images_dir() -> anyhow::Result<PathBuf> {

--- a/kit/src/components/embeds/file_embed/mod.rs
+++ b/kit/src/components/embeds/file_embed/mod.rs
@@ -5,7 +5,9 @@ use crate::elements::button::Button;
 use crate::elements::Appearance;
 use common::icons::outline::Shape as Icon;
 use common::icons::Icon as IconElement;
+use common::is_audio;
 use common::is_video;
+use common::return_correct_icon;
 use common::utils::local_file_path::get_fixed_path_to_load_local_file;
 use common::STATIC_ARGS;
 use dioxus_html::input_data::keyboard_types::Modifiers;
@@ -162,6 +164,8 @@ pub fn FileEmbed<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let temp_dir = STATIC_ARGS
         .temp_files
         .join(file_name_with_extension.clone());
+    let is_video_or_audio =
+        is_video(&file_name_with_extension) || is_audio(&file_name_with_extension);
     let is_video = is_video(&file_name_with_extension);
 
     cx.render(rsx! (
@@ -228,7 +232,7 @@ pub fn FileEmbed<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                                         width: "60px",
                                         margin: "30px 0",
                                         IconElement {
-                                            icon: cx.props.attachment_icon.unwrap_or(if is_video {Icon::DocumentMedia} else {Icon::Document})
+                                            icon: cx.props.attachment_icon.unwrap_or(return_correct_icon(&file_name_with_extension.clone()))
                                         }
                                         if !file_extension_is_empty {
                                             rsx!( label {
@@ -245,12 +249,12 @@ pub fn FileEmbed<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                                     class: "document-container",
                                     height: "60px",
                                     onclick: move |mouse_event_data: Event<MouseData>| {
-                                        if mouse_event_data.modifiers() != Modifiers::CONTROL && is_video && !is_from_attachments {
+                                        if mouse_event_data.modifiers() != Modifiers::CONTROL && is_video_or_audio && !is_from_attachments {
                                             cx.props.on_press.call(Some(temp_dir.clone()));
                                         }
                                     },
                                     IconElement {
-                                        icon: cx.props.attachment_icon.unwrap_or(if is_video {Icon::DocumentMedia} else {Icon::Document})
+                                        icon: cx.props.attachment_icon.unwrap_or(return_correct_icon(&file_name_with_extension.clone()))
                                     }
                                     if !file_extension_is_empty {
                                         rsx!( label {

--- a/kit/src/elements/file/mod.rs
+++ b/kit/src/elements/file/mod.rs
@@ -1,5 +1,6 @@
 use std::ffi::OsStr;
 
+use common::return_correct_icon;
 use dioxus::prelude::*;
 use dioxus_elements::input_data::keyboard_types::Code;
 
@@ -90,7 +91,7 @@ pub fn File<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                                 "{file_extension}"
                             },
                             IconElement {
-                                icon: if is_video {Icon::DocumentMedia} else {Icon::Document}
+                                icon: return_correct_icon(&file_extension.clone())
                             }
                         )
                     } else {

--- a/ui/src/layouts/storage/files_layout/file_preview.rs
+++ b/ui/src/layouts/storage/files_layout/file_preview.rs
@@ -192,7 +192,7 @@ fn FileTypeTag(cx: Scope<FileTypeTagProps>) -> Element {
     let file_type = cx.props.file_type.clone();
     let source_path = cx.props.source.clone();
     cx.render(match file_type {
-        FileType::Video => rsx!(video {
+        FileType::Video | FileType::Audio => rsx!(video {
             id: "file_preview_img",
             aria_label: "file-preview-image",
             max_height: IMAGE_MAX_HEIGHT,
@@ -206,13 +206,6 @@ fn FileTypeTag(cx: Scope<FileTypeTagProps>) -> Element {
             aria_label: "file-preview-image",
             max_height: IMAGE_MAX_HEIGHT,
             max_width: IMAGE_MAX_WIDTH,
-            src: "{source_path}"
-        },),
-        FileType::Audio => rsx!(audio {
-            id: "file_preview_img",
-            aria_label: "file-preview-image",
-            autoplay: true,
-            controls: true,
             src: "{source_path}"
         },),
     })

--- a/ui/src/layouts/storage/shared_component.rs
+++ b/ui/src/layouts/storage/shared_component.rs
@@ -6,9 +6,9 @@ use crate::layouts::storage::send_files_layout::send_files_components::{
 use super::files_layout::controller::StorageController;
 use common::icons::outline::Shape as Icon;
 use common::icons::Icon as IconElement;
-use common::is_video;
 use common::state::{State, ToastNotification};
 use common::warp_runner::thumbnail_to_base64;
+use common::{is_audio, is_video};
 use common::{language::get_local_text, ROOT_DIR_NAME};
 
 use dioxus::html::input_data::keyboard_types::Code;
@@ -284,7 +284,7 @@ pub fn FilesAndFolders<'a>(cx: Scope<'a, FilesAndFoldersProps<'a>>) -> Element<'
                                         ));
                                         return;
                                     }
-                                    if file3.thumbnail().is_empty() && !is_video(&file3.name()) {
+                                    if file3.thumbnail().is_empty() && !is_video(&file3.name()) && !is_audio(&file3.name()) {
                                         state
                                         .write()
                                         .mutate(common::state::Action::AddToastNotification(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
### 1. Possible to listen audios now
#### a. Possible to listen audios from storage
#### b. Possible to listen audios from Messages
#### c. Changed Icon to user know that it is audio

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

