### PR TITLE
fix(Keybinds): Fix keybinds order when recording

### DIFF
--- a/common/src/state/settings.rs
+++ b/common/src/state/settings.rs
@@ -60,6 +60,25 @@ impl Shortcut {
             .unwrap_or(false)
     }
 
+    pub fn reorder_keybind_string(mut keybinds: Vec<String>) -> Vec<String> {
+        keybinds.sort_by(|a, b| match (a.as_str(), b.as_str()) {
+            ("Command", "Shift")
+            | ("Command", "Alt")
+            | ("Ctrl", "Shift")
+            | ("Ctrl", "Alt")
+            | ("Ctrl", "Command") => std::cmp::Ordering::Less,
+            ("Shift", "Alt") => std::cmp::Ordering::Less,
+            ("Shift", "Command") => std::cmp::Ordering::Greater,
+            ("Shift", "Ctrl") => std::cmp::Ordering::Greater,
+            ("Alt", _) => std::cmp::Ordering::Less,
+            ("Ctrl", _) => std::cmp::Ordering::Less,
+            ("Command", _) => std::cmp::Ordering::Less,
+            ("Shift", _) => std::cmp::Ordering::Less,
+            _ => std::cmp::Ordering::Equal,
+        });
+        keybinds
+    }
+
     pub fn get_keys_and_modifiers_as_string(&self) -> Vec<String> {
         let key_code_strs: Vec<String> = self
             .keys

--- a/ui/src/components/settings/sub_pages/keybinds.rs
+++ b/ui/src/components/settings/sub_pages/keybinds.rs
@@ -189,7 +189,6 @@ pub fn KeybindSection(cx: Scope<KeybindSectionProps>) -> Element {
                     is_recording.set(true);
                 },
                 onkeydown: move |evt| {
-                    // println!("evt: {:?}", evt); 
 
                     if evt.data.code() == Code::Escape {
                         is_recording.set(false);
@@ -210,7 +209,9 @@ pub fn KeybindSection(cx: Scope<KeybindSectionProps>) -> Element {
                         binding.extend(modifier_string_vec);
                     }
 
-                    recorded_bindings.set(binding);
+                    let binding2 = Shortcut::reorder_keybind_string(binding);
+
+                    recorded_bindings.set(binding2);
                     evt.stop_propagation();
                 },
                 onkeyup: move |_| {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
### 1.  Fix keybinds order when recording

Order of keybinds will be always like image above. Being "E" any other key is not modifier.

![image](https://github.com/Satellite-im/Uplink/assets/63157656/40034a8c-6b06-424a-a63e-628e09d96412)

### Which issue(s) this PR fixes 🔨

- Resolve #1845 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

