### PR TITLE
chore(cargo): Re-enable unwind when paniking 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,6 @@ members = [
 
 resolver = "2"
 
-[profile.dev]
-panic = "abort"
-
 [profile.rapid]
 inherits = "dev"
 opt-level = 2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

We added this previously due to https://github.com/Satellite-im/Uplink/issues/1351

This PR is to test again to see if works without crashing on macOS 14.