### PR TITLE
fix(ui): rfd import for file dialog fix

### DIFF
--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1,4 +1,7 @@
 #![cfg_attr(feature = "production_mode", windows_subsystem = "windows")]
+// Having it here fixes a file dialog crash for some reason. (Seems to only be on some MacOS)
+#[allow(unused_imports)]
+use rfd::FileDialog;
 
 fn main() {
     uplink::main_lib();


### PR DESCRIPTION
### What this PR does 📖

- Adds rfd import to main.lib to fix an issue on macos with opening a file dialog.  It has a comment there indicating the problem/fix.
