### PR TITLE
chore(build): update build mac workflow to macos14

### DIFF
--- a/.github/workflows/build-dmg-universal.yml
+++ b/.github/workflows/build-dmg-universal.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build_sign_macos:
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4


### PR DESCRIPTION
### What this PR does 📖

- Update build macos workflow to use macos-14 instead of macos-latest, in order to improve execution speed of this workflow

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

