### PR TITLE
fix(calling): Request mic (and camera)

### DIFF
--- a/ui/extra/macos/Uplink.app/Contents/Info.plist
+++ b/ui/extra/macos/Uplink.app/Contents/Info.plist
@@ -34,5 +34,9 @@
   <string>Uplink</string>
   <key>NSRequiresAquaSystemAppearance</key>
   <string>NO</string>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>Calling</string>
+  <key>NSCameraUsageDescription</key>
+  <string>Calling</string>
 </dict>
 </plist>


### PR DESCRIPTION
### What this PR does 📖

- On MacOS calling was not working in prod due to no access to the microphone. This PR makes it so the app will request mic (and camera) access when needed

### Which issue(s) this PR fixes 🔨

- Resolve #1963

### Additional comments 🎤

The prod build works on linux. The issue also mentions windows but i am unsure about that since idk if you need to request access to the mic or not there.
(though it can also be that the testing done in the issue was via a windows <-> mac communication which made it seem like so)
