### PR TITLE
chore(appium): replace default warp node on CI tests with script

### DIFF
--- a/.github/workflows/ui-test-automation.yml
+++ b/.github/workflows/ui-test-automation.yml
@@ -170,10 +170,8 @@ jobs:
 
       - name: Get Warp Peer ID and Build app 🚀
         run: |
-          $localPeerId = Select-String -Path .\warp\peerID.txt -Pattern 'Local PeerID: ([^\s]*)' | ForEach-Object { $_.Matches.Groups[1].Value }
-          echo "localPeerId=$localPeerId" >> $env:GITHUB_ENV
-          $env:SHUTTLE_ADDR_POINT="/ip4/127.0.0.1/tcp/4444/p2p/" + $localPeerId
-          cargo build --release
+          ./utils/replace_node.ps1
+          cargo build --release -F production_mode
 
       - name: Build Installer
         run: cargo wix --package uplink --no-build --nocapture

--- a/utils/replace_node.ps1
+++ b/utils/replace_node.ps1
@@ -1,0 +1,23 @@
+# Set the path to the mod.rs file
+$modRsFilePath = ".\common\src\warp_runner\mod.rs"
+
+# Read the contents of the mod.rs file
+$modRsContent = Get-Content -Path $modRsFilePath -Raw
+
+# Replace the old address with the new address in the mod.rs content
+$newModRsContentFirst = $modRsContent -replace "/ip4/104.236.194.35/tcp/34053/", "/ip4/127.0.0.1/tcp/4444/"
+
+# Set the new address based on the content of peerID.txt
+$peerIDFilePath = ".\warp\peerID.txt"
+$newPeerID = (Get-Content -Path $peerIDFilePath | Select-String -Pattern '/ip4/\d+\.\d+\.\d+\.\d+/tcp/\d+/p2p/(\S+)').Matches.Groups[1].Value
+
+# Define the old address to be replaced
+$oldPeerId = "12D3KooWJSes8386p2T1sMeZ2DzsNJThKkZWbj4US6uPMpEgBTHu"
+
+# Replace the old address with the new address in the mod.rs content
+$newModRsContentTwo = $newModRsContentFirst -replace $oldPeerId, $newPeerID
+
+# Write the modified content back to the mod.rs file
+Set-Content -Path $modRsFilePath -Value $newModRsContentTwo
+
+Write-Host "Replacement complete for Local Peer ID."

--- a/utils/replace_node.sh
+++ b/utils/replace_node.sh
@@ -4,7 +4,7 @@
 local_peer_id=$(grep -o 'Local PeerID: [^[:space:]]*' ./warp/peerID.txt | awk '{print $NF}')
 
 # Update the values in ./common/src/warp_runner/mod.rs and store in a temporary file
-sed -e "s#cargo build --release -F#SHUTTLE_ADDR_POINT=/ip4/127.0.0.1/tcp/4444/p2p/$local_peer_id cargo build --release -F#" ./Makefile > temp_file
+sed -e "s#/ip4/104.236.194.35/tcp/34053/p2p/12D3KooWJSes8386p2T1sMeZ2DzsNJThKkZWbj4US6uPMpEgBTHu#/ip4/127.0.0.1/tcp/4444/p2p/$local_peer_id#" ./common/src/warp_runner/mod.rs > temp_file
 
 # Replace the original mod.rs with the modified content
-mv temp_file ./Makefile
+mv temp_file ./common/src/warp_runner/mod.rs


### PR DESCRIPTION
### What this PR does 📖

- Launching the app executable (.app or .exe) through appium does not support passing SHUTTLE_ADDR_POINT env variable and this is making that the app is using the default SHUTTLE_ADDR_POINT instead of the custom one passed through command
- Upading scripts .ps1 and .sh to make the update of warp_runner/mod.rs file on the CI run, so the default address/peerID are the ones that were previously assigned when running the create-node step on CI workflow

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

