### PR TITLE
add(aria): add aria label for input error on enter seed

### DIFF
--- a/ui/src/layouts/log_in/enter_seed_words.rs
+++ b/ui/src/layouts/log_in/enter_seed_words.rs
@@ -133,6 +133,7 @@ pub fn Layout(cx: Scope, pin: UseRef<String>, page: UseState<AuthPages>) -> Elem
             },
             seed_error.as_ref().map(|e| rsx!(
                 span {
+                    aria_label: "input-error",
                     class: "error",
                     e.translation()
                 }


### PR DESCRIPTION
### What this PR does 📖

- Adding aria label for new input error message shown when entering a wrong seed phrase
- Required to add automated test for this test case (entering invalid seed phrase)

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

