### PR TITLE
fix(VideoExtensions):  Fix mkv preview

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -191,9 +191,8 @@ pub const MAX_FILES_PER_MESSAGE: usize = 8;
 
 pub const ROOT_DIR_NAME: &str = "root";
 
-pub const VIDEO_FILE_EXTENSIONS: &[&str] = &[
-    ".mp4", ".mov", ".mkv", ".avi", ".flv", ".wmv", ".m4v", ".3gp",
-];
+pub const VIDEO_FILE_EXTENSIONS: &[&str] =
+    &[".mp4", ".mov", ".avi", ".flv", ".wmv", ".m4v", ".3gp"];
 
 pub const DOC_EXTENSIONS: &[&str] = &[".doc", ".docx", ".pdf", ".txt"];
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
#### 1. To not broke videos with mkv format, how it is a complex format and html does not support it, it was removed from VIDEO_EXTENSIONS
- 

### Which issue(s) this PR fixes 🔨

- Resolve #1799 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

