### PR TITLE
chore(debug): Don't link debug info for dev profile

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[profile.dev]
+debug = 0
+strip = "debuginfo"
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

This helps with lowering the build time for dev (which is what's used by default by rust-analyzer when checking the code). This change combined with use of mold (or sold for Mac) improve the cold build time by 12%.

Not including the linker configuration here because that requires separately building/installing the linker first. For Linux, the instructions for mold are [here][mi] and the configuration is [here][mc].

For Mac, [sold] can be built using the same (similar) instructions. The configuration can be put in `~/.cargo/config.toml`. Mine is as follows:

```toml
[target.aarch64-apple-darwin]
linker = "clang"
rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/ld64.sold"]
```

The linker optimization esecially helps warm builds, which is again what affects the rust-analyzer checks.

**Note:** the linker optimization applies to all profiles so it's highly recommended.

[mi]: https://github.com/rui314/mold?tab=readme-ov-file#compile-mold
[mc]: https://github.com/rui314/mold?tab=readme-ov-file#how-to-use
[sold]: https://github.com/bluewhalesystems/sold
