### PR TITLE
feat(files): Resolve directory names for storage

### DIFF
--- a/common/locales/en-US/main.ftl
+++ b/common/locales/en-US/main.ftl
@@ -203,6 +203,7 @@ files = Files
     .transfer-finishing = Finishing...
     .transfer-cancelling = Cancelling...
     .transfer-error = { $error }
+    .direct-message-name = DM: { $with }
 
 settings = Settings
     .settings = Settings

--- a/ui/src/layouts/storage/shared_component.rs
+++ b/ui/src/layouts/storage/shared_component.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use crate::layouts::storage::functions::{self, download_file, ChanCmd};
 use crate::layouts::storage::send_files_layout::send_files_components::{
     toggle_selected_file, FileCheckbox,
@@ -7,6 +9,7 @@ use super::files_layout::controller::StorageController;
 use common::icons::outline::Shape as Icon;
 use common::icons::Icon as IconElement;
 use common::is_file_available_to_preview;
+use common::language::get_local_text_with_args;
 use common::state::{State, ToastNotification};
 use common::warp_runner::thumbnail_to_base64;
 use common::{language::get_local_text, ROOT_DIR_NAME};
@@ -16,8 +19,10 @@ use dioxus::prelude::*;
 use kit::components::context_menu::{ContextItem, ContextMenu};
 use kit::elements::file::File;
 use kit::elements::folder::Folder;
+use uuid::Uuid;
+use warp::constellation::directory::Directory;
 use warp::constellation::item::Item;
-use warp::raygun::Location;
+use warp::raygun::{ConversationSettings, Location};
 
 #[derive(Props)]
 pub struct FilesBreadcumbsProps<'a> {
@@ -28,6 +33,7 @@ pub struct FilesBreadcumbsProps<'a> {
 
 #[allow(non_snake_case)]
 pub fn FilesBreadcumbs<'a>(cx: Scope<'a, FilesBreadcumbsProps<'a>>) -> Element<'a> {
+    let state = use_shared_state::<State>(cx)?;
     let send_files_mode = cx.props.send_files_mode;
     let storage_controller = cx.props.storage_controller;
     let ch = cx.props.ch;
@@ -58,7 +64,8 @@ pub fn FilesBreadcumbs<'a>(cx: Scope<'a, FilesBreadcumbsProps<'a>>) -> Element<'
                     }
                 })
             } else {
-                let folder_name_formatted = functions::format_item_name(dir_name);
+                let folder_name_resolved = resolve_directory_name(dir, &state.read());
+                let folder_name_formatted = functions::format_item_name(folder_name_resolved);
                 rsx!(div {
                     class: "crumb",
                     onclick: move |_| {
@@ -125,8 +132,9 @@ pub fn FilesAndFolders<'a>(cx: Scope<'a, FilesAndFoldersProps<'a>>) -> Element<'
             }),
             storage_controller.read().directories_list.iter().map(|dir| {
                 let folder_name = dir.name();
-                let folder_name2 = dir.name();
-                let folder_name3 = dir.name();
+                let folder_name2 = folder_name.clone();
+                let folder_name3 = folder_name.clone();
+                let folder_name_resolved = resolve_directory_name(dir, &state.read());
                 let key = dir.id();
                 let dir2 = dir.clone();
                 let deleting = storage_controller.read().deleting.iter().any(|i|{
@@ -163,8 +171,8 @@ pub fn FilesAndFolders<'a>(cx: Scope<'a, FilesAndFoldersProps<'a>>) -> Element<'
                         )),
                         Folder {
                             key: "{key}-folder",
-                            text: dir.name(),
-                            aria_label: dir.name(),
+                            text: folder_name_resolved.clone(),
+                            aria_label: folder_name_resolved,
                             with_rename:storage_controller.with(|i| i.is_renaming_map == Some(key)),
                             onrename: move |(val, key_code)| {
                                 if val == folder_name3 {
@@ -349,4 +357,31 @@ pub fn FilesAndFolders<'a>(cx: Scope<'a, FilesAndFoldersProps<'a>>) -> Element<'
             }),
         },
     }))
+}
+
+fn resolve_directory_name(dir: &Directory, state: &State) -> String {
+    let folder_name = dir.name();
+    // Try to check and resolve the foldername for chats
+    match Uuid::from_str(&folder_name) {
+        Ok(id) => state
+            .get_chat_by_id(id)
+            .and_then(|c| {
+                c.conversation_name.or(match c.settings {
+                    ConversationSettings::Direct(_) => {
+                        // If DM try use the other users name
+                        let own = state.did_key();
+                        let other = c.participants.iter().find(|id| !own.eq(id));
+                        other.and_then(|o| state.get_identity(o)).map(|id| {
+                            get_local_text_with_args(
+                                "files.direct-message-name",
+                                vec![("with", id.username())],
+                            )
+                        })
+                    }
+                    ConversationSettings::Group(_) => None,
+                })
+            })
+            .unwrap_or(folder_name),
+        Err(_) => folder_name,
+    }
 }


### PR DESCRIPTION
### What this PR does 📖

- Resolve directory names for storage in case it is related to a chat. This makes it so the directory doesn't display the chats uuid now and instead will display the chats name (if exist) or in case it is a direct message will display it as `DM: <other participant>`
- The change is purely visual as the directory is still referred with the uuid under the hood

### Which issue(s) this PR fixes 🔨

- Resolve #1956

