### PR TITLE
fix(login): Set min size and increase size for phrase window

### DIFF
--- a/ui/src/layouts/log_in/copy_seed_words.rs
+++ b/ui/src/layouts/log_in/copy_seed_words.rs
@@ -3,12 +3,13 @@ use std::time::Duration;
 use arboard::Clipboard;
 use common::{icons, language::get_local_text, state::State};
 use dioxus::prelude::*;
-use dioxus_desktop::{use_window, LogicalSize};
+use dioxus_desktop::use_window;
 use kit::elements::{button::Button, label::Label, Appearance};
 use tokio::time::sleep;
 
 use super::AuthPages;
 use crate::get_app_style;
+use crate::layouts::log_in::update_window_size;
 use common::state::configuration::Configuration;
 use common::{
     sounds,
@@ -26,10 +27,7 @@ pub fn Layout(cx: Scope, page: UseState<AuthPages>, username: String, pin: Strin
     let window = use_window(cx);
 
     if !matches!(&*page.current(), AuthPages::Success(_)) {
-        window.set_inner_size(LogicalSize {
-            width: 500.0,
-            height: 480.0,
-        });
+        update_window_size(window, 500.0, 500.0);
     }
 
     let words = use_future(cx, (), |_| async move {

--- a/ui/src/layouts/log_in/create_or_recover.rs
+++ b/ui/src/layouts/log_in/create_or_recover.rs
@@ -1,9 +1,9 @@
 use common::{language::get_local_text, state::State};
 use dioxus::prelude::*;
-use dioxus_desktop::{use_window, LogicalSize};
+use dioxus_desktop::use_window;
 use kit::elements::{button::Button, label::Label};
 
-use crate::get_app_style;
+use crate::{get_app_style, layouts::log_in::update_window_size};
 
 use super::AuthPages;
 
@@ -14,10 +14,7 @@ pub fn Layout(cx: Scope, page: UseState<AuthPages>) -> Element {
     let window = use_window(cx);
 
     if !matches!(&*page.current(), AuthPages::Success(_)) {
-        window.set_inner_size(LogicalSize {
-            width: 500.0,
-            height: 250.0,
-        });
+        update_window_size(window, 500.0, 250.0);
     }
     cx.render(rsx!(
         style {get_app_style(&state.read())},

--- a/ui/src/layouts/log_in/enter_seed_words.rs
+++ b/ui/src/layouts/log_in/enter_seed_words.rs
@@ -6,7 +6,7 @@ use common::{
     WARP_CMD_CH,
 };
 use dioxus::prelude::*;
-use dioxus_desktop::{use_window, LogicalSize};
+use dioxus_desktop::use_window;
 use futures::{channel::oneshot, StreamExt};
 use kit::elements::{
     button::Button,
@@ -15,7 +15,7 @@ use kit::elements::{
     Appearance,
 };
 
-use crate::get_app_style;
+use crate::{get_app_style, layouts::log_in::update_window_size};
 
 use super::AuthPages;
 
@@ -50,10 +50,7 @@ pub fn Layout(cx: Scope, pin: UseRef<String>, page: UseState<AuthPages>) -> Elem
     let window = use_window(cx);
 
     if !matches!(&*page.current(), AuthPages::Success(_)) {
-        window.set_inner_size(LogicalSize {
-            width: 500.0,
-            height: 480.0,
-        });
+        update_window_size(window, 500.0, 500.0);
     }
 
     let eval = use_eval(cx);

--- a/ui/src/layouts/log_in/enter_username.rs
+++ b/ui/src/layouts/log_in/enter_username.rs
@@ -1,7 +1,7 @@
 use common::icons::outline::Shape as Icon;
 use common::language::get_local_text;
 use dioxus::prelude::*;
-use dioxus_desktop::{use_window, LogicalSize};
+use dioxus_desktop::use_window;
 use kit::elements::label::Label;
 use kit::elements::{
     button::Button,
@@ -9,6 +9,7 @@ use kit::elements::{
 };
 use tracing::log;
 
+use crate::layouts::log_in::update_window_size;
 use crate::AuthPages;
 
 pub const MIN_USERNAME_LEN: i32 = 4;
@@ -20,10 +21,7 @@ pub fn Layout(cx: Scope, page: UseState<AuthPages>, user_name: UseRef<String>) -
     let window = use_window(cx);
 
     if !matches!(&*page.current(), AuthPages::Success(_)) {
-        window.set_inner_size(LogicalSize {
-            width: 500.0,
-            height: 250.0,
-        });
+        update_window_size(window, 500.0, 250.0);
     }
 
     //let error = use_state(cx, String::new);

--- a/ui/src/layouts/log_in/mod.rs
+++ b/ui/src/layouts/log_in/mod.rs
@@ -6,7 +6,7 @@ mod entry_point;
 mod recover_account;
 
 use dioxus::prelude::*;
-use dioxus_desktop::{use_window, LogicalSize};
+use dioxus_desktop::{use_window, DesktopService, LogicalSize};
 use kit::components::topbar_controls::TopbarControls;
 use kit::STYLE as UIKIT_STYLES;
 use warp::multipass;
@@ -35,17 +35,13 @@ pub fn AuthGuard(cx: Scope, page: UseState<AuthPages>) -> Element {
 
     let pin = use_ref(cx, String::new);
     let user_name = use_ref(cx, String::new);
-    let desktop = use_window(cx);
     let theme = "";
 
     // make the window smaller while the user authenticates
     let window = use_window(cx);
 
     if !matches!(&*page.current(), AuthPages::Success(_)) {
-        window.set_inner_size(LogicalSize {
-            width: 500.0,
-            height: 350.0,
-        });
+        update_window_size(window, 500.0, 350.0);
     }
 
     cx.render(rsx! (
@@ -57,7 +53,7 @@ pub fn AuthGuard(cx: Scope, page: UseState<AuthPages>) -> Element {
                 id: "lockscreen-controls",
                 div {
                     class: "draggable-topbar",
-                    onmousedown: move |_| { desktop.drag(); },
+                    onmousedown: move |_| { window.drag(); },
                 },
                 TopbarControls {},
             },
@@ -72,4 +68,11 @@ pub fn AuthGuard(cx: Scope, page: UseState<AuthPages>) -> Element {
             }
         }
     ))
+}
+
+// Sets both inner and min size for logins
+pub fn update_window_size(window: &DesktopService, width: f64, height: f64) {
+    let size = LogicalSize { width, height };
+    window.set_min_inner_size(Some(size));
+    window.set_inner_size(size);
 }


### PR DESCRIPTION
### What this PR does 📖

- Increases the window size a little for the copy phrase login page. On linux that page was a bit too small
- Set the min window size too when updating the window size for login pages since otherwise resizing it and making it smaller will make some elements out of bounds

