### PR TITLE
chore(appium): upgrade rust toolchain on test jobs

### DIFF
--- a/.github/workflows/ui-test-automation.yml
+++ b/.github/workflows/ui-test-automation.yml
@@ -199,7 +199,7 @@ jobs:
       - name: Install Rust 💿
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.73.0
+          toolchain: 1.74.0
           override: true
           components: rustfmt, clippy
 
@@ -332,7 +332,7 @@ jobs:
       - name: Install Rust 💿
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.73.0
+          toolchain: 1.74.0
           override: true
           components: rustfmt, clippy
 
@@ -464,7 +464,7 @@ jobs:
       - name: Install Rust 💿
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.73.0
+          toolchain: 1.74.0
           override: true
           components: rustfmt, clippy
 


### PR DESCRIPTION
### What this PR does 📖

- Upgrade rust toolchain from 1.73 to 1.74 on test jobs from automation tests workflow, since suddenly we started to receive an error on the step of running ```cargo build --bin shuttle --release``` stating the following: "error: package `clap_derive v4.5.0` cannot be built because it requires rustc 1.74 or newer"

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

