### PR TITLE
fix(themes): Text selection color

### DIFF
--- a/kit/src/elements/textarea/markdown.scss
+++ b/kit/src/elements/textarea/markdown.scss
@@ -47,7 +47,7 @@
     }
 
     &.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection {
-        background: var(--text-selection);
+        background: color-mix(in srgb, var(--text-selection) 40%, transparent);
     }
 }
 

--- a/kit/src/style.scss
+++ b/kit/src/style.scss
@@ -265,7 +265,7 @@ pre code {
   --text-color-bright: #ffffff;
   --text-color-link: #4761fc;
   --text-color-user-tag: #576ae5b1;
-  --text-selection: #e0e0e0;
+  --text-selection: #c3c3c3;
   --text-selection-dark: #757575;
   --placeholder: #bcbcbc;
   --primary: #4d4dff;

--- a/kit/src/style.scss
+++ b/kit/src/style.scss
@@ -266,6 +266,7 @@ pre code {
   --text-color-link: #4761fc;
   --text-color-user-tag: #576ae5b1;
   --text-selection: #e0e0e0;
+  --text-selection-dark: #757575;
   --placeholder: #bcbcbc;
   --primary: #4d4dff;
   --primary-dark: color-mix(in srgb, var(--primary) 50%, black);

--- a/kit/src/style.scss
+++ b/kit/src/style.scss
@@ -265,8 +265,8 @@ pre code {
   --text-color-bright: #ffffff;
   --text-color-link: #4761fc;
   --text-color-user-tag: #576ae5b1;
-  --text-selection: #c3c3c3;
-  --text-selection-dark: #757575;
+  --text-selection: #c3c3c3fe;
+  --text-selection-dark: #757575fe;
   --placeholder: #bcbcbc;
   --primary: #4d4dff;
   --primary-dark: color-mix(in srgb, var(--primary) 50%, black);

--- a/kit/src/style.scss
+++ b/kit/src/style.scss
@@ -265,8 +265,8 @@ pre code {
   --text-color-bright: #ffffff;
   --text-color-link: #4761fc;
   --text-color-user-tag: #576ae5b1;
-  --text-selection: #c3c3c3fe;
-  --text-selection-dark: #757575fe;
+  --text-selection: #c3c3c366;
+  --text-selection-dark: #75757566;
   --placeholder: #bcbcbc;
   --primary: #4d4dff;
   --primary-dark: color-mix(in srgb, var(--primary) 50%, black);

--- a/ui/src/layouts/style.scss
+++ b/ui/src/layouts/style.scss
@@ -320,6 +320,9 @@
     border-radius: var(--border-radius);
     /* color: var(--text-color-dark); */
     padding: var(--gap-less);
+    &::selection {
+      background-color: var(--text-selection-dark);
+    }
   }
 
   .button-container {


### PR DESCRIPTION
### What this PR does 📖

- Changes the text selection color. While fixing the issue i noticed some stuff though:
  - Text selection color gets applied with some blending algorithm with the background if the provided color either has no alpha value provided (e.g. `#ff00ff`) or an alpha value of 1 (e.g. `#ff00ffff`). This seems to only apply to macos though as just judging from the linked issue on windows the color gets applied as it is causing the problem.
    This makes a consistent ui kinda hard.
  - For now i made the contrast between selection and text color a bit more to see how it goes

### Which issue(s) this PR fixes 🔨

- Resolve #1948