### PR TITLE
update(aria): add dynamic aria label for chat messages

### DIFF
--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -426,7 +426,7 @@ pub fn ChatText<'a>(cx: Scope<'a, ChatMessageProps<'a>>) -> Element<'a> {
             class: text_type_class,
             p {
                 class: text_type_class,
-                aria_label: "message-text",
+                aria_label: "message-text-{cx.props.text}",
                 dangerous_inner_html: "{formatted_text}",
             },
             links.first().and_then(|l| cx.render(rsx!(


### PR DESCRIPTION
### What this PR does 📖

- Currently aria label for chat messages is static: "message-text"
- Updating aria label to be "message-text-*" and passing the chat message, which will help to improve locating UI elements on appium tests (no more xpaths looking for that aria containing text = *), and also for people with accessibility needs to locate the messages easier

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

