### PR TITLE
chore(appium): save uplink logs as artifacts on failure

### DIFF
--- a/.github/workflows/ui-test-automation.yml
+++ b/.github/workflows/ui-test-automation.yml
@@ -447,6 +447,15 @@ jobs:
           name: appium-log-macos-chats
           path: ./appium.log
 
+      - name: Upload Uplink Logs if test fails 📷
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: uplink-logs
+          path: |
+            ~/.uplink/.user/debug.log
+            ~/.uplinkUserB/.user/debug.log
+
       - name: Add label if any of test jobs failed
         if: failure()
         uses: buildsville/add-remove-label@v2.0.0
@@ -730,6 +739,7 @@ jobs:
             test-allure-macos-ci
             test-allure-windows-ci
             test-allure-macos-chats
+            uplink-logs
 
       - name: Remove label if all test jobs succeeded
         uses: buildsville/add-remove-label@v2.0.0


### PR DESCRIPTION
### What this PR does 📖

- Save uplink logs for both instances as artifacts when chats tests are failed
- For now, only implemented on chats tests, since appium is enabling the save logs in a file option from UI when starting to run the tests
- Do not keep uplinks logs when job is passed

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

