### PR TITLE
chore(keybinds): remove keybinds from experimental

### DIFF
--- a/ui/src/components/settings/sidebar.rs
+++ b/ui/src/components/settings/sidebar.rs
@@ -177,9 +177,7 @@ pub fn Sidebar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     routes.push(audio);
     // routes.push(files);
     routes.push(extensions);
-    if state.read().configuration.developer.experimental_features {
-        routes.push(keybinds);
-    }
+    routes.push(keybinds);
     routes.push(accessibility);
     routes.push(notifications);
     routes.push(about);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Remove keybinds feature from experimental features

when you have developer activated, and the toggle of experimental features is deactivated the feature still appears

<img width="1013" alt="Captura de ecrã 2024-02-01, às 19 30 59" src="https://github.com/Satellite-im/Uplink/assets/29093946/8e8b8594-ae17-4643-8490-1f0617c0c13b">

when you do a new account, without developer activated, the feature still appears

<img width="950" alt="Captura de ecrã 2024-02-01, às 19 32 03" src="https://github.com/Satellite-im/Uplink/assets/29093946/4fc4b45f-cdb9-423a-b2ba-c930c026a323">


flow
- keybinds feature should appear on a brand new account
- keybinds feature should appear even when in developer settings experimental features toggle is both either deactivated or activated
- keybinds feature should work the same as dev
