### PR TITLE
add(aria): aria labels for share did and color swatch

### DIFF
--- a/kit/src/components/swatch/mod.rs
+++ b/kit/src/components/swatch/mod.rs
@@ -17,6 +17,7 @@ pub fn ColorSwatch<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
 
     cx.render(rsx!(div {
         class: "color-swatch {active}",
+        aria_label: "color-swatch-button-rgb-{cx.props.color.0}-{cx.props.color.1}-{cx.props.color.2}",
         style: "background-color: rgb({cx.props.color.0}, {cx.props.color.1}, {cx.props.color.2})",
         onclick: |_| cx.props.onpress.call(()),
     }))

--- a/kit/src/components/swatch/mod.rs
+++ b/kit/src/components/swatch/mod.rs
@@ -17,7 +17,8 @@ pub fn ColorSwatch<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
 
     cx.render(rsx!(div {
         class: "color-swatch {active}",
-        aria_label: "color-swatch-button-rgb-{cx.props.color.0}-{cx.props.color.1}-{cx.props.color.2}",
+        aria_label:
+            "color-swatch-button-rgb-{cx.props.color.0}-{cx.props.color.1}-{cx.props.color.2}",
         style: "background-color: rgb({cx.props.color.0}, {cx.props.color.1}, {cx.props.color.2})",
         onclick: |_| cx.props.onpress.call(()),
     }))

--- a/ui/src/components/friends/friends_list/mod.rs
+++ b/ui/src/components/friends/friends_list/mod.rs
@@ -451,11 +451,13 @@ pub fn ShareFriendsModal(cx: Scope<FriendProps>) -> Element {
         close_on_click_inside_modal: false,
         dont_pad: true,
         div {
+            aria_label: "share-did-modal",
             class: "modal-share-friends",
             div {
                 class: "modal-share-friends-header",
                 padding: "12px",
                 Label {
+                    aria_label: "share-did-header".into(),
                     text: get_local_text("friends.select-chat"),
                 },
                 div {
@@ -463,7 +465,7 @@ pub fn ShareFriendsModal(cx: Scope<FriendProps>) -> Element {
                     Button {
                         text: get_local_text("friends.share-to-chat"),
                         icon: Icon::Share,
-                        aria_label: "share_to_chat".into(),
+                        aria_label: "share-to-chat-button".into(),
                         appearance: Appearance::Secondary,
                         disabled: chats_selected.read().is_empty(),
                         onpress: move |_| {
@@ -476,6 +478,7 @@ pub fn ShareFriendsModal(cx: Scope<FriendProps>) -> Element {
             chats.is_empty().then(||{
                 rsx!(div {
                     class: "modal-share-friend-empty",
+                    aria_label: "modal-share-friend-empty",
                     get_local_text("messages.no-chats")
                 })
             }),
@@ -510,6 +513,7 @@ pub fn ShareFriendsModal(cx: Scope<FriendProps>) -> Element {
                 rsx!(div {
                     class: format_args!("modal-share-friend {}", if selected {"share-friend-selected"} else {""}),
                     User {
+                        aria_label: participants_name.clone(),
                         username: participants_name,
                         subtext: subtext_val,
                         timestamp: raygun::Message::default().date(),
@@ -518,6 +522,7 @@ pub fn ShareFriendsModal(cx: Scope<FriendProps>) -> Element {
                             div {
                                 class: "modal-share-friend-image-group",
                                 Checkbox {
+                                    aria_label: "user-to-share-did-checkbox".into(),
                                     disabled: false,
                                     width: "1em".into(),
                                     height: "1em".into(),

--- a/ui/src/components/settings/sub_pages/accessibility.rs
+++ b/ui/src/components/settings/sub_pages/accessibility.rs
@@ -15,7 +15,7 @@ pub fn AccessibilitySettings(cx: Scope) -> Element {
     cx.render(rsx!(
         div {
             id: "settings-general",
-            aria_label: "settings-general",
+            aria_label: "settings-accessibility",
             div {
                 class: format_args!("{}", if state.read().configuration.general.dyslexia_support {"open-dyslexic-activated"} else {"open-dyslexic"}),
                 SettingSection {


### PR DESCRIPTION
### What this PR does 📖

- Adding aria labels for color swatch buttons on Settings General
- Adding aria labels for Share DID modal 
- Fixing aria label for Settings Accessibility screen

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

