### PR TITLE
feat(settings): Implement missing calltimer setting

### DIFF
--- a/common/src/state/ui.rs
+++ b/common/src/state/ui.rs
@@ -184,6 +184,7 @@ pub struct UI {
     // stores information related to the current call
     #[serde(skip)]
     pub call_info: call::CallInfo,
+    pub call_timer: bool,
     #[serde(skip)]
     pub current_debug_logger: Option<DebugLogger>,
     // false: the media player is anchored in place
@@ -235,6 +236,7 @@ impl Default for UI {
         Self {
             notifications: Default::default(),
             call_info: Default::default(),
+            call_timer: true,
             current_debug_logger: Default::default(),
             popout_media_player: Default::default(),
             toast_notifications: Default::default(),

--- a/ui/src/components/media/calling.rs
+++ b/ui/src/components/media/calling.rs
@@ -400,11 +400,13 @@ fn ActiveCallControl(cx: Scope<ActiveCallProps>) -> Element {
                     "{participants_name}"
                 }
             )),
-            p {
-                class: format_args!("call-time {}", if cx.props.in_chat {"in-chat"} else {""}),
-                aria_label: "call-time",
-                format_timestamp_timeago(active_call.answer_time.into(), &state.read().settings.language_id()),
-            },
+            state.read().ui.call_timer.then(||rsx!(
+                p {
+                    class: format_args!("call-time {}", if cx.props.in_chat {"in-chat"} else {""}),
+                    aria_label: "call-time",
+                    format_timestamp_timeago(active_call.answer_time.into(), &state.read().settings.language_id()),
+                }
+            )),
             cx.props.in_chat.then(||rsx!(div {
                 class: "self-identity",
                 UserImage {

--- a/ui/src/components/settings/sub_pages/audio.rs
+++ b/ui/src/components/settings/sub_pages/audio.rs
@@ -411,7 +411,12 @@ pub fn AudioSettings(cx: Scope) -> Element {
                 aria_label: "call-timer-section".into(),
                 section_label: get_local_text("settings-audio.call-timer"),
                 section_description: get_local_text("settings-audio.call-timer-description"),
-                Switch {}
+                Switch {
+                    active: state.read().ui.call_timer,
+                    onflipped: move |e| {
+                        state.write().ui.call_timer = e;
+                    }
+                }
             }
         }
     ))


### PR DESCRIPTION
### What this PR does 📖

- Implements the missing call timer setting in audio

### Which issue(s) this PR fixes 🔨

- Resolves this issue here: https://issues.satellite.im/b/issues/text-is-unreadable-when-highlighted-in-the-save-recovery-phase-screen/
