### PR TITLE
chore(toast): Remove the toast crash fix to see what happens

### DIFF
--- a/ui/src/layouts/chats/mod.rs
+++ b/ui/src/layouts/chats/mod.rs
@@ -92,12 +92,6 @@ pub fn ChatLayout(cx: Scope) -> Element {
         }
     });
 
-    // HACK: When enter in chats with notification, for some reason app is crashing
-    // this a hack solution to clear notifications and not crash app if user change to chats page
-    if !state.read().ui.toast_notifications.is_empty() {
-        state.write().ui.toast_notifications.clear();
-    }
-
     cx.render(rsx!(
         div {
             id: "chat-layout",


### PR DESCRIPTION
### What this PR does 📖

- Removes a hack fix that causes toasts to apparently crash when in chat layout. 
  The relevant merged PR for that is here #1665 which simply disables toasts for chat layout but does not actually fix the underlying issue.
  We might need to dig into the underlying cause of that crash instead to fix it.

This is relevant for following PR: 
#1877
#1876
where we want to show toasts in chat layout