### PR TITLE
fix(chat): Dont stop profile fetching when one errors

### DIFF
--- a/common/src/profile_update_channel.rs
+++ b/common/src/profile_update_channel.rs
@@ -47,7 +47,7 @@ pub fn fetch_identity_data(identities: &[Identity]) {
                 Ok(res) => res.ok(),
                 Err(e) => {
                     log::error!("error fetching profile pic {e}");
-                    return;
+                    Option::None
                 }
             };
             let (tx, rx) = oneshot::channel();
@@ -59,7 +59,7 @@ pub fn fetch_identity_data(identities: &[Identity]) {
                 Ok(res) => res.ok(),
                 Err(e) => {
                     log::error!("error fetching profile banner {e}");
-                    return;
+                    Option::None
                 }
             };
             if profile_picture.is_some() || profile_banner.is_some() {


### PR DESCRIPTION
### What this PR does 📖

- Makes it so when banner/profile errors during fetching the whole thing is not aborted. This MIGHT fix the linked issue where one person changes their profile picture, another tries to add them but only sees a blank profile picture.
  I was only able to reproduce the linked issue once (might be due to some caching thing maybe?) so not really able to confirm this but it seemed to be a good point here.
  
### Which issue(s) this PR fixes 🔨

- Resolve #1934

