### PR TITLE
fix(groups): Context menu renders behind group rename

### DIFF
--- a/ui/src/layouts/chats/style.scss
+++ b/ui/src/layouts/chats/style.scss
@@ -179,7 +179,7 @@
   justify-content: center;
   align-items: stretch;
   margin-right: 8px;
-  z-index: 10002; // To be above the modal
+  // z-index: 10002; // To be above the modal
 }
 
 .create-group-name {


### PR DESCRIPTION
### What this PR does 📖

- Removes the z-index for edit group div which fixes it rendering behind the context menu.
  I am unsure why we had it in the first place as the comment specifies its for it rendering above a modal but from what I'm seeing there is no modal anywhere there. It can of course be that over the course of the dev the layout changed and there is no more modal there as it was done quite a while ago. 

### Which issue(s) this PR fixes 🔨

- Resolve  #1850
