### PR TITLE
feat(chat): Impl editing last message key shortcut

### DIFF
--- a/ui/src/layouts/chats/data/chat_data/active_chat/mod.rs
+++ b/ui/src/layouts/chats/data/chat_data/active_chat/mod.rs
@@ -36,7 +36,7 @@ impl ActiveChat {
     ) -> Self {
         Self {
             metadata: Metadata::new(s, chat),
-            messages: Messages::new(messages),
+            messages: Messages::new(s.did_key(), messages),
             is_initialized: false,
             key: Uuid::new_v4(),
         }

--- a/ui/src/layouts/chats/data/chat_data/mod.rs
+++ b/ui/src/layouts/chats/data/chat_data/mod.rs
@@ -23,6 +23,11 @@ pub struct MessagesToSend {
     pub messages_to_send: Vec<(Option<String>, Vec<FileLocation>)>,
 }
 
+#[derive(Clone, Default)]
+pub struct MessagesToEdit {
+    pub edit: Option<Uuid>,
+}
+
 impl PartialEq for ChatData {
     fn eq(&self, _other: &Self) -> bool {
         false
@@ -162,7 +167,9 @@ impl ChatData {
             return;
         }
 
-        self.active_chat.messages.insert_messages(messages);
+        self.active_chat
+            .messages
+            .insert_messages(self.active_chat.my_id().did_key(), messages);
     }
 
     pub fn is_loaded(&self, conv_id: Uuid) -> bool {
@@ -191,7 +198,9 @@ impl ChatData {
         }
 
         if should_append_msg {
-            self.active_chat.messages.insert_messages(vec![msg]);
+            self.active_chat
+                .messages
+                .insert_messages(self.active_chat.my_id().did_key(), vec![msg]);
             true
         } else {
             if let Some(behavior) = behavior {

--- a/ui/src/layouts/chats/presentation/chat/mod.rs
+++ b/ui/src/layouts/chats/presentation/chat/mod.rs
@@ -16,7 +16,7 @@ use kit::{
 use crate::{
     components::media::calling::CallControl,
     layouts::chats::{
-        data::{self, ChatData, MessagesToSend, ScrollBtn},
+        data::{self, ChatData, MessagesToEdit, MessagesToSend, ScrollBtn},
         presentation::{
             chat::{edit_group::EditGroup, group_settings::GroupSettings, group_users::GroupUsers},
             chatbar::get_chatbar,
@@ -40,6 +40,7 @@ pub fn Compose(cx: Scope) -> Element {
     use_shared_state_provider(cx, ChatData::default);
     use_shared_state_provider(cx, ScrollBtn::new);
     use_shared_state_provider(cx, MessagesToSend::default);
+    use_shared_state_provider(cx, MessagesToEdit::default);
     let state = use_shared_state::<State>(cx)?;
     let chat_data = use_shared_state::<ChatData>(cx)?;
 

--- a/ui/src/layouts/chats/presentation/chatbar/mod.rs
+++ b/ui/src/layouts/chats/presentation/chatbar/mod.rs
@@ -42,7 +42,10 @@ use crate::{
     components::{files::attachments::Attachments, shortcuts},
     layouts::{
         chats::{
-            data::{ChatData, ChatProps, MessagesToSend, MsgChInput, ScrollBtn, TypingIndicator},
+            data::{
+                ChatData, ChatProps, MessagesToEdit, MessagesToSend, MsgChInput, ScrollBtn,
+                TypingIndicator,
+            },
             scripts::SHOW_CONTEXT,
         },
         storage::send_files_layout::{modal::SendFilesLayoutModal, SendFilesStartLocation},
@@ -62,6 +65,7 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, ChatProps>) -> Element<'a> {
     let chat_data = use_shared_state::<ChatData>(cx)?;
     let scroll_btn = use_shared_state::<ScrollBtn>(cx)?;
     let to_send = use_shared_state::<MessagesToSend>(cx)?;
+    let edit_msg = use_shared_state::<MessagesToEdit>(cx)?;
     state.write_silent().scope_ids.chatbar = Some(cx.scope_id().0);
 
     let active_chat_id = chat_data.read().active_chat.id();
@@ -435,6 +439,13 @@ pub fn get_chatbar<'a>(cx: &'a Scoped<'a, ChatProps>) -> Element<'a> {
                         }
                     }
                     suggestions.set(SuggestionType::None);
+                }
+            },
+            onup_down_arrow: move |code|{
+                if code == Code::ArrowUp && edit_msg.read().edit.is_none() {
+                    if let Some(msg) = chat_data.read().active_chat.messages.last_user_msg {
+                        edit_msg.write().edit = Some(msg);
+                    }
                 }
             },
             controls: cx.render(


### PR DESCRIPTION
### What this PR does 📖

- When user presses up key while in chatbar and having nothing typed will automatically select the last sent message from them to edit

### Which issue(s) this PR fixes 🔨

- Resolve #1929
