### PR TITLE
fix(emoji): fix emoji reaction wrap

### DIFF
--- a/kit/src/components/message/mod.rs
+++ b/kit/src/components/message/mod.rs
@@ -364,7 +364,7 @@ pub fn Message<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
         },
         div {
             class: "{reactions_class}",
-            aria_label: "message-reaction-container",
+            aria_label: "message-reactions-container",
             cx.props.reactions.iter().map(|reaction| {
                 let reaction_count = reaction.reaction_count;
                 let emoji = &reaction.emoji;

--- a/kit/src/components/message/style.scss
+++ b/kit/src/components/message/style.scss
@@ -125,8 +125,6 @@
 	border: 1px solid var(--border-subtle-color);
 	border-radius: var(--border-radius-more);
 	background-color: var(--secondary-dark);
-	margin-left: 5px;
-	margin-top: 3px;
 	padding: 2px 5px;
 	cursor: pointer;
 	border: none;

--- a/ui/src/layouts/chats/style.scss
+++ b/ui/src/layouts/chats/style.scss
@@ -39,8 +39,11 @@
 .message-reactions-container {
   display: inline-flex;
   flex-direction: row;
+  flex-wrap: wrap;
   color: var(--text-color);
   justify-content: flex-end;
+  scale: 0.8;
+  transform-origin: left;
 
   &.pointer {
     cursor: pointer


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Fixes problem where adding lots of emoji reactions does not wrap.
- Renamed aria label from `message-reaction-container` to `message-reactions-container` since the class uses `reactions`
- Removed margin of emoji container since that handled by the parent now
- Also reduced overall size of emoji reactions as previously they where as big as the text message

### Which issue(s) this PR fixes 🔨

- Resolve #1964
- Resolve #1965
