### PR TITLE
feat(chat): Clicking outside will stop editing msg

### DIFF
--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -269,6 +269,7 @@ pub fn Message<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
         .pending
         .then_some("message-pending")
         .unwrap_or_default();
+    let is_editing = cx.props.with_text.is_some() && cx.props.editing;
 
     cx.render(rsx! (
         cx.props.pinned.then(|| {
@@ -287,11 +288,21 @@ pub fn Message<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 },
             })
         }),
+        is_editing.then(||
+            rsx! (
+                div {
+                    class: "edit-message-wrap",
+                    onclick: move |_| {
+                        cx.props.on_edit.call(cx.props.with_text.clone().unwrap_or_default());
+                    }
+                },
+            )
+        ),
         div {
             class: {
                 format_args!(
-                    "message {} {} {} {} {}",
-                   loading_class, remote_class, order_class, msg_pending_class, mention_class
+                    "message {} {} {} {} {} {}",
+                   loading_class, remote_class, order_class, msg_pending_class, mention_class, if is_editing { "edit-message" } else { "" }
                 )
             },
             aria_label: {
@@ -309,7 +320,7 @@ pub fn Message<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     cx.props.with_content.as_ref(),
                 },
             )),
-            (cx.props.with_text.is_some() && cx.props.editing).then(||
+            is_editing.then(||
                 rsx! (
                     p {
                         class: "text",

--- a/kit/src/components/message/style.scss
+++ b/kit/src/components/message/style.scss
@@ -48,6 +48,22 @@
 	}
 }
 
+.edit-message-wrap {
+	display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    position: fixed;
+    z-index: 1001;
+    top: 1.5rem;
+    left: 0;
+    bottom: 0;
+    right: 0;
+}
+
+.edit-message {
+	z-index: 1002;
+}
+
 .message.mention {
 	background-color: var(--background-mention);
 }


### PR DESCRIPTION
### What this PR does 📖

- Makes it so clicking outside of the message will stop editing the message

### Which issue(s) this PR fixes 🔨

- Resolve #1941
