### PR TITLE
task(files): Add failed msg to upload failing

### DIFF
--- a/common/locales/en-US/main.ftl
+++ b/common/locales/en-US/main.ftl
@@ -107,6 +107,8 @@ messages = Messages
     .username-suggestion = Suggested Users
     .control-group = More
     .no-chats = No chats available
+    .attachments-fail = Upload Failed!
+    .attachments-fail-msg = Upload failed: { $reason }
     
 favorites = Favorites
     .favorites = Favorites

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -1262,7 +1262,8 @@ impl State {
         conv_id: Uuid,
         msg: PendingMessage,
         progress: Progression,
-    ) {
+    ) -> bool {
+        let mut update = false;
         if let Progression::ProgressFailed {
             name,
             last_size: _,
@@ -1271,9 +1272,9 @@ impl State {
         {
             let err = match error.as_ref() {
                 Some(err) => {
-                    get_local_text_with_args("attachments-fail-msg", vec![("reason", err)])
+                    get_local_text_with_args("messages.attachments-fail-msg", vec![("reason", err)])
                 }
-                None => get_local_text("attachments-fail"),
+                None => get_local_text("messages.attachments-fail"),
             };
             self.mutate(Action::AddToastNotification(ToastNotification::init(
                 name.clone(),
@@ -1281,10 +1282,12 @@ impl State {
                 None,
                 2,
             )));
+            update = true;
         }
         if let Some(chat) = self.chats.all.get_mut(&conv_id) {
             chat.update_pending_msg(msg, progress);
         }
+        update
     }
 
     pub fn decrement_outgoing_messagess(

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -1263,6 +1263,25 @@ impl State {
         msg: PendingMessage,
         progress: Progression,
     ) {
+        if let Progression::ProgressFailed {
+            name,
+            last_size: _,
+            error,
+        } = &progress
+        {
+            let err = match error.as_ref() {
+                Some(err) => {
+                    get_local_text_with_args("attachments-fail-msg", vec![("reason", err)])
+                }
+                None => get_local_text("attachments-fail"),
+            };
+            self.mutate(Action::AddToastNotification(ToastNotification::init(
+                name.clone(),
+                err,
+                None,
+                2,
+            )));
+        }
         if let Some(chat) = self.chats.all.get_mut(&conv_id) {
             chat.update_pending_msg(msg, progress);
         }

--- a/kit/src/components/embeds/file_embed/mod.rs
+++ b/kit/src/components/embeds/file_embed/mod.rs
@@ -7,6 +7,8 @@ use common::icons::outline::Shape as Icon;
 use common::icons::Icon as IconElement;
 use common::is_file_available_to_preview;
 use common::is_video;
+use common::language::get_local_text;
+use common::language::get_local_text_with_args;
 use common::return_correct_icon;
 use common::utils::local_file_path::get_fixed_path_to_load_local_file;
 use common::STATIC_ARGS;
@@ -127,9 +129,15 @@ pub fn FileEmbed<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             Progression::ProgressFailed {
                 name: _,
                 last_size: _,
-                error: _,
+                error,
             } => {
-                file_size_pending.push_str("Failed");
+                match error.as_ref() {
+                    Some(err) => file_size_pending.push_str(&get_local_text_with_args(
+                        "attachments-fail-msg",
+                        vec![("reason", err)],
+                    )),
+                    None => file_size_pending.push_str(&get_local_text("attachments-fail")),
+                }
                 0
             }
         }

--- a/kit/src/components/embeds/file_embed/mod.rs
+++ b/kit/src/components/embeds/file_embed/mod.rs
@@ -12,9 +12,8 @@ use common::language::get_local_text_with_args;
 use common::return_correct_icon;
 use common::utils::local_file_path::get_fixed_path_to_load_local_file;
 use common::STATIC_ARGS;
-use dioxus_html::input_data::keyboard_types::Modifiers;
-
 use dioxus::prelude::*;
+use dioxus_html::input_data::keyboard_types::Modifiers;
 
 use humansize::format_size;
 use humansize::DECIMAL;
@@ -133,11 +132,13 @@ pub fn FileEmbed<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             } => {
                 match error.as_ref() {
                     Some(err) => file_size_pending.push_str(&get_local_text_with_args(
-                        "attachments-fail-msg",
+                        "messages.attachments-fail-msg",
                         vec![("reason", err)],
                     )),
-                    None => file_size_pending.push_str(&get_local_text("attachments-fail")),
-                }
+                    None => {
+                        file_size_pending.push_str(&get_local_text("messages.attachments-fail"))
+                    }
+                };
                 0
             }
         }

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -505,18 +505,22 @@ fn use_app_coroutines(cx: &ScopeState) -> Option<()> {
                     msg,
                 }) = evt
                 {
-                    state
+                    if state
                         .write_silent()
-                        .update_outgoing_messages(conversation_id, msg, progress);
-                    let read = state.read();
-                    if read
-                        .get_active_chat()
-                        .map(|c| c.id.eq(&conversation_id))
-                        .unwrap_or_default()
+                        .update_outgoing_messages(conversation_id, msg, progress)
                     {
-                        //Update the component only instead of whole state
-                        if let Some(v) = read.scope_ids.pending_message_component {
-                            schedule(ScopeId(v))
+                        state.write();
+                    } else {
+                        let read = state.read();
+                        if read
+                            .get_active_chat()
+                            .map(|c| c.id.eq(&conversation_id))
+                            .unwrap_or_default()
+                        {
+                            //Update the component only instead of whole state
+                            if let Some(v) = read.scope_ids.pending_message_component {
+                                schedule(ScopeId(v))
+                            }
                         }
                     }
                 } else {


### PR DESCRIPTION
### What this PR does 📖

- Adds the error message to pending message if an error occurred during file upload
- Also show the error as a toast notification 

### Which issue(s) this PR fixes 🔨

- Resolve #1848
