### PR TITLE
add(aria): add a common aria label for spinner

### DIFF
--- a/kit/src/elements/loader/mod.rs
+++ b/kit/src/elements/loader/mod.rs
@@ -24,6 +24,7 @@ pub fn Loader(cx: Scope<Props>) -> Element {
         class: if is_large(&cx) { "loader large" } else { "loader" },
         div {
             class: "spin",
+            aria_label: "loader",
             IconElement { icon: Icon::Loader }
         }
     }))


### PR DESCRIPTION
### What this PR does 📖

- Add aria label for loader elements, so it can be used on the automamed tests element location

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

