### PR TITLE
fix(groups): add option to unset context-wrap width

### DIFF
--- a/kit/src/components/context_menu/mod.rs
+++ b/kit/src/components/context_menu/mod.rs
@@ -168,6 +168,7 @@ pub struct Props<'a> {
     devmode: Option<bool>,
     on_mouseenter: Option<EventHandler<'a, MouseEvent>>,
     left_click_trigger: Option<bool>,
+    fit_parent: Option<bool>,
 }
 
 #[allow(non_snake_case)]
@@ -192,7 +193,7 @@ pub fn ContextMenu<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
 
     cx.render(rsx! {
         div {
-            class: "context-wrap",
+            class: format_args!("context-wrap {}", if cx.props.fit_parent.unwrap_or_default() {"context-wrap-fit"} else {""}),
             onmouseenter: |e| {
                 if let Some(f) = cx.props.on_mouseenter.as_ref() { f.call(e) }
             },

--- a/kit/src/components/context_menu/style.scss
+++ b/kit/src/components/context_menu/style.scss
@@ -57,6 +57,9 @@
 	min-height: fit-content;
 	min-width: fit-content;
 	display: inline-flex;
+	&.context-wrap-fit {
+		min-width: unset;
+	}
 }
 .context-menu.hidden {
 	display: none;

--- a/ui/src/layouts/chats/presentation/chat/topbar.rs
+++ b/ui/src/layouts/chats/presentation/chat/topbar.rs
@@ -145,6 +145,7 @@ pub fn get_topbar_children(cx: Scope<ChatProps>) -> Element {
         )}
         ContextMenu {
             id: "chat_topbar_context".into(),
+            fit_parent: true,
             key: "{cx.props.channel.id}-channel",
             devmode: state.read().configuration.developer.developer_mode,
             items: cx.render(rsx!(


### PR DESCRIPTION
### What this PR does 📖

- Adds option for context menu to unset `min-width` style which fixes the problem with renaming group text being cut off

### Which issue(s) this PR fixes 🔨

- Resolve #1851