### PR TITLE
task(files): Improve upload error msg for storage limit

### DIFF
--- a/common/locales/en-US/main.ftl
+++ b/common/locales/en-US/main.ftl
@@ -111,6 +111,7 @@ messages = Messages
     .no-chats = No chats available
     .attachments-fail = Upload Failed!
     .attachments-fail-msg = Upload failed: { $reason }
+    .attachments-fail-no-storage = No more storage left!
     
 favorites = Favorites
     .favorites = Favorites

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -1270,10 +1270,7 @@ impl State {
             error,
         } = &progress
         {
-            let err = get_local_text_with_args(
-                "messages.attachments-fail-msg",
-                vec![("reason", error.to_string())],
-            );
+            let err = get_upload_error_text(error);
             self.mutate(Action::AddToastNotification(ToastNotification::init(
                 name.clone(),
                 err,
@@ -1959,4 +1956,22 @@ pub fn pending_group_messages<'a>(
         remote: false,
         messages,
     })
+}
+
+pub fn get_upload_error_text(err: &warp::error::Error) -> String {
+    match err {
+        warp::error::Error::InvalidLength {
+            context: _,
+            current: _,
+            minimum: _,
+            maximum: _,
+        } => get_local_text_with_args(
+            "messages.attachments-fail-msg",
+            vec![(
+                "reason",
+                get_local_text("messages.attachments-fail-no-storage"),
+            )],
+        ),
+        _ => get_local_text("messages.attachments-fail"),
+    }
 }

--- a/kit/src/components/embeds/file_embed/mod.rs
+++ b/kit/src/components/embeds/file_embed/mod.rs
@@ -7,8 +7,8 @@ use common::icons::outline::Shape as Icon;
 use common::icons::Icon as IconElement;
 use common::is_file_available_to_preview;
 use common::is_video;
-use common::language::get_local_text_with_args;
 use common::return_correct_icon;
+use common::state::get_upload_error_text;
 use common::state::pending_message::FileProgression;
 use common::utils::local_file_path::get_fixed_path_to_load_local_file;
 use common::STATIC_ARGS;
@@ -129,10 +129,7 @@ pub fn FileEmbed<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 last_size: _,
                 error,
             } => {
-                file_size_pending.push_str(&get_local_text_with_args(
-                    "messages.attachments-fail-msg",
-                    vec![("reason", error.to_string())],
-                ));
+                file_size_pending.push_str(&get_upload_error_text(error));
                 0
             }
         }


### PR DESCRIPTION
### What this PR does 📖

- Change upload error msg to use new warp error to create a better error message
- Note: Seems there is atm one relevant error regarding file upload? (InvalidLength -> storage limit reached).

### Which issue(s) this PR fixes 🔨

- Resolve #1900