### PR TITLE
task(chat): Update what should be skipped in state.json

### DIFF
--- a/common/src/state/chats.rs
+++ b/common/src/state/chats.rs
@@ -223,6 +223,9 @@ pub struct Chats {
     pub in_sidebar: VecDeque<Uuid>,
     // Favorite Chats
     pub favorites: Vec<Uuid>,
+    // If there was a problem with loading state or state was deleted we readd all existing chats to the sidebar.
+    #[serde(skip)]
+    pub readd_sidebars: bool,
 }
 
 impl Chats {

--- a/common/src/state/chats.rs
+++ b/common/src/state/chats.rs
@@ -224,7 +224,6 @@ pub struct Chats {
     // Favorite Chats
     pub favorites: Vec<Uuid>,
     // If there was a problem with loading state or state was deleted we readd all existing chats to the sidebar.
-    #[serde(skip)]
     pub readd_sidebars: bool,
 }
 

--- a/common/src/state/chats.rs
+++ b/common/src/state/chats.rs
@@ -211,6 +211,7 @@ impl Chat {
 #[derive(Clone, Serialize, Debug, Default, Deserialize)]
 pub struct Chats {
     // All active chats from warp.
+    #[serde(skip)]
     pub all: HashMap<Uuid, Chat>,
     // Chat to display / interact with currently.
     pub active: Option<Uuid>,

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -787,6 +787,8 @@ impl State {
             return State::load_mock();
         };
 
+        let mut success = true;
+
         let mut state = {
             match fs::read_to_string(&STATIC_ARGS.cache_path) {
                 Ok(contents) => match serde_json::from_str(&contents) {
@@ -795,11 +797,13 @@ impl State {
                         log::error!(
                             "state.json failed to deserialize: {e}. Initializing State with default values"
                         );
+                        success = false;
                         State::default()
                     }
                 },
                 Err(_) => {
                     log::info!("state.json not found. Initializing State with default values");
+                    success = false;
                     State::default()
                 }
             }
@@ -807,6 +811,10 @@ impl State {
         // not sure how these defaulted to true, but this should serve as additional
         // protection in the future
         state.initialized = false;
+
+        if !success {
+            state.chats.readd_sidebars = true;
+        }
 
         if state.settings.font_scale() == 0.0 {
             state.settings.set_font_scale(1.0);
@@ -879,6 +887,13 @@ impl State {
             }
         }
         self.identities.extend(identities.drain());
+
+        if self.chats.readd_sidebars {
+            self.chats.readd_sidebars = false;
+            self.chats
+                .in_sidebar
+                .append(&mut self.chats.all.keys().cloned().collect())
+        }
 
         self.initialized = true;
     }

--- a/common/src/state/mod.rs
+++ b/common/src/state/mod.rs
@@ -74,6 +74,7 @@ pub struct State {
     friends: friends::Friends,
     #[serde(skip)]
     pub storage: storage::Storage,
+    #[serde(skip)]
     pub scope_ids: scope_ids::ScopeIds,
     pub settings: settings::Settings,
     pub ui: ui::UI,

--- a/common/src/state/scope_ids.rs
+++ b/common/src/state/scope_ids.rs
@@ -3,15 +3,11 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Debug, Deserialize, Serialize)]
 pub struct ScopeIds {
-    #[serde(skip)]
     pub chatbar: Option<usize>,
     // Would be nice in future if there is a way to access a shared state without subscribing
     // This can then be removed
-    #[serde(skip)]
     pub file_transfer: Option<usize>,
-    #[serde(skip)]
     pub file_transfer_icon: Option<usize>,
-    #[serde(skip)]
     pub pending_message_component: Option<usize>,
 }
 

--- a/common/src/testing/mock.rs
+++ b/common/src/testing/mock.rs
@@ -79,6 +79,7 @@ pub fn generate_mock() -> State {
         active_media: None,
         in_sidebar,
         favorites: vec![],
+        readd_sidebars: false,
     };
     let friends = Friends {
         all: HashSet::from_iter(identities.iter().map(|x| x.did_key())),


### PR DESCRIPTION
### What this PR does 📖

- Do not (de)serialize chats.
  - Conversations are already fetched from warp on load. This will just make it not save those chats.
  - Chats in sidebar are simply resolved with the uuids
  - Not saving the chats should prevent problems with loading when the internal structure changes.

### Which issue(s) this PR fixes 🔨

- Resolve #1936

### Additional comments 🎤

We should probably move sidebar chats + favorites to warp.
