### PR TITLE
fix(ui): make modals in chat render on top of all

### DIFF
--- a/ui/src/layouts/chats/style.scss
+++ b/ui/src/layouts/chats/style.scss
@@ -70,7 +70,7 @@
   min-height: 0;
   display: inline-flex;
   flex-direction: column;
-  position: sticky;
+  position: relative;
 }
 
 #create-group {


### PR DESCRIPTION
### What this PR does 📖

- Makes modals in chat render on top of other components fixing e.g. the sidebar being on top while viewing a file in chat

### Which issue(s) this PR fixes 🔨

- Resolve #1955

