### PR TITLE
chore(build): fix typo on env variable for cert

### DIFF
--- a/.github/workflows/build-release-windows.yml
+++ b/.github/workflows/build-release-windows.yml
@@ -36,7 +36,7 @@ jobs:
           echo "CERTIFICATE_NAME=gt-certificate" >> $GITHUB_OUTPUT
           echo "SM_HOST=${{ secrets.SM_HOST }}" >> "$GITHUB_ENV"
           echo "SM_API_KEY=${{ secrets.SM_API_KEY }}" >> "$GITHUB_ENV"
-          echo "SM_CLIENT_CERT_FILE=C:\\certificate.p12" >> "$GITHUB_ENV"
+          echo "SM_CLIENT_CERT_FILE=C:\certificate.p12" >> "$GITHUB_ENV"
           echo "SM_CLIENT_CERT_PASSWORD=${{ secrets.SM_CLIENT_CERT_PASSWORD }}" >> "$GITHUB_ENV"
           echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH
           echo "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools" >> $GITHUB_PATH


### PR DESCRIPTION
### What this PR does 📖

- It looks like one more "\" is being passed in environment variable for SM_CLIENT_CERT_FILE and this is making the signtool process to fail on uplink copy repo when running build windows action
![image](https://github.com/Satellite-im/Uplink/assets/35935591/3059da64-be8d-4404-8c59-fab83af73bb2)


### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤

