### PR TITLE
fix(login): change ordering of account creation pages

### DIFF
--- a/ui/src/layouts/log_in/create_or_recover.rs
+++ b/ui/src/layouts/log_in/create_or_recover.rs
@@ -39,7 +39,7 @@ pub fn Layout(cx: Scope, page: UseState<AuthPages>) -> Element {
                     aria_label: "create-button".into(),
                     text: get_local_text("create-or-recover.create"),
                     onpress: move |_| {
-                        page.set(AuthPages::CopySeedWords);
+                        page.set(AuthPages::EnterUserName);
                     }
                 },
                 Button {

--- a/ui/src/layouts/log_in/mod.rs
+++ b/ui/src/layouts/log_in/mod.rs
@@ -34,7 +34,7 @@ pub fn AuthGuard(cx: Scope, page: UseState<AuthPages>) -> Element {
     log::trace!("rendering auth guard");
 
     let pin = use_ref(cx, String::new);
-    let seed_words = use_ref(cx, String::new);
+    let user_name = use_ref(cx, String::new);
     let desktop = use_window(cx);
     let theme = "";
 
@@ -64,10 +64,10 @@ pub fn AuthGuard(cx: Scope, page: UseState<AuthPages>) -> Element {
 
             match *page.current() {
                 AuthPages::EntryPoint => rsx!(entry_point::Layout { page: page.clone(), pin: pin.clone() }),
-                AuthPages::EnterUserName => rsx!(enter_username::Layout { page: page.clone(), pin: pin.clone(), seed_words: seed_words.clone() }),
+                AuthPages::EnterUserName => rsx!(enter_username::Layout { page: page.clone(), user_name: user_name.clone() }),
                 AuthPages::CreateOrRecover => rsx!(create_or_recover::Layout { page: page.clone() }),
                 AuthPages::EnterSeedWords => rsx!(enter_seed_words::Layout { page: page.clone(), pin: pin.clone(), }),
-                AuthPages::CopySeedWords => rsx!(copy_seed_words::Layout { page: page.clone(), seed_words: seed_words.clone() }),
+                AuthPages::CopySeedWords => rsx!(copy_seed_words::Layout { page: page.clone(), username: user_name.read().clone(), pin: pin.read().clone() }),
                 _ => unreachable!("this view should disappear when an account is unlocked or created"),
             }
         }


### PR DESCRIPTION
### What this PR does 📖

- Reorders the pages in account creation. Previously it went Password -> Create/Import -> Phrases -> Username.
  Now: Password -> Create/Import -> Username -> Phrases.

### Which issue(s) this PR fixes 🔨

- Resolve #1968
