### PR TITLE
fix(Shortcut): Fix black screen after shortcut to hide the app

### DIFF
--- a/ui/src/utils/keyboard/shortcut_handlers/navigation.rs
+++ b/ui/src/utils/keyboard/shortcut_handlers/navigation.rs
@@ -1,8 +1,15 @@
 use dioxus_core::ScopeState;
 use dioxus_desktop::use_window;
 
+/// The functionality will operate correctly only when the application is not in fullscreen mode.
+///
+/// In fullscreen mode, activating the shortcut for the first time will minimize the application.
+///
+/// Upon a second activation, the shortcut will then execute the intended action of hiding the application.
 pub fn set_app_visible(cx: &ScopeState) {
     let window = use_window(cx);
+
+    window.set_fullscreen(false);
 
     if !window.is_focused() && !window.is_minimized() {
         window.set_focus();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
### 1. Fix black screen after shortcut to hide the app 
Obs: If app is on fullscreen, first time, it will minimize the app, just when app is not more on fullscreen mode, and user press shortcut, then app will be hide

https://github.com/Satellite-im/Uplink/assets/63157656/b4fde4b7-c468-4c72-b836-5bf8c18b2074





### Which issue(s) this PR fixes 🔨

- Resolve #1861 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

