### PR TITLE
fix(PinnedMessage): fix pinned messages modal position

### DIFF
--- a/ui/src/layouts/chats/presentation/chat/controls.rs
+++ b/ui/src/layouts/chats/presentation/chat/controls.rs
@@ -253,6 +253,7 @@ pub fn get_controls(cx: Scope<ChatProps>) -> Element {
     let pinned = cx.render(rsx!(show_pinned.then(|| rsx!(
         Modal {
             open: true,
+            right: "8px",
             transparent: true,
             change_horizontal_position: true,
             with_title: get_local_text("messages.pin-view"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
### 1. fix pinned messages modal position

<img width="867" alt="image" src="https://github.com/Satellite-im/Uplink/assets/63157656/c36945e1-87f2-45d4-8f08-2da06e8167d5">



### Which issue(s) this PR fixes 🔨

- Resolve #1870 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

